### PR TITLE
Fix Foxy Branch

### DIFF
--- a/.github/parse_platformio.py
+++ b/.github/parse_platformio.py
@@ -1,0 +1,18 @@
+import configparser
+import json
+
+""" This script parses the platformio.ini file and outputs a JSON array of environments to be used by GitHub Actions."""
+
+# Parse the platformio.ini file
+config = configparser.ConfigParser()
+config.read('firmware/platformio.ini')
+
+# Extract the environment names from the sections
+environments = []
+for section in config.sections():
+    if section.startswith("env:"):
+        env_name = section.split("env:")[1]
+        environments.append({"env": env_name})
+
+# Output the environments as a JSON array
+print(json.dumps(environments))

--- a/.github/workflows/foxy-firmware-build.yml
+++ b/.github/workflows/foxy-firmware-build.yml
@@ -3,9 +3,11 @@ name: ROS Foxy Firmware Build
 on:
   pull_request:
     branches:
+      - foxy
       - foxy*
   push:
     branches:
+      - foxy
       - foxy*
   schedule:
     # Run every morning to detect flakiness and broken dependencies

--- a/.github/workflows/foxy-firmware-build.yml
+++ b/.github/workflows/foxy-firmware-build.yml
@@ -1,0 +1,21 @@
+name: ROS Foxy Firmware Build
+
+on:
+  pull_request:
+    branches:
+      - foxy
+  push:
+    branches:
+      - foxy
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+  workflow_dispatch:
+
+
+jobs:
+  firmware:
+    uses: ./.github/workflows/reusable-platformio-ci.yml
+    with:
+      ros_distro: foxy
+      reference: foxy

--- a/.github/workflows/foxy-firmware-build.yml
+++ b/.github/workflows/foxy-firmware-build.yml
@@ -3,10 +3,10 @@ name: ROS Foxy Firmware Build
 on:
   pull_request:
     branches:
-      - foxy
+      - foxy*
   push:
     branches:
-      - foxy
+      - foxy*
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 1 * * *'

--- a/.github/workflows/foxy-firmware-build.yml
+++ b/.github/workflows/foxy-firmware-build.yml
@@ -20,4 +20,3 @@ jobs:
     uses: ./.github/workflows/reusable-platformio-ci.yml
     with:
       ros_distro: foxy
-      reference: foxy

--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -1,0 +1,133 @@
+name: Reusable PlatformIO CI
+
+# Controls when this action will run.
+on:
+  workflow_call:
+    inputs:
+      ros_distro:
+        description: 'ROS_DISTRO variable'
+        required: true
+        type: string
+
+      reference:
+        description: 'Branch or tag of repo to checkout for build.'
+        default: ''
+        required: false
+        type: string
+
+    
+jobs:
+  # This job is used to build the calibration firmware
+  build-calibration:
+    name: Build Calibration
+    runs-on: ubuntu-latest
+
+    steps:
+      # Check out the repository
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.reference }}
+
+      # Cache dependencies to speed up workflows
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build Calibration
+        run: |
+          cd calibration
+          pio run
+
+
+  # This job parses the firmware/platformio.ini file
+  pio-fw-matrix:
+    name: Parse firmware/platformio.ini
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+      # check out the repository
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.reference }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      # run the python script to parse the platformio.ini file and output as json to a matrix
+      # pass the ros distros desired as arguments
+      - name: Parse platformio.ini
+        id: set-matrix
+        run: |
+          echo "matrix=$(python .github/parse_platformio.py)" >> $GITHUB_OUTPUT
+
+
+  # This job builds the firmware for each environment parsed from the platformio.ini file
+  build-firmware:
+    # require the pio-fw-matrix job to complete before running
+    needs: pio-fw-matrix
+    runs-on: ubuntu-latest
+    name: Build ${{ matrix.env }} firmware on ROS ${{ inputs.ros_distro }}
+    strategy:
+      # don't stop all jobs if one fails
+      fail-fast: false
+      # Build the firmware for each environment from parsing job in parallel
+      matrix:
+        include: ${{fromJson(needs.pio-fw-matrix.outputs.matrix)}}
+
+    steps:
+      # Check out the repository
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.reference }}
+
+      # speed up workflows by caching dependencies
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Install PIO in Home
+        run: |
+          python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
+          echo "PATH=\"\$PATH:\$HOME/.platformio/penv/bin\"" >> $HOME/.bashrc
+          source $HOME/.bashrc
+
+      # NOTE all req. PIO pip packages should already be installed, but found these to be necessary
+      # Missing packages determined from error messages
+      - name: Install required pip packages
+        run: |
+          source $HOME/.platformio/penv/bin/activate
+          pip install --upgrade catkin_pkg
+          pip uninstall em
+          pip install empy lark
+
+      # Build the firmware for each environment in parallel
+      - name: Build Firmware
+        env:
+          ROS_DISTRO: ${{ inputs.ros_distro }}
+        run: |
+          cd firmware
+          pio run -e ${{ matrix.env }}

--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: DEBUG look at environment
+        run: ls -laR
+
       # run the python script to parse the platformio.ini file and output as json to a matrix
       # pass the ros distros desired as arguments
       - name: Parse platformio.ini

--- a/firmware/lib/rosidl_typesupport_introspection_c/CHANGELOG.rst
+++ b/firmware/lib/rosidl_typesupport_introspection_c/CHANGELOG.rst
@@ -1,0 +1,64 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package rosidl_typesupport_introspection_c
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1.3.1 (2023-05-27)
+------------------
+
+1.3.0 (2022-09-20)
+------------------
+
+1.2.1 (2021-04-14)
+------------------
+
+1.2.0 (2020-12-08)
+------------------
+
+1.1.0 (2020-08-17)
+------------------
+
+1.0.1 (2020-06-03)
+------------------
+
+1.0.0 (2020-05-22)
+------------------
+* Fix variable suffix in rosidl_export_typesupport_targets (`#483 <https://github.com/ros2/rosidl/issues/483>`_)
+* Contributors: Ivan Santiago Paunovic
+
+0.9.2 (2020-05-19)
+------------------
+* Force extension points to be registered in order (`#485 <https://github.com/ros2/rosidl/issues/485>`_)
+* Contributors: Ivan Santiago Paunovic
+
+0.9.1 (2020-05-08)
+------------------
+* use typesuport targets instead of libraries (`#478 <https://github.com/ros2/rosidl/issues/478>`_)
+* Contributors: Dirk Thomas
+
+0.9.0 (2020-04-24)
+------------------
+* Export missing targets for single typesupport build, avoid exposing build directories in include dirs (`#477 <https://github.com/ros2/rosidl/issues/477>`_)
+* Export targets in addition to include directories / libraries (`#471 <https://github.com/ros2/rosidl/issues/471>`_)
+* Fix build with single introspection typesupport (`#470 <https://github.com/ros2/rosidl/issues/470>`_)
+* Rename rosidl_runtime_c_message_initialization to rosidl_runtime_c__message_initialization (`#464 <https://github.com/ros2/rosidl/issues/464>`_)
+* Move non-entry point headers into detail subdirectory (`#461 <https://github.com/ros2/rosidl/issues/461>`_)
+* Rename rosidl_generator_c 'namespace' to rosidl_runtime_c (`#458 <https://github.com/ros2/rosidl/issues/458>`_)
+* Split rosidl_generator_c and rosidl_generator_cpp in two: rosidl_generator_x and rosidl_runtime_x (`#442 <https://github.com/ros2/rosidl/issues/442>`_)
+* Export typesupport library in a separate cmake variable (`#453 <https://github.com/ros2/rosidl/issues/453>`_)
+* Style update to match uncrustify with explicit language (`#439 <https://github.com/ros2/rosidl/issues/439>`_)
+* Move repeated logic for C include prefix into common function (`#432 <https://github.com/ros2/rosidl/issues/432>`_)
+* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Ivan Santiago Paunovic, Jacob Perron
+
+0.8.2 (2020-01-17)
+------------------
+
+0.8.1 (2019-10-23)
+------------------
+* Add init and fini function for creating introspection messages (`#416 <https://github.com/ros2/rosidl/issues/416>`_)
+* Contributors: Karsten Knese
+
+0.8.0 (2019-09-24)
+------------------
+* [rosidl_typesupport_introspection_c] Use message namespaced type name as function prefix (`#387 <https://github.com/ros2/rosidl/issues/387>`_)
+* fix cpp generator and introspection ts for long double (`#383 <https://github.com/ros2/rosidl/issues/383>`_)
+* Contributors: Dirk Thomas, Jacob Perron

