### PR TITLE
Fixed reconnection with agent by removing while(1) loop

### DIFF
--- a/firmware/src/firmware.ino
+++ b/firmware/src/firmware.ino
@@ -35,7 +35,7 @@
 #define ENCODER_OPTIMIZE_INTERRUPTS
 #include "encoder.h"
 
-#define RCCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){rclErrorLoop();}}
+#define RCCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){flashLED(2);}}
 #define RCSOFTCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){}}
 #define EXECUTE_EVERY_N_MS(MS, X)  do { \
   static volatile int64_t init = -1; \
@@ -330,14 +330,6 @@ struct timespec getTime()
     tp.tv_nsec = (now % 1000) * 1000000;
 
     return tp;
-}
-
-void rclErrorLoop() 
-{
-    while(true)
-    {
-        flashLED(2);
-    }
 }
 
 void flashLED(int n_times)


### PR DESCRIPTION
The microcontroller device does not reconnect when the agent is terminated and then relaunched. This is because the code fails in the create_entities() function, enters the error loop and gets stuck in the while(1). On the other hand, this is not observed when the agent is kept running and the microcontroller device is disconnected and reconnected - because the while(1) loop is exited.

Removing the while(1) fixed this. I added the flashLED(2) directly instead of the call to the rclErrorLoop() in RCCHECK instead of having a separate function. 

Tested using: ROS2 galactic, Teensy 4.1. 
