### PR TITLE
Feature/ci pio (#1)

### DIFF
--- a/.github/parse_platformio.py
+++ b/.github/parse_platformio.py
@@ -1,0 +1,13 @@
+import configparser
+import json
+
+config = configparser.ConfigParser()
+config.read('firmware/platformio.ini')
+
+environments = []
+for section in config.sections():
+    if section.startswith("env:"):
+        env_name = section.split("env:")[1]
+        environments.append({"env": env_name})
+
+print(json.dumps(environments))

--- a/.github/parse_platformio.py
+++ b/.github/parse_platformio.py
@@ -1,13 +1,18 @@
 import configparser
 import json
 
+""" This script parses the platformio.ini file and outputs a JSON array of environments to be used by GitHub Actions."""
+
+# Parse the platformio.ini file
 config = configparser.ConfigParser()
 config.read('firmware/platformio.ini')
 
+# Extract the environment names from the sections
 environments = []
 for section in config.sections():
     if section.startswith("env:"):
         env_name = section.split("env:")[1]
         environments.append({"env": env_name})
 
+# Output the environments as a JSON array
 print(json.dumps(environments))

--- a/.github/workflows/ci-pio.yml
+++ b/.github/workflows/ci-pio.yml
@@ -1,0 +1,93 @@
+name: PlatformIO CI
+
+on:
+  push:
+  pull_request: 
+  workflow_dispatch:
+    
+jobs:
+  build-calibration:
+    name: Build Calibration
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build Calibration
+        run: |
+          cd calibration
+          pio run
+
+
+  pio-fw-matrix:
+    name: Parse firmware/platformio.ini
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Parse platformio.ini
+        id: set-matrix
+        run: |
+          echo "matrix=$(python .github/parse_platformio.py)" >> $GITHUB_OUTPUT
+
+  build-firmware:
+    needs: pio-fw-matrix
+    runs-on: ubuntu-latest
+    name: Build ${{ matrix.env }} firmware
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{fromJson(needs.pio-fw-matrix.outputs.matrix)}}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Install PIO in Home
+        run: |
+          python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
+          echo "PATH=\"\$PATH:\$HOME/.platformio/penv/bin\"" >> $HOME/.bashrc
+          source $HOME/.bashrc
+
+      - name: Install required pip packages
+        run: |
+          source $HOME/.platformio/penv/bin/activate
+          pip install --upgrade catkin_pkg
+          pip uninstall em
+          pip install empy lark
+
+      - name: Build Firmware
+        env:
+            ROS_DISTRO: rolling
+        run: |
+          cd firmware
+          pio run -e ${{ matrix.env }}

--- a/.github/workflows/ci-pio.yml
+++ b/.github/workflows/ci-pio.yml
@@ -1,26 +1,33 @@
 name: PlatformIO CI
 
+# Controls when this action will run.
 on:
   push:
   pull_request: 
   workflow_dispatch:
     
 jobs:
+  # This job is used to build the calibration firmware
   build-calibration:
     name: Build Calibration
     runs-on: ubuntu-latest
 
     steps:
+      # Check out the repository
       - uses: actions/checkout@v3
+
+      # Cache dependencies to speed up workflows
       - uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
           key: ${{ runner.os }}-pio
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
 
@@ -30,6 +37,7 @@ jobs:
           pio run
 
 
+  # This job parses the firmware/platformio.ini file
   pio-fw-matrix:
     name: Parse firmware/platformio.ini
     runs-on: ubuntu-latest
@@ -37,6 +45,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
     steps:
+      # check out the repository
       - uses: actions/checkout@v3
 
       - name: Set up Python
@@ -44,31 +53,42 @@ jobs:
         with:
           python-version: '3.9'
 
+      # run the python script to parse the platformio.ini file and output as json to a matrix
       - name: Parse platformio.ini
         id: set-matrix
         run: |
           echo "matrix=$(python .github/parse_platformio.py)" >> $GITHUB_OUTPUT
 
+
+  # This job builds the firmware for each environment parsed from the platformio.ini file
   build-firmware:
+    # require the pio-fw-matrix job to complete before running
     needs: pio-fw-matrix
     runs-on: ubuntu-latest
     name: Build ${{ matrix.env }} firmware
     strategy:
+      # don't stop all jobs if one fails
       fail-fast: false
+      # Build the firmware for each environment from parsing job in parallel
       matrix:
         include: ${{fromJson(needs.pio-fw-matrix.outputs.matrix)}}
 
     steps:
+      # Check out the repository
       - uses: actions/checkout@v3
+
+      # speed up workflows by caching dependencies
       - uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
           key: ${{ runner.os }}-pio
+      
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
 
@@ -78,6 +98,8 @@ jobs:
           echo "PATH=\"\$PATH:\$HOME/.platformio/penv/bin\"" >> $HOME/.bashrc
           source $HOME/.bashrc
 
+      # NOTE all req. PIO pip packages should already be installed, but found these to be necessary
+      # Missing packages determined from error messages
       - name: Install required pip packages
         run: |
           source $HOME/.platformio/penv/bin/activate
@@ -85,6 +107,7 @@ jobs:
           pip uninstall em
           pip install empy lark
 
+      # Build the firmware for each environment in parallel
       - name: Build Firmware
         env:
             ROS_DISTRO: rolling


### PR DESCRIPTION
A good place to start with CI for PlatformIO builds. 
Implements #36

* build calibration

* parse firmware/platformio.ini with a python script to get configurations

* build each firmware configuration in parallel to reduce run time from 40 min to ~7