--- a/firmware/lib/rosidl_typesupport_introspection_c/CMakeLists.txt
+++ b/firmware/lib/rosidl_typesupport_introspection_c/CMakeLists.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rosidl_typesupport_introspection_c)
+
+# Default to C11
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 11)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake_python REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
+
+ament_export_dependencies(rosidl_cmake)
+ament_export_dependencies(rosidl_runtime_c)
+# The reason the impl folder is exported is that it contains the implementation
+# for the get_*_type_support_handle functions and defines the opensplice
+# specific version of these functions.
+
+ament_export_include_directories(include)
+
+ament_python_install_package(${PROJECT_NAME})
+
+add_library(${PROJECT_NAME} src/identifier.c)
+if(WIN32)
+  target_compile_definitions(${PROJECT_NAME}
+    PRIVATE "ROSIDL_TYPESUPPORT_INTROSPECTION_C_BUILDING_DLL")
+endif()
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
+ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(${PROJECT_NAME})
+
+ament_index_register_resource("rosidl_typesupport_c")
+ament_index_register_resource("rosidl_runtime_packages")
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+if(BUILD_SHARED_LIBS)
+  set(${PROJECT_NAME}_LIBRARY_TYPE "SHARED")
+else()
+  set(${PROJECT_NAME}_LIBRARY_TYPE "STATIC")
+endif()
+
+ament_package(
+  CONFIG_EXTRAS "rosidl_typesupport_introspection_c-extras.cmake.in"
+)
+
+install(
+  PROGRAMS bin/rosidl_typesupport_introspection_c
+  DESTINATION lib/rosidl_typesupport_introspection_c
+)
+install(
+  DIRECTORY cmake resource
+  DESTINATION share/${PROJECT_NAME}
+)
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+install(
+  TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)

--- a/firmware/lib/rosidl_typesupport_introspection_c/LICENSE
+++ b/firmware/lib/rosidl_typesupport_introspection_c/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/firmware/lib/rosidl_typesupport_introspection_c/bin/rosidl_typesupport_introspection_c
+++ b/firmware/lib/rosidl_typesupport_introspection_c/bin/rosidl_typesupport_introspection_c
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+
+from rosidl_typesupport_introspection_c import generate_c
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description='Generate the C type support to dynamically handle ROS messages.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--generator-arguments-file',
+        required=True,
+        help='The location of the file containing the generator arguments')
+    args = parser.parse_args(argv)
+
+    return generate_c(args.generator_arguments_file)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/firmware/lib/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/firmware/lib/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -1,0 +1,179 @@
+# Copyright 2014-2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(NOT rosidl_generator_c_FOUND)
+  message(FATAL_ERROR
+    "'rosidl_generator_c' not found when executing "
+    "'rosidl_typesupport_introspection_c' extension.")
+endif()
+
+set(_output_path
+  "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_introspection_c/${PROJECT_NAME}")
+set(_generated_header_files "")
+set(_generated_source_files "")
+foreach(_abs_idl_file ${rosidl_generate_interfaces_ABS_IDL_FILES})
+  get_filename_component(_parent_folder "${_abs_idl_file}" DIRECTORY)
+  get_filename_component(_parent_folder "${_parent_folder}" NAME)
+  get_filename_component(_idl_name "${_abs_idl_file}" NAME_WE)
+  string_camel_case_to_lower_case_underscore("${_idl_name}" _header_name)
+  list(APPEND _generated_header_files
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__rosidl_typesupport_introspection_c.h")
+  list(APPEND _generated_source_files
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__type_support.c")
+endforeach()
+
+set(_dependency_files "")
+set(_dependencies "")
+foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
+  foreach(_idl_file ${${_pkg_name}_IDL_FILES})
+    set(_abs_idl_file "${${_pkg_name}_DIR}/../${_idl_file}")
+    normalize_path(_abs_idl_file "${_abs_idl_file}")
+    list(APPEND _dependency_files "${_abs_idl_file}")
+    list(APPEND _dependencies "${_pkg_name}:${_abs_idl_file}")
+  endforeach()
+endforeach()
+
+set(target_dependencies
+  "${rosidl_typesupport_introspection_c_BIN}"
+  ${rosidl_typesupport_introspection_c_GENERATOR_FILES}
+  "${rosidl_typesupport_introspection_c_TEMPLATE_DIR}/idl__rosidl_typesupport_introspection_c.h.em"
+  "${rosidl_typesupport_introspection_c_TEMPLATE_DIR}/idl__type_support.c.em"
+  "${rosidl_typesupport_introspection_c_TEMPLATE_DIR}/msg__rosidl_typesupport_introspection_c.h.em"
+  "${rosidl_typesupport_introspection_c_TEMPLATE_DIR}/msg__type_support.c.em"
+  "${rosidl_typesupport_introspection_c_TEMPLATE_DIR}/srv__rosidl_typesupport_introspection_c.h.em"
+  "${rosidl_typesupport_introspection_c_TEMPLATE_DIR}/srv__type_support.c.em"
+  ${rosidl_generate_interfaces_ABS_IDL_FILES}
+  ${_dependency_files})
+foreach(dep ${target_dependencies})
+  if(NOT EXISTS "${dep}")
+    message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+  endif()
+endforeach()
+
+set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_introspection_c__arguments.json")
+rosidl_write_generator_arguments(
+  "${generator_arguments_file}"
+  PACKAGE_NAME "${PROJECT_NAME}"
+  IDL_TUPLES "${rosidl_generate_interfaces_IDL_TUPLES}"
+  ROS_INTERFACE_DEPENDENCIES "${_dependencies}"
+  OUTPUT_DIR "${_output_path}"
+  TEMPLATE_DIR "${rosidl_typesupport_introspection_c_TEMPLATE_DIR}"
+  TARGET_DEPENDENCIES ${target_dependencies}
+)
+
+add_custom_command(
+  OUTPUT ${_generated_header_files} ${_generated_source_files}
+  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_typesupport_introspection_c_BIN}
+  --generator-arguments-file "${generator_arguments_file}"
+  DEPENDS ${target_dependencies}
+  COMMENT "Generating C introspection for ROS interfaces"
+  VERBATIM
+)
+
+# generate header to switch between export and import for a specific package
+set(_visibility_control_file
+  "${_output_path}/msg/rosidl_typesupport_introspection_c__visibility_control.h")
+string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
+configure_file(
+  "${rosidl_typesupport_introspection_c_TEMPLATE_DIR}/rosidl_typesupport_introspection_c__visibility_control.h.in"
+  "${_visibility_control_file}"
+  @ONLY
+)
+list(APPEND _generated_msg_header_files "${_visibility_control_file}")
+
+set(_target_suffix "__rosidl_typesupport_introspection_c")
+
+add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} ${rosidl_typesupport_introspection_c_LIBRARY_TYPE}
+  ${_generated_header_files} ${_generated_source_files})
+if(rosidl_generate_interfaces_LIBRARY_NAME)
+  set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PROPERTIES OUTPUT_NAME "${rosidl_generate_interfaces_LIBRARY_NAME}${_target_suffix}")
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix} PROPERTIES
+    C_STANDARD 11
+    COMPILE_OPTIONS -Wall -Wextra -Wpedantic)
+endif()
+if(WIN32)
+  target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PRIVATE "ROSIDL_TYPESUPPORT_INTROSPECTION_C_BUILDING_DLL_${PROJECT_NAME}")
+endif()
+target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_introspection_c>"
+)
+target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c)
+ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  "rosidl_typesupport_introspection_c")
+foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
+  ament_target_dependencies(
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ${_pkg_name})
+  target_link_libraries(
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ${${_pkg_name}_TARGETS${_target_suffix}})
+endforeach()
+
+add_dependencies(
+  ${rosidl_generate_interfaces_TARGET}
+  ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+)
+
+if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
+  if(NOT _generated_header_files STREQUAL "")
+    install(
+      DIRECTORY ${_output_path}/
+      DESTINATION "include/${PROJECT_NAME}"
+      PATTERN "*.h"
+    )
+  endif()
+  install(
+    TARGETS ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    EXPORT ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+  )
+  rosidl_export_typesupport_targets(${_target_suffix}
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix})
+  ament_export_targets(${rosidl_generate_interfaces_TARGET}${_target_suffix})
+endif()
+
+if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)
+  if(NOT _generated_header_files STREQUAL "")
+    find_package(ament_cmake_cppcheck REQUIRED)
+    ament_cppcheck(
+      TESTNAME "cppcheck_rosidl_typesupport_introspection_c"
+      "${_output_path}")
+
+    find_package(ament_cmake_cpplint REQUIRED)
+    get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
+    ament_cpplint(
+      TESTNAME "cpplint_rosidl_typesupport_introspection_c"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      ROOT "${_cpplint_root}"
+      "${_output_path}")
+
+    find_package(ament_cmake_uncrustify REQUIRED)
+    ament_uncrustify(
+      TESTNAME "uncrustify_rosidl_typesupport_introspection_c"
+      # the generated code might contain longer lines for templated types
+      # a value of zero tells uncrustify to ignore line length
+      MAX_LINE_LENGTH 0
+      "${_output_path}")
+  endif()
+endif()

