### PR TITLE
pico: fix clock_gettime compilation error

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -134,7 +134,7 @@ build_flags =
     -D USE_ESP32S3_CONFIG
 
 [env:pico]
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#196d31bbafaf60b84751b1a415d8dca2365debdf
 board = rpipico
 monitor_speed = 115200
 monitor_port = /dev/ttyACM0


### PR DESCRIPTION
The latest pico toolchains (gcc14.2) caused pico build error. Revert to earlier working version.