### PR TITLE
ci for each ROS distro

### DIFF
--- a/.github/workflows/foxy-firmware-build.yml
+++ b/.github/workflows/foxy-firmware-build.yml
@@ -3,10 +3,10 @@ name: ROS Foxy Firmware Build
 on:
   pull_request:
     branches:
-      - foxy
+      - foxy*
   push:
     branches:
-      - foxy
+      - foxy*
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
@@ -18,4 +18,3 @@ jobs:
     uses: ./.github/workflows/reusable-platformio-ci.yml
     with:
       ros_distro: foxy
-      reference: foxy

--- a/.github/workflows/foxy-firmware-build.yml
+++ b/.github/workflows/foxy-firmware-build.yml
@@ -4,9 +4,21 @@ on:
   pull_request:
     branches:
       - foxy*
+    paths-ignore:
+      - 'docs/**'
+      - .gitignore
+      - LICENSE
+      - README.md
+  
   push:
     branches:
       - foxy*
+    paths-ignore:
+      - 'docs/**'
+      - .gitignore
+      - LICENSE
+      - README.md
+  
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/foxy-firmware-build.yml
+++ b/.github/workflows/foxy-firmware-build.yml
@@ -1,0 +1,21 @@
+name: ROS Foxy Firmware Build
+
+on:
+  pull_request:
+    branches:
+      - foxy
+  push:
+    branches:
+      - foxy
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+  workflow_dispatch:
+
+
+jobs:
+  firmware:
+    uses: ./.github/workflows/reusable-platformio-ci.yml
+    with:
+      ros_distro: foxy
+      reference: foxy

--- a/.github/workflows/galactic-firmware-build.yml
+++ b/.github/workflows/galactic-firmware-build.yml
@@ -4,9 +4,21 @@ on:
   pull_request:
     branches:
       - galactic*
+    paths-ignore:
+      - 'docs/**'
+      - .gitignore
+      - LICENSE
+      - README.md
+
   push:
     branches:
       - galactic*
+    paths-ignore:
+      - 'docs/**'
+      - .gitignore
+      - LICENSE
+      - README.md
+  
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/galactic-firmware-build.yml
+++ b/.github/workflows/galactic-firmware-build.yml
@@ -1,0 +1,21 @@
+name: ROS Galactic Firmware Build
+
+on:
+  pull_request:
+    branches:
+      - galactic
+  push:
+    branches:
+      - galactic
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+  workflow_dispatch:
+
+
+jobs:
+  firmware:
+    uses: ./.github/workflows/reusable-platformio-ci.yml
+    with:
+      ros_distro: galactic
+      reference: galactic

--- a/.github/workflows/galactic-firmware-build.yml
+++ b/.github/workflows/galactic-firmware-build.yml
@@ -3,10 +3,10 @@ name: ROS Galactic Firmware Build
 on:
   pull_request:
     branches:
-      - galactic
+      - galactic*
   push:
     branches:
-      - galactic
+      - galactic*
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
@@ -18,4 +18,3 @@ jobs:
     uses: ./.github/workflows/reusable-platformio-ci.yml
     with:
       ros_distro: galactic
-      reference: galactic

--- a/.github/workflows/humble-firmware-build.yml
+++ b/.github/workflows/humble-firmware-build.yml
@@ -4,9 +4,21 @@ on:
   pull_request:
     branches:
       - humble*
+    paths-ignore:
+      - 'docs/**'
+      - .gitignore
+      - LICENSE
+      - README.md
+  
   push:
     branches:
       - humble*
+    paths-ignore:
+      - 'docs/**'
+      - .gitignore
+      - LICENSE
+      - README.md
+
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/humble-firmware-build.yml
+++ b/.github/workflows/humble-firmware-build.yml
@@ -3,10 +3,10 @@ name: ROS Humble Firmware Build
 on:
   pull_request:
     branches:
-      - humble
+      - humble*
   push:
     branches:
-      - humble
+      - humble*
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
@@ -18,4 +18,3 @@ jobs:
     uses: ./.github/workflows/reusable-platformio-ci.yml
     with:
       ros_distro: humble
-      reference: humble

--- a/.github/workflows/humble-firmware-build.yml
+++ b/.github/workflows/humble-firmware-build.yml
@@ -1,0 +1,21 @@
+name: ROS Humble Firmware Build
+
+on:
+  pull_request:
+    branches:
+      - humble
+  push:
+    branches:
+      - humble
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+  workflow_dispatch:
+
+
+jobs:
+  firmware:
+    uses: ./.github/workflows/reusable-platformio-ci.yml
+    with:
+      ros_distro: humble
+      reference: humble

--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -108,9 +108,13 @@ jobs:
 
       - name: Install PlatformIO Core
         run: pip3 install --upgrade platformio
-
-      - name: Manually create penv
+        
+      - name: Initialize PlatformIO and create penv
         run: |
+          pio --venv
+          if [ ! -d ~/.platformio ]; then
+            mkdir ~/.platformio
+          fi
           cd ~/.platformio
           python3 -m venv penv
 

--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -111,7 +111,7 @@ jobs:
         
       - name: Initialize PlatformIO and create penv
         run: |