--- a/firmware/lib/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/field_types.h
+++ b/firmware/lib/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/field_types.h
@@ -1,0 +1,58 @@
+// Copyright 2014-2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_INTROSPECTION_C__FIELD_TYPES_H_
+#define ROSIDL_TYPESUPPORT_INTROSPECTION_C__FIELD_TYPES_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+enum
+{
+  rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT = 1,
+  rosidl_typesupport_introspection_c__ROS_TYPE_DOUBLE = 2,
+  rosidl_typesupport_introspection_c__ROS_TYPE_LONG_DOUBLE = 3,
+  rosidl_typesupport_introspection_c__ROS_TYPE_CHAR = 4,
+  rosidl_typesupport_introspection_c__ROS_TYPE_WCHAR = 5,
+  rosidl_typesupport_introspection_c__ROS_TYPE_BOOLEAN = 6,
+  rosidl_typesupport_introspection_c__ROS_TYPE_OCTET = 7,
+  rosidl_typesupport_introspection_c__ROS_TYPE_UINT8 = 8,
+  rosidl_typesupport_introspection_c__ROS_TYPE_INT8 = 9,
+  rosidl_typesupport_introspection_c__ROS_TYPE_UINT16 = 10,
+  rosidl_typesupport_introspection_c__ROS_TYPE_INT16 = 11,
+  rosidl_typesupport_introspection_c__ROS_TYPE_UINT32 = 12,
+  rosidl_typesupport_introspection_c__ROS_TYPE_INT32 = 13,
+  rosidl_typesupport_introspection_c__ROS_TYPE_UINT64 = 14,
+  rosidl_typesupport_introspection_c__ROS_TYPE_INT64 = 15,
+  rosidl_typesupport_introspection_c__ROS_TYPE_STRING = 16,
+  rosidl_typesupport_introspection_c__ROS_TYPE_WSTRING = 17,
+
+  rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE = 18,
+
+  // for backward compatibility only
+  rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32 = 1,
+  rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT64 = 2,
+  rosidl_typesupport_introspection_c__ROS_TYPE_BOOL = 6,
+  rosidl_typesupport_introspection_c__ROS_TYPE_BYTE = 7
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_C__FIELD_TYPES_H_

--- a/firmware/lib/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/identifier.h
+++ b/firmware/lib/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/identifier.h
@@ -1,0 +1,32 @@
+// Copyright 2014-2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_INTROSPECTION_C__IDENTIFIER_H_
+#define ROSIDL_TYPESUPPORT_INTROSPECTION_C__IDENTIFIER_H_
+
+#include "rosidl_typesupport_introspection_c/visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC
+extern const char * rosidl_typesupport_introspection_c__identifier;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_C__IDENTIFIER_H_

--- a/firmware/lib/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/firmware/lib/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -1,0 +1,55 @@
+// Copyright 2014-2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_INTROSPECTION_C__MESSAGE_INTROSPECTION_H_
+#define ROSIDL_TYPESUPPORT_INTROSPECTION_C__MESSAGE_INTROSPECTION_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rosidl_runtime_c/message_initialization.h"
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+#include "rosidl_typesupport_introspection_c/visibility_control.h"
+
+typedef struct rosidl_typesupport_introspection_c__MessageMember
+{
+  const char * name_;
+  uint8_t type_id_;
+  size_t string_upper_bound_;
+  const rosidl_message_type_support_t * members_;
+  bool is_array_;
+  size_t array_size_;
+  bool is_upper_bound_;
+  uint32_t offset_;
+  const void * default_value_;
+  size_t (* size_function)(const void *);
+  const void * (*get_const_function)(const void *, size_t index);
+  void * (*get_function)(void *, size_t index);
+  bool (* resize_function)(void *, size_t size);
+} rosidl_typesupport_introspection_c__MessageMember;
+
+typedef struct rosidl_typesupport_introspection_c__MessageMembers
+{
+  const char * message_namespace_;
+  const char * message_name_;
+  uint32_t member_count_;
+  size_t size_of_;
+  const rosidl_typesupport_introspection_c__MessageMember * members_;
+  void (* init_function)(void *, enum rosidl_runtime_c__message_initialization);
+  void (* fini_function)(void *);
+} rosidl_typesupport_introspection_c__MessageMembers;
+
+#endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_C__MESSAGE_INTROSPECTION_H_

--- a/firmware/lib/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/service_introspection.h
+++ b/firmware/lib/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/service_introspection.h
@@ -1,0 +1,34 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_INTROSPECTION_C__SERVICE_INTROSPECTION_H_
+#define ROSIDL_TYPESUPPORT_INTROSPECTION_C__SERVICE_INTROSPECTION_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rosidl_runtime_c/service_type_support_struct.h"
+#include "rosidl_runtime_c/visibility_control.h"
+
+#include "rosidl_typesupport_introspection_c/message_introspection.h"
+
+typedef struct rosidl_typesupport_introspection_c__ServiceMembers
+{
+  const char * service_namespace_;
+  const char * service_name_;
+  const rosidl_typesupport_introspection_c__MessageMembers * request_members_;
+  const rosidl_typesupport_introspection_c__MessageMembers * response_members_;
+} rosidl_typesupport_introspection_c__ServiceMembers;
+
+#endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_C__SERVICE_INTROSPECTION_H_

--- a/firmware/lib/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/visibility_control.h
+++ b/firmware/lib/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/visibility_control.h
@@ -1,0 +1,56 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_
+#define ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT __attribute__ ((dllexport))
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_IMPORT __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT __declspec(dllexport)
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_TYPESUPPORT_INTROSPECTION_C_BUILDING_DLL
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT
+  #else
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC ROSIDL_TYPESUPPORT_INTROSPECTION_C_IMPORT
+  #endif
+  #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_LOCAL
+#else
+  #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT __attribute__ ((visibility("default")))
+  #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_IMPORT
+  #if __GNUC__ >= 4
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC __attribute__ ((visibility("default")))
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_LOCAL
+  #endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_

--- a/firmware/lib/rosidl_typesupport_introspection_c/package.xml
+++ b/firmware/lib/rosidl_typesupport_introspection_c/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosidl_typesupport_introspection_c</name>
+  <version>1.3.1</version>
+  <description>
+    Generate the message type support for dynamic message construction in C.
+  </description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+  <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
+
+  <build_export_depend>rosidl_runtime_c</build_export_depend>
+
+  <exec_depend>rosidl_cmake</exec_depend>
+  <exec_depend>rosidl_parser</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_typesupport_c_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/firmware/lib/rosidl_typesupport_introspection_c/resource/idl__rosidl_typesupport_introspection_c.h.em
+++ b/firmware/lib/rosidl_typesupport_introspection_c/resource/idl__rosidl_typesupport_introspection_c.h.em
@@ -1,0 +1,119 @@
+// generated from rosidl_typesupport_introspection_c/resource/idl__rosidl_typesupport_introspection_c.h.em
+// with input from @(package_name):@(interface_path)
+// generated code does not contain a copyright notice
+@
+@#######################################################################
+@# EmPy template for generating <idl>__rosidl_typesupport_introspection_c.h files
+@#
+@# Context:
+@#  - package_name (string)
+@#  - interface_path (Path relative to the directory named after the package)
+@#  - content (IdlContent, list of elements, e.g. Messages or Services)
+@#######################################################################
+@{
+from rosidl_cmake import convert_camel_case_to_lower_case_underscore
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+header_guard_variable = '__'.join([x.upper() for x in include_parts]) + \
+    '__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_'
+}@
+
+#ifndef @(header_guard_variable)
+#define @(header_guard_variable)
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+@{
+include_directives = set()
+}@
+@#######################################################################
+@# Handle message
+@#######################################################################
+@{
+from rosidl_parser.definition import Message
+}@
+@[for message in content.get_elements_of_type(Message)]@
+
+@{
+TEMPLATE(
+    'msg__rosidl_typesupport_introspection_c.h.em',
+    package_name=package_name, interface_path=interface_path, message=message,
+    include_directives=include_directives)
+}@
+@[end for]@
+@
+@#######################################################################
+@# Handle service
+@#######################################################################
+@{
+from rosidl_parser.definition import Service
+}@
+@[for service in content.get_elements_of_type(Service)]@
+
+@{
+TEMPLATE(
+    'srv__rosidl_typesupport_introspection_c.h.em',
+    package_name=package_name, interface_path=interface_path, service=service,
+    include_directives=include_directives)
+}@
+@[end for]@
+@
+@#######################################################################
+@# Handle action
+@#######################################################################
+@{
+from rosidl_parser.definition import Action
+}@
+@[for action in content.get_elements_of_type(Action)]@
+
+@{
+TEMPLATE(
+    'msg__rosidl_typesupport_introspection_c.h.em',
+    package_name=package_name, interface_path=interface_path, message=action.goal,
+    include_directives=include_directives)
+}@
+
+@{
+TEMPLATE(
+    'msg__rosidl_typesupport_introspection_c.h.em',
+    package_name=package_name, interface_path=interface_path, message=action.result,
+    include_directives=include_directives)
+}@
+
+@{
+TEMPLATE(
+    'msg__rosidl_typesupport_introspection_c.h.em',
+    package_name=package_name, interface_path=interface_path, message=action.feedback,
+    include_directives=include_directives)
+}@
+
+@{
+TEMPLATE(
+    'srv__rosidl_typesupport_introspection_c.h.em',
+    package_name=package_name, interface_path=interface_path, service=action.send_goal_service,
+    include_directives=include_directives)
+}@
+
+@{
+TEMPLATE(
+    'srv__rosidl_typesupport_introspection_c.h.em',
+    package_name=package_name, interface_path=interface_path, service=action.get_result_service,
+    include_directives=include_directives)
+}@
+
+@{
+TEMPLATE(
+    'msg__rosidl_typesupport_introspection_c.h.em',
+    package_name=package_name, interface_path=interface_path, message=action.feedback_message,
+    include_directives=include_directives)
+}@
+@[end for]@
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // @(header_guard_variable)

--- a/firmware/lib/rosidl_typesupport_introspection_c/resource/idl__type_support.c.em
+++ b/firmware/lib/rosidl_typesupport_introspection_c/resource/idl__type_support.c.em
@@ -1,0 +1,97 @@
+// generated from rosidl_typesupport_introspection_c/resource/idl__type_support.c.em
+// with input from @(package_name):@(interface_path)
+// generated code does not contain a copyright notice
+@
+@#######################################################################
+@# EmPy template for generating <idl>__type_support.c files
+@#
+@# Context:
+@#  - package_name (string)
+@#  - interface_path (Path relative to the directory named after the package)
+@#  - content (IdlContent, list of elements, e.g. Messages or Services)
+@#######################################################################
+@{
+include_directives = set()
+}@
+@#######################################################################
+@# Handle message
+@#######################################################################
+@{
+from rosidl_parser.definition import Message
+}@
+@[for message in content.get_elements_of_type(Message)]@
+
+@{
+TEMPLATE(
+    'msg__type_support.c.em',
+    package_name=package_name, interface_path=interface_path, message=message,
+    include_directives=include_directives)
+}@
+@[end for]@
+@
+@#######################################################################
+@# Handle service
+@#######################################################################
+@{
+from rosidl_parser.definition import Service
+}@
+@[for service in content.get_elements_of_type(Service)]@
+
+@{
+TEMPLATE(
+    'srv__type_support.c.em',
+    package_name=package_name, interface_path=interface_path, service=service,
+    include_directives=include_directives)
+}@
+@[end for]@
+@
+@#######################################################################
+@# Handle action
+@#######################################################################
+@{
+from rosidl_parser.definition import Action
+}@
+@[for action in content.get_elements_of_type(Action)]@
+
+@{
+TEMPLATE(
+    'msg__type_support.c.em',
+    package_name=package_name, interface_path=interface_path, message=action.goal,
+    include_directives=include_directives)
+}@
+
+@{
+TEMPLATE(
+    'msg__type_support.c.em',
+    package_name=package_name, interface_path=interface_path, message=action.result,
+    include_directives=include_directives)
+}@
+
+@{
+TEMPLATE(
+    'msg__type_support.c.em',
+    package_name=package_name, interface_path=interface_path, message=action.feedback,
+    include_directives=include_directives)
+}@
+
+@{
+TEMPLATE(
+    'srv__type_support.c.em',
+    package_name=package_name, interface_path=interface_path, service=action.send_goal_service,
+    include_directives=include_directives)
+}@
+
+@{
+TEMPLATE(
+    'srv__type_support.c.em',
+    package_name=package_name, interface_path=interface_path, service=action.get_result_service,
+    include_directives=include_directives)
+}@
+
+@{
+TEMPLATE(
+    'msg__type_support.c.em',
+    package_name=package_name, interface_path=interface_path, message=action.feedback_message,
+    include_directives=include_directives)
+}@
+@[end for]@

--- a/firmware/lib/rosidl_typesupport_introspection_c/resource/msg__rosidl_typesupport_introspection_c.h.em
+++ b/firmware/lib/rosidl_typesupport_introspection_c/resource/msg__rosidl_typesupport_introspection_c.h.em
@@ -1,0 +1,21 @@
+@# Included from rosidl_typesupport_introspection_c/resource/idl__rosidl_typesupport_introspection_c.h.em
+@{
+header_files = [
+    'rosidl_runtime_c/message_type_support_struct.h',
+    'rosidl_typesupport_interface/macros.h',
+    package_name + '/msg/rosidl_typesupport_introspection_c__visibility_control.h',
+]
+}@
+@[for header_file in header_files]@
+@[    if header_file in include_directives]@
+// already included above
+// @
+@[    else]@
+@{include_directives.add(header_file)}@
+@[    end if]@
+#include "@(header_file)"
+@[end for]@
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_@(package_name)
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(message.structure.namespaced_type.name))();

