### PR TITLE
Microros baudrate issue103

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,54 @@ ROS 2 Distro | Branch | Build status
 **Galactic** | [`galactic`](../../tree/galactic) | [![Galactic Firmware Build](../../actions/workflows/galactic-firmware-build.yml/badge.svg?branch=galactic)](../../actions/workflows/galactic-firmware-build.yml?branch=galactic)
 **Foxy** | [`foxy`](../../tree/foxy) | [![Foxy Firmware Build](../../actions/workflows/foxy-firmware-build.yml/badge.svg?branch=foxy)](../../actions/workflows/foxy-firmware-build.yml?branch=foxy)
 
+# linorobot2_hardware for ESP32 and Pico
+
+## Overview
+The linorobot2_hardware repo uses platformio to build microcontroller firmware for mobile robots based on micro-ROS.
+It is extremely parameterized and easily customizable for varied hardware configurations.
+
+This version of linorobot2_hardware supports various flavors of the
+Expressif ESP32 and Raspberry Pi pico microcontrollers as well as other robot sensors.
+It should also support the legacy Teensy family of microcontrollers - support has not been removed - but Teensy is untested on this version.
+
+This firmware performs the low-level realtime interation with robot hardware.
+It accepts commands from, and delivers robot data to ROS2 software launched
+from the [linorobot2](https://github.com/linorobot/linorobot2) repo packages.
+See that repo for system architecture diagrams, and installation and operation instructions
+for running the ROS2 nodes. This firmware has been tested with the jazzy branch of linorobot2.
+
+#### Firmwware interaction with linorobot2 ROS nodes
+The micro-ROS robot controller firmware subscribes to /cmd_vel, converts the Twist message and commands motor drivers
+to move the wheels under PID control.
+It publishes wheel odometry to /odom/unfiltered and IMU data to /imu/data.
+On the robot computer, an EKF filter fuses /odom/unfiltered and /imu/data to publish /odom.
+Robot state, joint state and transforms are published.
+
+### About this release
+The main benefit of this release of linorobot2_hardware is it enables running your linorobot2 software in both gazebo simulation and
+on real robot hardware using the Jazzy release of ROS2. This is excellent for those familiar with linorobot2 who want to run
+on ROS2 Jazzy.
+
+#### Limitations and caveats
+This version of linorobot2_hardware is not the best place to start if you are beginning your hardware journey. As of this writing
+(July 2025):
+- This README.md is mainly focused on the legacy Teensy microcontroller and how to use it, and less focused on the
+more modern ESP32 and Pico.
+- This release of linorobot2 and linorobot2_hardware requires a serial port between the microcontroller and an on-robot computer.
+Micro-ROS over wifi is not documented or tested, and won't work "out of the box". This means you must have a robot computer
+(e.g. Raspberry Pi) on your robot in order for it to talk to the ROS nodes and navigate.
+- Only esp32 esp32-s2 and esp32-s3 are supported. Some [variants](https://docs.espressif.com/projects/esp-idf/en/v5.0/esp32s3/hw-reference/chip-series-comparison.html), such as esp32-c3, are not supported.
+
+
+If you are new to linorobot2 and want to run an ESP32 or Pico microcontroller, or if you want your microcontroller to talk to
+ROS over wifi, there is a lot of detailed information in
+the [hippo5329 wiki](https://github.com/hippo5329/linorobot2_hardware/wiki).
+
+Micro-ROS over wifi is supported by the downstream hippo5329
+[linorobot2](https://github.com/hippo5329/linorobot2)
+and [linorobot2_hardware](https://github.com/hippo5329/linorobot2_hardware)
+repos.
+
 ## Installation
 All software mentioned in this guide must be installed on the robot computer.
 
@@ -16,7 +64,7 @@ It is assumed that you already have ROS2 and linorobot2 package installed. If yo
 ### 2. Download linorobot2_hardware
 
     cd $HOME
-    git clone https://github.com/linorobot/linorobot2_hardware -b $ROS_DISTRO
+    git clone https://github.com/linorobot/linorobot2_hardware
 
 ### 3. Install PlatformIO
 Download and install platformio. [Platformio](https://platformio.org/) allows you to develop, configure, and upload the firmware without the Arduino IDE. This means that you can upload the firmware remotely which is ideal on headless setup especially when all components have already been fixed. 
@@ -29,7 +77,7 @@ Add platformio to your $PATH:
     echo "PATH=\"\$PATH:\$HOME/.platformio/penv/bin\"" >> $HOME/.bashrc
     source $HOME/.bashrc
 
-### 4. UDEV Rule
+### 4. Teensy UDEV Rule
 Download the udev rules from Teensy's website:
 
     wget https://www.pjrc.com/teensy/00-teensy.rules
@@ -93,7 +141,7 @@ Supported MAGs:
 - **AK09918**
 - **QMC5883L**
 
-### 4. Connection Diagram
+### 4. Teensy Connection Diagram
 Below are connection diagrams you can follow for each supported motor driver and IMU. For simplicity, only one motor connection is provided but the same diagram can be used to connect the rest of the motors. You are free to decide which microcontroller pin to use just ensure that the following are met:
 
 - Reserve SCL0 and SDA0 (pins 18 and 19 on Teensy boards) for IMU.

--- a/README.md
+++ b/README.md
@@ -13,15 +13,14 @@ ROS 2 Distro | Branch | Build status
 The linorobot2_hardware repo uses platformio to build microcontroller firmware for mobile robots based on micro-ROS.
 It is extremely parameterized and easily customizable for varied hardware configurations.
 
-This version of linorobot2_hardware supports various flavors of the
-Expressif ESP32 and Raspberry Pi pico microcontrollers as well as other robot sensors.
-It should also support the legacy Teensy family of microcontrollers - support has not been removed - but Teensy is untested on this version.
-
 This firmware performs the low-level realtime interation with robot hardware.
 It accepts commands from, and delivers robot data to ROS2 software launched
 from the [linorobot2](https://github.com/linorobot/linorobot2) repo packages.
 See that repo for system architecture diagrams, and installation and operation instructions
 for running the ROS2 nodes. This firmware has been tested with the jazzy branch of linorobot2.
+
+This version of linorobot2_hardware supports various flavors of the
+Expressif ESP32 and Raspberry Pi pico microcontrollers as well as other robot sensors.
 
 #### Firmwware interaction with linorobot2 ROS nodes
 The micro-ROS robot controller firmware subscribes to /cmd_vel, converts the Twist message and commands motor drivers
@@ -35,10 +34,13 @@ The main benefit of this release of linorobot2_hardware is it enables running yo
 on real robot hardware using the Jazzy release of ROS2. This is excellent for those familiar with linorobot2 who want to run
 on ROS2 Jazzy.
 
+#### Teensy microcontroller family deprecated
+The last versions of the Teensy microcontroller family (4.0 and 4.1) were introduced in 2019 and 2020. The owner, PJRC, has transferred the design to Sparkfun and there will be no more Teensy models. This version of linorobot2_hardware should support the Teensy family of microcontrollers as it used to - support has not been removed - but Teensy is untested on this version and the Teensy family should be considered deprecated. Problems may not be fixed. This version of firmware changes the default baud rate for the micro-ROS serial connection to 921600 baud. Specs indicate the Teensy 3.2 and later should support that baud rate but this version of linorobot2_hardware has not been tested with any of the Teensy miicrocontrollers.
+
 #### Limitations and caveats
 This version of linorobot2_hardware is not the best place to start if you are beginning your hardware journey. As of this writing
 (July 2025):
-- This README.md is mainly focused on the legacy Teensy microcontroller and how to use it, and less focused on the
+- This README.md is mainly focused on the now-deprecated Teensy microcontroller and how to use it, and less focused on the
 more modern ESP32 and Pico.
 - This release of linorobot2 and linorobot2_hardware requires a serial port between the microcontroller and an on-robot computer.
 Micro-ROS over wifi is not documented or tested, and won't work "out of the box". This means you must have a robot computer

--- a/config/custom/pico_config.h
+++ b/config/custom/pico_config.h
@@ -206,7 +206,7 @@ ROBOT ORIENTATION
 #define LIDAR_BAUDRATE 230400
 #define LIDAR_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define LIDAR_PORT 8889
-#define BAUDRATE 115200
+#define BAUDRATE 921600
 #define SDA_PIN 4 // specify I2C pins
 #define SCL_PIN 5
 #define NODE_NAME "pico"

--- a/firmware/src/firmware.ino
+++ b/firmware/src/firmware.ino
@@ -105,7 +105,7 @@ IMU imu;
 MAG mag;
 
 #ifndef BAUDRATE
-#define BAUDRATE 115200
+#define BAUDRATE 921600
 #endif
 
 void setup() 


### PR DESCRIPTION
This PR closes Issue #103 where the pico runs 115200 baud rate, and the default is 115200 if not specified. This would cause a mismatch after linorobot2 PR #174 is merged. The baud rate for all microcontrollers is set to 921600. 

The README.md is updated to give an overview of this repo and to advise when using this repo is appropriate, and to note its coupling to the Jazzy branch of linorobot2, and to point to the hippo5329 repo for new users. This advice should be good until most of the goodness in the hippo5392 repos are migrated to this upstream repo.

This PR is tied to https://github.com/linorobot/linorobot2/pull/176

Please merge this and the associated linorobot2 PR at the same time, to avoid inconsistent repos.