-          pio --venv
+          pio --version
           if [ ! -d ~/.platformio ]; then
             mkdir ~/.platformio
           fi

--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -1,10 +1,20 @@
-name: PlatformIO CI
+name: Reusable PlatformIO CI
 
 # Controls when this action will run.
 on:
-  push:
-  pull_request: 
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ros_distro:
+        description: 'ROS_DISTRO variable'
+        required: true
+        type: string
+
+      reference:
+        description: 'Branch or tag of repo to checkout for build.'
+        default: ''
+        required: false
+        type: string
+
     
 jobs:
   # This job is used to build the calibration firmware
@@ -15,6 +25,8 @@ jobs:
     steps:
       # Check out the repository
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.reference }}
 
       # Cache dependencies to speed up workflows
       - uses: actions/cache@v3
@@ -47,6 +59,8 @@ jobs:
     steps:
       # check out the repository
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.reference }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -54,6 +68,7 @@ jobs:
           python-version: '3.9'
 
       # run the python script to parse the platformio.ini file and output as json to a matrix
+      # pass the ros distros desired as arguments
       - name: Parse platformio.ini
         id: set-matrix
         run: |
@@ -65,7 +80,7 @@ jobs:
     # require the pio-fw-matrix job to complete before running
     needs: pio-fw-matrix
     runs-on: ubuntu-latest
-    name: Build ${{ matrix.env }} firmware
+    name: Build ${{ matrix.env }} firmware on ROS ${{ inputs.ros_distro }}
     strategy:
       # don't stop all jobs if one fails
       fail-fast: false
@@ -76,6 +91,8 @@ jobs:
     steps:
       # Check out the repository
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.reference }}
 
       # speed up workflows by caching dependencies
       - uses: actions/cache@v3
@@ -110,7 +127,7 @@ jobs:
       # Build the firmware for each environment in parallel
       - name: Build Firmware
         env:
-            ROS_DISTRO: rolling
+          ROS_DISTRO: ${{ inputs.ros_distro }}
         run: |
           cd firmware
           pio run -e ${{ matrix.env }}

--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -104,25 +104,15 @@ jobs:
       
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install PlatformIO Core
-        run: pip install --upgrade platformio
+        run: pip3 install --upgrade platformio
 
-      - name: Install PIO in Home
+      - name: Manually create penv
         run: |
-          python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
-          echo "PATH=\"\$PATH:\$HOME/.platformio/penv/bin\"" >> $HOME/.bashrc
-          source $HOME/.bashrc
-
-      # NOTE all req. PIO pip packages should already be installed, but found these to be necessary
-      # Missing packages determined from error messages
-      - name: Install required pip packages
-        run: |
-          source $HOME/.platformio/penv/bin/activate
-          pip install --upgrade catkin_pkg
-          pip uninstall em
-          pip install empy lark
+          cd ~/.platformio
+          python3 -m venv penv
 
       # Build the firmware for each environment in parallel
       - name: Build Firmware

--- a/.github/workflows/rolling-firmware-build.yml
+++ b/.github/workflows/rolling-firmware-build.yml
@@ -1,16 +1,19 @@
 name: ROS Rolling Firmware Build
 
-# TODO rename main branch of repo to rolling and then fix
 on:
-  # using branches-ignore to avoid running on unrelated branches but still in dev
+  # avoid running on distro branches but otherwise always
   pull_request:
     branches-ignore:
-      - foxy
-      - humble
+      - foxy*
+      # - galactic*
+      - humble*
+      - iron*
   push:
     branches-ignore:
-      - foxy
-      - humble
+      - foxy*
+      # - galactic*
+      - humble*
+      - iron*
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'
@@ -22,4 +25,3 @@ jobs:
     uses: ./.github/workflows/reusable-platformio-ci.yml
     with:
       ros_distro: rolling
-      reference: galactic

--- a/.github/workflows/rolling-firmware-build.yml
+++ b/.github/workflows/rolling-firmware-build.yml
@@ -1,0 +1,25 @@
+name: ROS Rolling Firmware Build
+
+# TODO rename main branch of repo to rolling and then fix
+on:
+  # using branches-ignore to avoid running on unrelated branches but still in dev
+  pull_request:
+    branches-ignore:
+      - foxy
+      - humble
+  push:
+    branches-ignore:
+      - foxy
+      - humble
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+  workflow_dispatch:
+
+
+jobs:
+  firmware:
+    uses: ./.github/workflows/reusable-platformio-ci.yml
+    with:
+      ros_distro: rolling
+      reference: galactic

--- a/.github/workflows/rolling-firmware-build.yml
+++ b/.github/workflows/rolling-firmware-build.yml
@@ -5,15 +5,27 @@ on:
   pull_request:
     branches-ignore:
       - foxy*
-      # - galactic*
+      - galactic*
       - humble*
       - iron*
+    paths-ignore:
+      - 'docs/**'
+      - .gitignore
+      - LICENSE
+      - README.md
+
   push:
     branches-ignore:
       - foxy*
-      # - galactic*
+      - galactic*
       - humble*
       - iron*