--- a/firmware/lib/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/firmware/lib/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -1,0 +1,283 @@
+@# Included from rosidl_typesupport_introspection_c/resource/idl__type_support.c.em
+@{
+from rosidl_cmake import convert_camel_case_to_lower_case_underscore
+from rosidl_generator_c import idl_structure_type_to_c_include_prefix
+from rosidl_parser.definition import AbstractGenericString
+from rosidl_parser.definition import AbstractNestedType
+from rosidl_parser.definition import AbstractSequence
+from rosidl_parser.definition import AbstractString
+from rosidl_parser.definition import AbstractWString
+from rosidl_parser.definition import Array
+from rosidl_parser.definition import BasicType
+from rosidl_parser.definition import BoundedSequence
+from rosidl_parser.definition import NamespacedType
+
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_base = '/'.join(include_parts)
+
+header_files = [
+    'stddef.h',  # providing offsetof()
+    include_base + '__rosidl_typesupport_introspection_c.h',
+    package_name + '/msg/rosidl_typesupport_introspection_c__visibility_control.h',
+    'rosidl_typesupport_introspection_c/field_types.h',
+    'rosidl_typesupport_introspection_c/identifier.h',
+    'rosidl_typesupport_introspection_c/message_introspection.h',
+    include_base + '__functions.h',
+    include_base + '__struct.h',
+]
+
+function_prefix = message.structure.namespaced_type.name + '__rosidl_typesupport_introspection_c'
+}@
+@[for header_file in header_files]@
+@[    if header_file in include_directives]@
+// already included above
+// @
+@[    else]@
+@{include_directives.add(header_file)}@
+@[    end if]@
+@[    if '/' not in header_file]@
+#include <@(header_file)>
+@[    else]@
+#include "@(header_file)"
+@[    end if]@
+@[end for]@
+
+@#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+@# Collect necessary include directives for all members
+@{
+from collections import OrderedDict
+includes = OrderedDict()
+for member in message.structure.members:
+    if isinstance(member.type, AbstractSequence) and isinstance(member.type.value_type, BasicType):
+        member_names = includes.setdefault(
+            'rosidl_runtime_c/primitives_sequence_functions.h', [])
+        member_names.append(member.name)
+        continue
+    type_ = member.type
+    if isinstance(type_, AbstractNestedType):
+        type_ = type_.value_type
+    if isinstance(type_, AbstractString):
+        member_names = includes.setdefault('rosidl_runtime_c/string_functions.h', [])
+        member_names.append(member.name)
+    elif isinstance(type_, AbstractWString):
+        member_names = includes.setdefault(
+            'rosidl_runtime_c/u16string_functions.h', [])
+        member_names.append(member.name)
+    elif isinstance(type_, NamespacedType):
+        include_prefix = idl_structure_type_to_c_include_prefix(type_)
+        member_names = includes.setdefault(
+            include_prefix + '.h', [])
+        member_names.append(member.name)
+        include_prefix_detail = idl_structure_type_to_c_include_prefix(type_, 'detail')
+        member_names = includes.setdefault(
+            include_prefix_detail + '__rosidl_typesupport_introspection_c.h', [])
+        member_names.append(member.name)
+}@
+@#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+@
+@#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+@[if includes]@
+
+// Include directives for member types
+@[    for header_file, member_names in includes.items()]@
+@[        for member_name in member_names]@
+// Member `@(member_name)`
+@[        end for]@
+@[        if header_file in include_directives]@
+// already included above
+// @
+@[        else]@
+@{include_directives.add(header_file)}@
+@[        end if]@
+#include "@(header_file)"
+@[    end for]@
+@[end if]@
+@#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+@
+@#######################################################################
+@# define callback functions
+@#######################################################################
+void @(function_prefix)__@(message.structure.namespaced_type.name)_init_function(
+  void * message_memory, enum rosidl_runtime_c__message_initialization _init)
+{
+  // TODO(karsten1987): initializers are not yet implemented for typesupport c
+  // see https://github.com/ros2/ros2/issues/397
+  (void) _init;
+  @('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))__init(message_memory);
+}
+
+void @(function_prefix)__@(message.structure.namespaced_type.name)_fini_function(void * message_memory)
+{
+  @('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))__fini(message_memory);
+}
+
+@[for member in message.structure.members]@
+@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, NamespacedType)]@
+size_t @(function_prefix)__size_function__@(member.type.value_type.name)__@(member.name)(
+  const void * untyped_member)
+{
+@[    if isinstance(member.type, Array)]@
+  (void)untyped_member;
+  return @(member.type.size);
+@[    else]@
+  const @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
+    (const @('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
+  return member->size;
+@[    end if]@
+}
+
+const void * @(function_prefix)__get_const_function__@(member.type.value_type.name)__@(member.name)(
+  const void * untyped_member, size_t index)
+{
+@[    if isinstance(member.type, Array)]@
+  const @('__'.join(member.type.value_type.namespaced_name())) ** member =
+    (const @('__'.join(member.type.value_type.namespaced_name())) **)(untyped_member);
+  return &(*member)[index];
+@[    else]@
+  const @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
+    (const @('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
+  return &member->data[index];
+@[    end if]@
+}
+
+void * @(function_prefix)__get_function__@(member.type.value_type.name)__@(member.name)(
+  void * untyped_member, size_t index)
+{
+@[    if isinstance(member.type, Array)]@
+  @('__'.join(member.type.value_type.namespaced_name())) ** member =
+    (@('__'.join(member.type.value_type.namespaced_name())) **)(untyped_member);
+  return &(*member)[index];
+@[    else]@
+  @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
+    (@('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
+  return &member->data[index];
+@[    end if]@
+}
+
+@[    if isinstance(member.type, AbstractSequence)]@
+bool @(function_prefix)__resize_function__@(member.type.value_type.name)__@(member.name)(
+  void * untyped_member, size_t size)
+{
+  @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
+    (@('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
+  @('__'.join(member.type.value_type.namespaced_name()))__Sequence__fini(member);
+  return @('__'.join(member.type.value_type.namespaced_name()))__Sequence__init(member, size);
+}
+
+@[    end if]@
+@[  end if]@
+@[end for]@
+static rosidl_typesupport_introspection_c__MessageMember @(function_prefix)__@(message.structure.namespaced_type.name)_message_member_array[@(len(message.structure.members))] = {
+@{
+for index, member in enumerate(message.structure.members):
+    type_ = member.type
+    if isinstance(type_, AbstractNestedType):
+        type_ = type_.value_type
+
+    print('  {')
+
+    # const char * name_
+    print('    "%s",  // name' % member.name)
+    if isinstance(type_, BasicType):
+        # uint8_t type_id_
+        print('    rosidl_typesupport_introspection_c__ROS_TYPE_%s,  // type' % type_.typename.replace(' ', '_').upper())
+        # size_t string_upper_bound
+        print('    0,  // upper bound of string')
+        # const rosidl_generator_c::MessageTypeSupportHandle * members_
+        print('    NULL,  // members of sub message')
+    elif isinstance(type_, AbstractGenericString):
+        # uint8_t type_id_
+        if isinstance(type_, AbstractString):
+            print('    rosidl_typesupport_introspection_c__ROS_TYPE_STRING,  // type')
+        elif isinstance(type_, AbstractWString):
+            print('    rosidl_typesupport_introspection_c__ROS_TYPE_WSTRING,  // type')
+        else:
+            assert False, 'Unknown type: ' + str(type_)
+        # size_t string_upper_bound
+        print('    %u,  // upper bound of string' % (type_.maximum_size if type_.has_maximum_size() else 0))
+        # const rosidl_generator_c::MessageTypeSupportHandle * members_
+        print('    NULL,  // members of sub message')
+    else:
+        # uint8_t type_id_
+        print('    rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE,  // type')
+        # size_t string_upper_bound
+        print('    0,  // upper bound of string')
+        # const rosidl_message_type_support_t * members_
+        print('    NULL,  // members of sub message (initialized later)')
+    # bool is_array_
+    print('    %s,  // is array' % ('true' if isinstance(member.type, AbstractNestedType) else 'false'))
+    # size_t array_size_
+    print('    %u,  // array size' % (member.type.size if isinstance(member.type, Array) else (member.type.maximum_size if isinstance(member.type, BoundedSequence) else 0)))
+    # bool is_upper_bound_
+    print('    %s,  // is upper bound' % ('true' if isinstance(member.type, BoundedSequence) else 'false'))
+    # unsigned long offset_
+    print('    offsetof(%s__%s, %s),  // bytes offset in struct' % ('__'.join([package_name] + list(interface_path.parents[0].parts)), message.structure.namespaced_type.name, member.name))
+    # void * default_value_
+    print('    NULL,  // default value')  # TODO default value to be set
+
+    function_suffix = ('%s__%s' % (member.type.value_type.name, member.name)) if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, NamespacedType) else None
+
+    # size_t(const void *) size_function
+    print('    %s,  // size() function pointer' % ('%s__size_function__%s' % (function_prefix, function_suffix) if function_suffix else 'NULL'))
+    # const void *(const void *, size_t) get_const_function
+    print('    %s,  // get_const(index) function pointer' % ('%s__get_const_function__%s' % (function_prefix, function_suffix) if function_suffix else 'NULL'))
+    # void *(void *, size_t) get_function
+    print('    %s,  // get(index) function pointer' % ('%s__get_function__%s' % (function_prefix, function_suffix) if function_suffix else 'NULL'))
+    # void(void *, size_t) resize_function
+    print('    %s  // resize(index) function pointer' % ('%s__resize_function__%s' % (function_prefix, function_suffix) if function_suffix and isinstance(member.type, AbstractSequence) else 'NULL'))
+
+    if index < len(message.structure.members) - 1:
+        print('  },')
+    else:
+        print('  }')
+}@
+};
+
+static const rosidl_typesupport_introspection_c__MessageMembers @(function_prefix)__@(message.structure.namespaced_type.name)_message_members = {
+  "@('__'.join([package_name] + list(interface_path.parents[0].parts)))",  // message namespace
+  "@(message.structure.namespaced_type.name)",  // message name
+  @(len(message.structure.members)),  // number of fields
+  sizeof(@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))),
+  @(function_prefix)__@(message.structure.namespaced_type.name)_message_member_array,  // message members
+  @(function_prefix)__@(message.structure.namespaced_type.name)_init_function,  // function to initialize message memory (memory has to be allocated)
+  @(function_prefix)__@(message.structure.namespaced_type.name)_fini_function  // function to terminate message instance (will not free memory)
+};
+
+// this is not const since it must be initialized on first access
+// since C does not allow non-integral compile-time constants
+static rosidl_message_type_support_t @(function_prefix)__@(message.structure.namespaced_type.name)_message_type_support_handle = {
+  0,
+  &@(function_prefix)__@(message.structure.namespaced_type.name)_message_members,
+  get_message_typesupport_handle_function,
+};
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_@(package_name)
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(', '.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name])))() {
+@[for i, member in enumerate(message.structure.members)]@
+@{
+type_ = member.type
+if isinstance(type_, AbstractNestedType):
+    type_ = type_.value_type
+}@
+@[    if isinstance(type_, NamespacedType)]@
+  @(function_prefix)__@(message.structure.namespaced_type.name)_message_member_array[@(i)].members_ =
+    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(', '.join(type_.namespaced_name())))();
+@[    end if]@
+@[end for]@
+  if (!@(function_prefix)__@(message.structure.namespaced_type.name)_message_type_support_handle.typesupport_identifier) {
+    @(function_prefix)__@(message.structure.namespaced_type.name)_message_type_support_handle.typesupport_identifier =
+      rosidl_typesupport_introspection_c__identifier;
+  }
+  return &@(function_prefix)__@(message.structure.namespaced_type.name)_message_type_support_handle;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/firmware/lib/rosidl_typesupport_introspection_c/resource/rosidl_typesupport_introspection_c__visibility_control.h.in
+++ b/firmware/lib/rosidl_typesupport_introspection_c/resource/rosidl_typesupport_introspection_c__visibility_control.h.in
@@ -1,0 +1,43 @@
+// generated from
+// rosidl_typesupport_introspection_c/resource/rosidl_typesupport_introspection_c__visibility_control.h.in
+// generated code does not contain a copyright notice
+
+#ifndef @PROJECT_NAME_UPPER@__MSG__ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_
+#define @PROJECT_NAME_UPPER@__MSG__ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_@PROJECT_NAME@ __attribute__ ((dllexport))
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_IMPORT_@PROJECT_NAME@ __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_@PROJECT_NAME@ __declspec(dllexport)
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_IMPORT_@PROJECT_NAME@ __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_TYPESUPPORT_INTROSPECTION_C_BUILDING_DLL_@PROJECT_NAME@
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_@PROJECT_NAME@ ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_@PROJECT_NAME@
+  #else
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_@PROJECT_NAME@ ROSIDL_TYPESUPPORT_INTROSPECTION_C_IMPORT_@PROJECT_NAME@
+  #endif
+#else
+  #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_@PROJECT_NAME@ __attribute__ ((visibility("default")))
+  #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_IMPORT_@PROJECT_NAME@
+  #if __GNUC__ >= 4
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_@PROJECT_NAME@ __attribute__ ((visibility("default")))
+  #else
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_@PROJECT_NAME@
+  #endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // @PROJECT_NAME_UPPER@__MSG__ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_

--- a/firmware/lib/rosidl_typesupport_introspection_c/resource/srv__rosidl_typesupport_introspection_c.h.em
+++ b/firmware/lib/rosidl_typesupport_introspection_c/resource/srv__rosidl_typesupport_introspection_c.h.em
@@ -1,0 +1,35 @@
+@# Included from rosidl_typesupport_introspection_c/resource/idl__rosidl_typesupport_introspection_c.h.em
+@{
+TEMPLATE(
+    'msg__rosidl_typesupport_introspection_c.h.em',
+    package_name=package_name, interface_path=interface_path, message=service.request_message,
+    include_directives=include_directives)
+}@
+
+@{
+TEMPLATE(
+    'msg__rosidl_typesupport_introspection_c.h.em',
+    package_name=package_name, interface_path=interface_path, message=service.response_message,
+    include_directives=include_directives)
+}@
+
+@{
+header_files = [
+    'rosidl_runtime_c/service_type_support_struct.h',
+    'rosidl_typesupport_interface/macros.h',
+    package_name + '/msg/rosidl_typesupport_introspection_c__visibility_control.h',
+]
+}@
+@[for header_file in header_files]@
+@[    if header_file in include_directives]@
+// already included above
+// @
+@[    else]@
+@{include_directives.add(header_file)}@
+@[    end if]@
+#include "@(header_file)"
+@[end for]@
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_@(package_name)
+const rosidl_service_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name))();

--- a/firmware/lib/rosidl_typesupport_introspection_c/resource/srv__type_support.c.em
+++ b/firmware/lib/rosidl_typesupport_introspection_c/resource/srv__type_support.c.em
@@ -1,0 +1,88 @@
+@# Included from rosidl_typesupport_introspection_c/resource/idl__type_support.c.em
+@{
+TEMPLATE(
+    'msg__type_support.c.em',
+    package_name=package_name, interface_path=interface_path, message=service.request_message,
+    include_directives=include_directives)
+}@
+
+@{
+TEMPLATE(
+    'msg__type_support.c.em',
+    package_name=package_name, interface_path=interface_path, message=service.response_message,
+    include_directives=include_directives)
+}@
+
+@{
+from rosidl_cmake import convert_camel_case_to_lower_case_underscore
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_base = '/'.join(include_parts)
+
+header_files = [
+    'rosidl_runtime_c/service_type_support_struct.h',
+    package_name + '/msg/rosidl_typesupport_introspection_c__visibility_control.h',
+    include_base + '__rosidl_typesupport_introspection_c.h',
+    'rosidl_typesupport_introspection_c/identifier.h',
+    'rosidl_typesupport_introspection_c/service_introspection.h',
+]
+
+function_prefix = '__'.join(include_parts) + '__rosidl_typesupport_introspection_c'
+}@
+@[for header_file in header_files]@
+@[    if header_file in include_directives]@
+// already included above
+// @
+@[    else]@
+@{include_directives.add(header_file)}@
+@[    end if]@
+#include "@(header_file)"
+@[end for]@
+
+// this is intentionally not const to allow initialization later to prevent an initialization race
+static rosidl_typesupport_introspection_c__ServiceMembers @(function_prefix)__@(service.namespaced_type.name)_service_members = {
+  "@('__'.join([package_name] + list(interface_path.parents[0].parts)))",  // service namespace
+  "@(service.namespaced_type.name)",  // service name
+  // these two fields are initialized below on the first access
+  NULL,  // request message
+  // @(function_prefix)__@(service.request_message.structure.namespaced_type.name)_message_type_support_handle,
+  NULL  // response message
+  // @(function_prefix)__@(service.response_message.structure.namespaced_type.name)_message_type_support_handle
+};
+
+static rosidl_service_type_support_t @(function_prefix)__@(service.namespaced_type.name)_service_type_support_handle = {
+  0,
+  &@(function_prefix)__@(service.namespaced_type.name)_service_members,
+  get_service_typesupport_handle_function,
+};
+
+// Forward declaration of request/response type support functions
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name)_Request)();
+
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name)_Response)();
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_@(package_name)
+const rosidl_service_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name))() {
+  if (!@(function_prefix)__@(service.namespaced_type.name)_service_type_support_handle.typesupport_identifier) {
+    @(function_prefix)__@(service.namespaced_type.name)_service_type_support_handle.typesupport_identifier =
+      rosidl_typesupport_introspection_c__identifier;
+  }
+  rosidl_typesupport_introspection_c__ServiceMembers * service_members =
+    (rosidl_typesupport_introspection_c__ServiceMembers *)@(function_prefix)__@(service.namespaced_type.name)_service_type_support_handle.data;
+
+  if (!service_members->request_members_) {
+    service_members->request_members_ =
+      (const rosidl_typesupport_introspection_c__MessageMembers *)
+      ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name)_Request)()->data;
+  }
+  if (!service_members->response_members_) {
+    service_members->response_members_ =
+      (const rosidl_typesupport_introspection_c__MessageMembers *)
+      ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name)_Response)()->data;
+  }
+
+  return &@(function_prefix)__@(service.namespaced_type.name)_service_type_support_handle;
+}