+    paths-ignore:
+      - 'docs/**'
+      - .gitignore
+      - LICENSE
+      - README.md
+
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## Build status
+<!-- Build Status populated by Github Actions runs -->
+ROS 2 Distro | Branch | Build status
+:----------: | :----: | :----------:
+**Rolling** | [`galactic`](https://github.com/linorobot/linorobot2_hardware/tree/galactic) | [![Rolling Firmware Build](https://github.com/linorobot/linorobot2_hardware/actions/workflows/rolling-firmware-build.yml/badge.svg?branch=galactic)](https://github.com/linorobot/linorobot2_hardware/actions/workflows/rolling-firmware-build.yml?branch=galactic)
+**Humble** | [`humble`](https://github.com/linorobot/linorobot2_hardware/tree/humble) | [![Humble Firmware Build](https://github.com/linorobot/linorobot2_hardware/actions/workflows/humble-firmware-build.yml/badge.svg?branch=humble)](https://github.com/linorobot/linorobot2_hardware/actions/workflows/humble-firmware-build.yml?branch=humble)
+**Galactic** | [`galactic`](https://github.com/linorobot/linorobot2_hardware/tree/galactic) | [![Galactic Firmware Build](https://github.com/linorobot/linorobot2_hardware/actions/workflows/galactic-firmware-build.yml/badge.svg?branch=galactic)](https://github.com/linorobot/linorobot2_hardware/actions/workflows/galactic-firmware-build.yml?branch=galactic)
+**Foxy** | [`foxy`](https://github.com/linorobot/linorobot2_hardware/tree/foxy) | [![Foxy Firmware Build](https://github.com/linorobot/linorobot2_hardware/actions/workflows/foxy-firmware-build.yml/badge.svg?branch=foxy)](https://github.com/linorobot/linorobot2_hardware/actions/workflows/foxy-firmware-build.yml?branch=foxy)
+
 ## Installation
 All software mentioned in this guide must be installed on the robot computer.
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 <!-- Build Status populated by Github Actions runs -->
 ROS 2 Distro | Branch | Build status
 :----------: | :----: | :----------:
-**Rolling** | [`galactic`](https://github.com/linorobot/linorobot2_hardware/tree/galactic) | [![Rolling Firmware Build](https://github.com/linorobot/linorobot2_hardware/actions/workflows/rolling-firmware-build.yml/badge.svg?branch=galactic)](https://github.com/linorobot/linorobot2_hardware/actions/workflows/rolling-firmware-build.yml?branch=galactic)
-**Humble** | [`humble`](https://github.com/linorobot/linorobot2_hardware/tree/humble) | [![Humble Firmware Build](https://github.com/linorobot/linorobot2_hardware/actions/workflows/humble-firmware-build.yml/badge.svg?branch=humble)](https://github.com/linorobot/linorobot2_hardware/actions/workflows/humble-firmware-build.yml?branch=humble)
-**Galactic** | [`galactic`](https://github.com/linorobot/linorobot2_hardware/tree/galactic) | [![Galactic Firmware Build](https://github.com/linorobot/linorobot2_hardware/actions/workflows/galactic-firmware-build.yml/badge.svg?branch=galactic)](https://github.com/linorobot/linorobot2_hardware/actions/workflows/galactic-firmware-build.yml?branch=galactic)
-**Foxy** | [`foxy`](https://github.com/linorobot/linorobot2_hardware/tree/foxy) | [![Foxy Firmware Build](https://github.com/linorobot/linorobot2_hardware/actions/workflows/foxy-firmware-build.yml/badge.svg?branch=foxy)](https://github.com/linorobot/linorobot2_hardware/actions/workflows/foxy-firmware-build.yml?branch=foxy)
+**Rolling** | [`master`](../../tree/master) | [![Rolling Firmware Build](../../actions/workflows/rolling-firmware-build.yml/badge.svg?branch=master)](../../actions/workflows/rolling-firmware-build.yml?branch=master)
+**Humble** | [`humble`](../../tree/humble) | [![Humble Firmware Build](../../actions/workflows/humble-firmware-build.yml/badge.svg?branch=humble)](../../actions/workflows/humble-firmware-build.yml?branch=humble)
+**Galactic** | [`galactic`](../../tree/galactic) | [![Galactic Firmware Build](../../actions/workflows/galactic-firmware-build.yml/badge.svg?branch=galactic)](../../actions/workflows/galactic-firmware-build.yml?branch=galactic)
+**Foxy** | [`foxy`](../../tree/foxy) | [![Foxy Firmware Build](../../actions/workflows/foxy-firmware-build.yml/badge.svg?branch=foxy)](../../actions/workflows/foxy-firmware-build.yml?branch=foxy)
 
 ## Installation
 All software mentioned in this guide must be installed on the robot computer.


### PR DESCRIPTION
Implements issue proposed in #39 as a step on the path to fixing build errors across branches and targeting different ROS distros. Build failures indicate issues with a particular distro.

* made PlatformIO firmware CI reusable and callable from other workflows

* created individual workflows per ROS distro/branch to allow badges/statuses

* firmware build status badges on README for each branch