--- a/firmware/lib/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c-extras.cmake.in
+++ b/firmware/lib/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c-extras.cmake.in
@@ -1,0 +1,31 @@
+# generated from
+# rosidl_typesupport_introspection_c/
+#   rosidl_typesupport_introspection_c-extras.cmake.in
+
+# use the same type of library
+set(rosidl_typesupport_introspection_c_LIBRARY_TYPE
+  "@rosidl_typesupport_introspection_c_LIBRARY_TYPE@")
+
+# Make sure rosidl_generator_c extension point is registered first
+find_package(rosidl_generator_c QUIET)
+
+find_package(ament_cmake_core QUIET REQUIRED)
+ament_register_extension(
+  "rosidl_generate_idl_interfaces"
+  "rosidl_typesupport_introspection_c"
+  "rosidl_typesupport_introspection_c_generate_interfaces.cmake")
+
+set(rosidl_typesupport_introspection_c_BIN
+  "${rosidl_typesupport_introspection_c_DIR}/../../../lib/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c")
+normalize_path(rosidl_typesupport_introspection_c_BIN
+  "${rosidl_typesupport_introspection_c_BIN}")
+
+set(rosidl_typesupport_introspection_c_GENERATOR_FILES
+  "${rosidl_typesupport_introspection_c_DIR}/../../../@PYTHON_INSTALL_DIR@/rosidl_typesupport_introspection_c/__init__.py")
+normalize_path(rosidl_typesupport_introspection_c_GENERATOR_FILES
+  "${rosidl_typesupport_introspection_c_GENERATOR_FILES}")
+
+set(rosidl_typesupport_introspection_c_TEMPLATE_DIR
+  "${rosidl_typesupport_introspection_c_DIR}/../resource")
+normalize_path(rosidl_typesupport_introspection_c_TEMPLATE_DIR
+  "${rosidl_typesupport_introspection_c_TEMPLATE_DIR}")

--- a/firmware/lib/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/__init__.py
+++ b/firmware/lib/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2014-2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rosidl_cmake import generate_files
+
+
+def generate_c(generator_arguments_file):
+    mapping = {
+        'idl__rosidl_typesupport_introspection_c.h.em':
+        'detail/%s__rosidl_typesupport_introspection_c.h',
+        'idl__type_support.c.em': 'detail/%s__type_support.c',
+    }
+    generate_files(generator_arguments_file, mapping)

--- a/firmware/lib/rosidl_typesupport_introspection_c/src/identifier.c
+++ b/firmware/lib/rosidl_typesupport_introspection_c/src/identifier.c
@@ -1,0 +1,17 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosidl_typesupport_introspection_c/identifier.h"
+
+const char * rosidl_typesupport_introspection_c__identifier = "rosidl_typesupport_introspection_c";

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -7,90 +7,66 @@
 ;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
-
 [env]
 platform = teensy
 framework = arduino
 upload_port = /dev/ttyACM0
 upload_protocol = teensy-cli
-lib_deps = 
-    https://github.com/micro-ROS/micro_ros_arduino
+board_microros_transport = serial
+board_microros_distro = ${sysenv.ROS_DISTRO}
+lib_deps = https://github.com/micro-ROS/micro_ros_platformio
+build_flags = -I ../config
 
 [env:teensy41] 
 board = teensy41
-build_flags = 
-    -L $PROJECT_DIR/.pio/libdeps/$PIOENV/micro_ros_arduino/src/imxrt1062/fpv5-d16-hard/
-    -l libmicroros
-    -I ../config
 
 [env:teensy40] 
 board = teensy40
-lib_ignore = NativeEthernet
-build_flags = 
-    -L $PROJECT_DIR/.pio/libdeps/$PIOENV/micro_ros_arduino/src/imxrt1062/fpv5-d16-hard/
-    -l libmicroros
-    -I ../config
 
 [env:teensy36]
 board = teensy36
-lib_ignore = NativeEthernet
 build_flags = 
-    -L $PROJECT_DIR/.pio/libdeps/$PIOENV/micro_ros_arduino/src/imxrt1062/fpv5-d16-hard/
-    -l libmicroros
     -I ../config
+    -llibc -lc
 
 [env:teensy35]
 board = teensy35
-lib_ignore = NativeEthernet
 build_flags = 
-    -L $PROJECT_DIR/.pio/libdeps/$PIOENV/micro_ros_arduino/src/mk64fx512/fpv4-sp-d16-hard/
-    -l libmicroros
     -I ../config
+    -llibc -lc
 
 [env:teensy31] 
 board = teensy31
 board_build.f_cpu = 96000000L
-lib_ignore = NativeEthernet
 build_flags = 
-    -L $PROJECT_DIR/.pio/libdeps/$PIOENV/micro_ros_arduino/src/mk20dx256
-    -l libmicroros
     -I ../config
+    -llibc -lc
 
 [env:dev] 
 board = teensy40
-lib_ignore = NativeEthernet
 build_flags = 
-    -L $PROJECT_DIR/.pio/libdeps/$PIOENV/micro_ros_arduino/src/imxrt1062/fpv5-d16-hard/
-    -l libmicroros
     -I ../config
     -D USE_DEV_CONFIG
 
 [env:beebo] 
 board = teensy31
 board_build.f_cpu = 96000000L
-lib_ignore = NativeEthernet
 build_flags = 
-    -L $PROJECT_DIR/.pio/libdeps/$PIOENV/micro_ros_arduino/src/mk20dx256
-    -l libmicroros
     -I ../config
+    -llibc -lc
     -D USE_BEEBO_CONFIG
 
 [env:beebo_m] 
 board = teensy31
 board_build.f_cpu = 96000000L
-lib_ignore = NativeEthernet
 build_flags = 
-    -L $PROJECT_DIR/.pio/libdeps/$PIOENV/micro_ros_arduino/src/mk20dx256
-    -l libmicroros
     -I ../config
+    -llibc -lc
     -D USE_BEEBO_M_CONFIG
 
 [env:square] 
 board = teensy40
-lib_ignore = NativeEthernet
 upload_port = /dev/linobase
 build_flags = 
-    -L $PROJECT_DIR/.pio/libdeps/$PIOENV/micro_ros_arduino/src/imxrt1062/fpv5-d16-hard/
-    -l libmicroros
     -I ../config
     -D USE_SQUARE_CONFIG

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -15,6 +15,7 @@ upload_protocol = teensy-cli
 board_microros_transport = serial
 board_microros_distro = ${sysenv.ROS_DISTRO}
 lib_deps = https://github.com/micro-ROS/micro_ros_platformio#22cf9b631b0bbb8861c30469e33b24e9241819ef
+    https://github.com/micro-ROS/micro_ros_utilities#2.0.0
 build_flags = -I ../config
 
 [env:teensy41] 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -14,7 +14,7 @@ upload_port = /dev/ttyACM0
 upload_protocol = teensy-cli
 board_microros_transport = serial
 board_microros_distro = ${sysenv.ROS_DISTRO}
-lib_deps = https://github.com/micro-ROS/micro_ros_platformio
+lib_deps = https://github.com/micro-ROS/micro_ros_platformio#22cf9b631b0bbb8861c30469e33b24e9241819ef
 build_flags = -I ../config
 
 [env:teensy41] 

--- a/firmware/src/firmware.ino
+++ b/firmware/src/firmware.ino
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <Arduino.h>
-#include <micro_ros_arduino.h>
+#include <micro_ros_platformio.h>
 #include <stdio.h>
 
 #include <rcl/rcl.h>
@@ -110,7 +110,8 @@ void setup()
         }
     }
     
-    set_microros_transports();
+    Serial.begin(115200);
+    set_microros_serial_transports(Serial);
 }
 
 void loop() {


### PR DESCRIPTION
This fixes the issues with building ROS Foxy firmware, encountered in issue #35 and adds CI to the branch to prove it

* Revert "revert back to micro_ros_arduino for foxy branch"
* Add CI
* Specify micro_ros_platformio as version with foxy support
* add micro_ros_utilities as lib_dep
* manually add typesupport library