### PR TITLE
Add support for ESP32 Wifi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .pio
 .swp
+.vscode

--- a/config/config.h
+++ b/config/config.h
@@ -22,6 +22,14 @@
     #include "custom/dev_config.h"
 #endif
 
+#ifdef USE_GENDRV_CONFIG
+    #include "custom/gendrv_config.h"
+#endif
+
+#ifdef USE_GENDRV_WIFI_CONFIG
+    #include "custom/gendrv_wifi_config.h"
+#endif
+
 #ifdef USE_ESP32_CONFIG
     #include "custom/esp32_config.h"
 #endif
@@ -41,6 +49,13 @@
 #ifdef USE_PICO_CONFIG
     #include "custom/pico_config.h"
 #endif
+
+// add maintainer configurations above this line
+// this barrier helps to reduce user merge conflict
+// add user configurations below this line
+
+
+// add user configurations above this line
 
 // this should be the last one
 #ifndef LINO_BASE

--- a/config/custom/esp32_wifi_config.h
+++ b/config/custom/esp32_wifi_config.h
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LINO_BASE_CONFIG_H
-#define LINO_BASE_CONFIG_H
+#ifndef ESP32_WIFI_CONFIG_H
+#define ESP32_WIFI_CONFIG_H
 
-#define LED_PIN 13 //used for debugging status
+#define LED_PIN LED_BUILTIN //used for debugging status
 
 //uncomment the base you're building
 #define LINO_BASE DIFFERENTIAL_DRIVE       // 2WD and Tracked robot w/ 2 motors
@@ -23,9 +23,9 @@
 // #define LINO_BASE MECANUM               // Mecanum drive robot
 
 //uncomment the motor driver you're using
-#define USE_GENERIC_2_IN_MOTOR_DRIVER      // Motor drivers with 2 Direction Pins(INA, INB) and 1 PWM(ENABLE) pin ie. L298, L293, VNH5019
+// #define USE_GENERIC_2_IN_MOTOR_DRIVER      // Motor drivers with 2 Direction Pins(INA, INB) and 1 PWM(ENABLE) pin ie. L298, L293, VNH5019
 // #define USE_GENERIC_1_IN_MOTOR_DRIVER   // Motor drivers with 1 Direction Pin(INA) and 1 PWM(ENABLE) pin.
-// #define USE_BTS7960_MOTOR_DRIVER        // BTS7970 Motor Driver
+#define USE_BTS7960_MOTOR_DRIVER        // BTS7970 Motor Driver using A4950 (<40V) module or DRV8833 (<10V)
 // #define USE_ESC_MOTOR_DRIVER            // Motor ESC for brushless motors
 
 //uncomment the IMU you're using
@@ -40,39 +40,50 @@
 // #define USE_AK09918_MAG
 // #define USE_QMC5883L_MAG
 // #define MAG_BIAS { 0, 0, 0 }
+// #define IMU_TWEAK {}
+// #define MAG_TWEAK {}
 
 #define K_P 0.6                             // P constant
 #define K_I 0.8                             // I constant
 #define K_D 0.5                             // D constant
 
+#define ACCEL_COV { 0.01, 0.01, 0.01 }
+#define GYRO_COV { 0.001, 0.001, 0.001 }
+#define ORI_COV { 0.01, 0.01, 0.01 }
+#define MAG_COV { 1e-12, 1e-12, 1e-12 }
+#define POSE_COV { 0.001, 0.001, 0.001, 0.001, 0.001, 0.001 }
+#define TWIST_COV { 0.001, 0.001, 0.001, 0.003, 0.003, 0.003 }
+
 /*
 ROBOT ORIENTATION
          FRONT
     MOTOR1  MOTOR2  (2WD/ACKERMANN)
-    MOTOR3  MOTOR4  (4WD/MECANUM)  
+    MOTOR3  MOTOR4  (4WD/MECANUM)
          BACK
 */
 
 //define your robot' specs here
-#define MOTOR_MAX_RPM 140                   // motor's max RPM          
-#define MAX_RPM_RATIO 0.85                  // max RPM allowed for each MAX_RPM_ALLOWED = MOTOR_MAX_RPM * MAX_RPM_RATIO          
-#define MOTOR_OPERATING_VOLTAGE 24          // motor's operating voltage (used to calculate max RPM)
+#define MOTOR_MAX_RPM 150                   // motor's max RPM
+#define MAX_RPM_RATIO 0.85                  // max RPM allowed for each MAX_RPM_ALLOWED = MOTOR_MAX_RPM * MAX_RPM_RATIO
+#define MOTOR_OPERATING_VOLTAGE 12          // motor's operating voltage (used to calculate max RPM)
 #define MOTOR_POWER_MAX_VOLTAGE 12          // max voltage of the motor's power source (used to calculate max RPM)
 #define MOTOR_POWER_MEASURED_VOLTAGE 12     // current voltage reading of the power connected to the motor (used for calibration)
-#define COUNTS_PER_REV1 144000              // wheel1 encoder's no of ticks per rev
-#define COUNTS_PER_REV2 144000              // wheel2 encoder's no of ticks per rev
-#define COUNTS_PER_REV3 144000              // wheel3 encoder's no of ticks per rev
-#define COUNTS_PER_REV4 144000              // wheel4 encoder's no of ticks per rev
-#define WHEEL_DIAMETER 0.152                // wheel's diameter in meters
-#define LR_WHEELS_DISTANCE 0.271            // distance between left and right wheels
-#define PWM_BITS 10                          // PWM Resolution of the microcontroller
+#define COUNTS_PER_REV1 450                 // wheel1 encoder's no of ticks per rev
+#define COUNTS_PER_REV2 450                 // wheel2 encoder's no of ticks per rev
+#define COUNTS_PER_REV3 450                 // wheel3 encoder's no of ticks per rev
+#define COUNTS_PER_REV4 450                 // wheel4 encoder's no of ticks per rev
+#define WHEEL_DIAMETER 0.0560               // wheel's diameter in meters
+#define LR_WHEELS_DISTANCE 0.224            // distance between left and right wheels
+#define PWM_BITS 10                         // PWM Resolution of the microcontroller
 #define PWM_FREQUENCY 20000                 // PWM Frequency
+#define SERVO_BITS 12                       // Servo PWM resolution
+#define SERVO_FREQ 50                       // Servo PWM frequency
 
 // INVERT ENCODER COUNTS
-#define MOTOR1_ENCODER_INV false 
-#define MOTOR2_ENCODER_INV false 
-#define MOTOR3_ENCODER_INV false 
-#define MOTOR4_ENCODER_INV false 
+#define MOTOR1_ENCODER_INV false
+#define MOTOR2_ENCODER_INV false
+#define MOTOR3_ENCODER_INV false
+#define MOTOR4_ENCODER_INV false
 
 // INVERT MOTOR DIRECTIONS
 #define MOTOR1_INV false
@@ -81,96 +92,96 @@ ROBOT ORIENTATION
 #define MOTOR4_INV false
 
 // ENCODER PINS
-#define MOTOR1_ENCODER_A 14
-#define MOTOR1_ENCODER_B 15 
+#define MOTOR1_ENCODER_A 36
+#define MOTOR1_ENCODER_B 39
 
-#define MOTOR2_ENCODER_A 11
-#define MOTOR2_ENCODER_B 12 
+#define MOTOR2_ENCODER_A 35
+#define MOTOR2_ENCODER_B 34
 
-#define MOTOR3_ENCODER_A 17
-#define MOTOR3_ENCODER_B 16 
+#define MOTOR3_ENCODER_A 32
+#define MOTOR3_ENCODER_B 27
 
-#define MOTOR4_ENCODER_A 9
-#define MOTOR4_ENCODER_B 10
+#define MOTOR4_ENCODER_A 26
+#define MOTOR4_ENCODER_B 25
 
 // MOTOR PINS
 #ifdef USE_GENERIC_2_IN_MOTOR_DRIVER
-  #define MOTOR1_PWM 21 //Pin no 21 is not a PWM pin on Teensy 4.x, you can swap it with pin no 1 instead.
-  #define MOTOR1_IN_A 20
-  #define MOTOR1_IN_B 1 
+  #define MOTOR1_PWM 19
+  #define MOTOR1_IN_A 5
+  #define MOTOR1_IN_B 15
 
-  #define MOTOR2_PWM 5
-  #define MOTOR2_IN_A 6
-  #define MOTOR2_IN_B 8
+  #define MOTOR2_PWM 18
+  #define MOTOR2_IN_A 13
+  #define MOTOR2_IN_B 12
 
-  #define MOTOR3_PWM 22
-  #define MOTOR3_IN_A 23
-  #define MOTOR3_IN_B 0
+  #define MOTOR3_PWM 16
+  #define MOTOR3_IN_A 4
+  #define MOTOR3_IN_B 23
 
-  #define MOTOR4_PWM 4
-  #define MOTOR4_IN_A 3
-  #define MOTOR4_IN_B 2
+  #define MOTOR4_PWM 17
+  #define MOTOR4_IN_A 14 // CONFLICK with LIDAR_RXD 14, comment out LIDAR_RXD
+  #define MOTOR4_IN_B 2  // CONFLICK with LED_PIN 2, set LED_PIN to -1
 
   #define PWM_MAX pow(2, PWM_BITS) - 1
   #define PWM_MIN -PWM_MAX
-#endif 
+#endif
 
 #ifdef USE_GENERIC_1_IN_MOTOR_DRIVER
-  #define MOTOR1_PWM 21 //Pin no 21 is not a PWM pin on Teensy 4.x, you can use pin no 1 instead.
-  #define MOTOR1_IN_A 20
+  #define MOTOR1_PWM 19
+  #define MOTOR1_IN_A 5
   #define MOTOR1_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder
 
-  #define MOTOR2_PWM 5
-  #define MOTOR2_IN_A 6
+  #define MOTOR2_PWM 18
+  #define MOTOR2_IN_A 15
   #define MOTOR2_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder
 
-  #define MOTOR3_PWM 22
-  #define MOTOR3_IN_A 23
+  #define MOTOR3_PWM 16
+  #define MOTOR3_IN_A 13
   #define MOTOR3_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder
 
-  #define MOTOR4_PWM 4
-  #define MOTOR4_IN_A 3
+  #define MOTOR4_PWM 17
+  #define MOTOR4_IN_A 12
   #define MOTOR4_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder
 
   #define PWM_MAX pow(2, PWM_BITS) - 1
   #define PWM_MIN -PWM_MAX
-#endif 
+#endif
 
 #ifdef USE_BTS7960_MOTOR_DRIVER
   #define MOTOR1_PWM -1 //DON'T TOUCH THIS! This is just a placeholder
-  #define MOTOR1_IN_A 21 // Pin no 21 is not a PWM pin on Teensy 4.x, you can use pin no 1 instead.
-  #define MOTOR1_IN_B 20 // Pin no 20 is not a PWM pin on Teensy 4.x, you can use pin no 0 instead.
+  #define MOTOR1_IN_A 19
+  #define MOTOR1_IN_B 18
 
   #define MOTOR2_PWM -1 //DON'T TOUCH THIS! This is just a placeholder
-  #define MOTOR2_IN_A 5
-  #define MOTOR2_IN_B 6
+  #define MOTOR2_IN_A 16
+  #define MOTOR2_IN_B 17
 
   #define MOTOR3_PWM -1 //DON'T TOUCH THIS! This is just a placeholder
-  #define MOTOR3_IN_A 22
-  #define MOTOR3_IN_B 23
+  #define MOTOR3_IN_A 13
+  #define MOTOR3_IN_B 12
 
   #define MOTOR4_PWM -1 //DON'T TOUCH THIS! This is just a placeholder
   #define MOTOR4_IN_A 4
-  #define MOTOR4_IN_B 3
+  #define MOTOR4_IN_B 23
 
   #define PWM_MAX pow(2, PWM_BITS) - 1
   #define PWM_MIN -PWM_MAX
 #endif
 
 #ifdef USE_ESC_MOTOR_DRIVER
-  #define MOTOR1_PWM 21 //Pin no 21 is not a PWM pin on Teensy 4.x. You can use pin no 1 instead.
+  #define MOTOR1_PWM 19
   #define MOTOR1_IN_A -1 //DON'T TOUCH THIS! This is just a placeholder
   #define MOTOR1_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder
 
-  #define MOTOR2_PWM 5
+  #define MOTOR2_PWM 18
   #define MOTOR2_IN_A -1 //DON'T TOUCH THIS! This is just a placeholder
   #define MOTOR2_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder
 
-  #define MOTOR3_PWM 22 
+  #define MOTOR3_PWM 16
   #define MOTOR3_IN_A -1 //DON'T TOUCH THIS! This is just a placeholder
   #define MOTOR3_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder
 
-  #define MOTOR4_PWM 4
+  #define MOTOR4_PWM 17
   #define MOTOR4_IN_A -1 //DON'T TOUCH THIS! This is just a placeholder
   #define MOTOR4_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder
 
@@ -178,36 +189,41 @@ ROBOT ORIENTATION
   #define PWM_MIN -PWM_MAX
 #endif
 
-// #define USE_WIFI_TRANSPORT  // use micro ros wifi transport
 #define AGENT_IP { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define AGENT_PORT 8888
 // Enable WiFi with null terminated list of multiple APs SSID and password
-// #define WIFI_AP_LIST {{"WIFI_SSID", "WIFI_PASSWORD"}, {NULL}}
-// #define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
-// #define USE_ARDUINO_OTA
-// #define USE_SYSLOG
+#define WIFI_AP_LIST {{"wifi_ssid", "wifi_passwd"}, {NULL}}
+#define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
+#define USE_ARDUINO_OTA
+#define USE_SYSLOG
 #define SYSLOG_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define SYSLOG_PORT 514
-#define DEVICE_HOSTNAME "linorobot2"
+#define DEVICE_HOSTNAME "esp32_wifi"
 #define APP_NAME "hardware"
-// #define USE_LIDAR_UDP  // send lidar data to udp server
-#define LIDAR_RXD 4
+#define USE_LIDAR_UDP
+#define LIDAR_RXD 14
 #define LIDAR_SERIAL 1 // uart number
 #define LIDAR_BAUDRATE 230400
 #define LIDAR_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define LIDAR_PORT 8889
-// #define BAUDRATE 115200
-// #define SDA_PIN 18 // specify I2C pins
-// #define SCL_PIN 19
-#define NODE_NAME "linorobot_base_node"
-// #define TOPIC_PREFIX "myrobot/"
+#define BAUDRATE 921600
+#define SDA_PIN 21 // specify I2C pins
+#define SCL_PIN 22
+#define NODE_NAME "esp32_wifi"
+// #define TOPIC_PREFIX "esp32_wifi/"
 // #define CONTROL_TIMER 20
 // #define BATTERY_TIMER 2000
 
 // battery voltage ADC pin
-// #define BATTERY_PIN 33
+#define BATTERY_PIN 33
 // 3.3V ref, 12 bits ADC, 33k + 10k voltage divider
+// #define USE_ADC_LUT
+#ifdef USE_ADC_LUT
+const int16_t ADC_LUT[4096] = { /* insert adc_calibrate data here */ };
+#define BATTERY_ADJUST(v) (ADC_LUT[v] * (3.3 / 4096 * (33 + 10) / 10 * 1.0))
+#else
 #define BATTERY_ADJUST(v) ((v) * (3.3 / 4096 * (33 + 10) / 10))
+#endif
 // #define USE_INA219
 #define BATTERY_DIP 0.98  // battery voltage drop alert
 // #define BATTERY_CAP 2.0  // battery capacity Ah
@@ -215,9 +231,12 @@ ROBOT ORIENTATION
 // #define BATTERY_MAX 12.6 // battery maximum voltage
 // #define TRIG_PIN 31 // ultrasonic sensor HC-SR04
 // #define ECHO_PIN 32
-// #define USE_SHORT_BRAKE // for shorter stopping distance
-// #define WDT_TIMEOUT 30 // Sec
-#define BOARD_INIT { Wire.begin(); } // needed for i2cdetect
+#define USE_SHORT_BRAKE // for shorter stopping distance
+// #define WDT_TIMEOUT 60 // Sec
+#define BOARD_INIT { \
+    Wire.begin(SDA_PIN, SCL_PIN); \
+    Wire.setClock(400000); \
+}
 // #define BOARD_INIT_LATE {}
 // #define BOARD_LOOP {}
 // #define JOINT_STATE_SUBSCRIBER "joint_states"

--- a/config/custom/gendrv_config.h
+++ b/config/custom/gendrv_config.h
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LINO_BASE_CONFIG_H
-#define LINO_BASE_CONFIG_H
+#ifndef GENDRV_CONFIG_H
+#define GENDRV_CONFIG_H
 
-#define LED_PIN 13 //used for debugging status
+#define LED_PIN LED_BUILTIN //used for debugging status
 
 //uncomment the base you're building
 #define LINO_BASE DIFFERENTIAL_DRIVE       // 2WD and Tracked robot w/ 2 motors
@@ -23,9 +23,9 @@
 // #define LINO_BASE MECANUM               // Mecanum drive robot
 
 //uncomment the motor driver you're using
-#define USE_GENERIC_2_IN_MOTOR_DRIVER      // Motor drivers with 2 Direction Pins(INA, INB) and 1 PWM(ENABLE) pin ie. L298, L293, VNH5019
+// #define USE_GENERIC_2_IN_MOTOR_DRIVER      // Motor drivers with 2 Direction Pins(INA, INB) and 1 PWM(ENABLE) pin ie. L298, L293, VNH5019
 // #define USE_GENERIC_1_IN_MOTOR_DRIVER   // Motor drivers with 1 Direction Pin(INA) and 1 PWM(ENABLE) pin.
-// #define USE_BTS7960_MOTOR_DRIVER        // BTS7970 Motor Driver
+#define USE_BTS7960_MOTOR_DRIVER        // BTS7970 Motor Driver using A4950 (<40V) module or DRV8833 (<10V)
 // #define USE_ESC_MOTOR_DRIVER            // Motor ESC for brushless motors
 
 //uncomment the IMU you're using
@@ -33,13 +33,22 @@
 // #define USE_MPU6050_IMU
 // #define USE_MPU9150_IMU
 // #define USE_MPU9250_IMU
-// #define USE_QMI8658_IMU
+#define USE_QMI8658_IMU
 // #define USE_HMC5883L_MAG
 // #define USE_AK8963_MAG
 // #define USE_AK8975_MAG
 // #define USE_AK09918_MAG
 // #define USE_QMC5883L_MAG
 // #define MAG_BIAS { 0, 0, 0 }
+// #define IMU_TWEAK {}
+// #define MAG_TWEAK {}
+
+#define ACCEL_COV { 0.01, 0.01, 0.01 }
+#define GYRO_COV { 0.001, 0.001, 0.001 }
+#define ORI_COV { 0.01, 0.01, 0.01 }
+#define MAG_COV { 1e-12, 1e-12, 1e-12 }
+#define POSE_COV { 0.001, 0.001, 0.001, 0.001, 0.001, 0.001 }
+#define TWIST_COV { 0.001, 0.001, 0.001, 0.003, 0.003, 0.003 }
 
 #define K_P 0.6                             // P constant
 #define K_I 0.8                             // I constant
@@ -49,30 +58,30 @@
 ROBOT ORIENTATION
          FRONT
     MOTOR1  MOTOR2  (2WD/ACKERMANN)
-    MOTOR3  MOTOR4  (4WD/MECANUM)  
+    MOTOR3  MOTOR4  (4WD/MECANUM)
          BACK
 */
 
 //define your robot' specs here
-#define MOTOR_MAX_RPM 140                   // motor's max RPM          
-#define MAX_RPM_RATIO 0.85                  // max RPM allowed for each MAX_RPM_ALLOWED = MOTOR_MAX_RPM * MAX_RPM_RATIO          
-#define MOTOR_OPERATING_VOLTAGE 24          // motor's operating voltage (used to calculate max RPM)
+#define MOTOR_MAX_RPM 150                   // motor's max RPM
+#define MAX_RPM_RATIO 0.85                  // max RPM allowed for each MAX_RPM_ALLOWED = MOTOR_MAX_RPM * MAX_RPM_RATIO
+#define MOTOR_OPERATING_VOLTAGE 12          // motor's operating voltage (used to calculate max RPM)
 #define MOTOR_POWER_MAX_VOLTAGE 12          // max voltage of the motor's power source (used to calculate max RPM)
 #define MOTOR_POWER_MEASURED_VOLTAGE 12     // current voltage reading of the power connected to the motor (used for calibration)
-#define COUNTS_PER_REV1 144000              // wheel1 encoder's no of ticks per rev
-#define COUNTS_PER_REV2 144000              // wheel2 encoder's no of ticks per rev
-#define COUNTS_PER_REV3 144000              // wheel3 encoder's no of ticks per rev
-#define COUNTS_PER_REV4 144000              // wheel4 encoder's no of ticks per rev
-#define WHEEL_DIAMETER 0.152                // wheel's diameter in meters
-#define LR_WHEELS_DISTANCE 0.271            // distance between left and right wheels
-#define PWM_BITS 10                          // PWM Resolution of the microcontroller
+#define COUNTS_PER_REV1 450                 // wheel1 encoder's no of ticks per rev
+#define COUNTS_PER_REV2 450                 // wheel2 encoder's no of ticks per rev
+#define COUNTS_PER_REV3 450                 // wheel3 encoder's no of ticks per rev
+#define COUNTS_PER_REV4 450                 // wheel4 encoder's no of ticks per rev
+#define WHEEL_DIAMETER 0.0560               // wheel's diameter in meters
+#define LR_WHEELS_DISTANCE 0.224            // distance between left and right wheels
+#define PWM_BITS 10                         // PWM Resolution of the microcontroller
 #define PWM_FREQUENCY 20000                 // PWM Frequency
 
 // INVERT ENCODER COUNTS
-#define MOTOR1_ENCODER_INV false 
-#define MOTOR2_ENCODER_INV false 
-#define MOTOR3_ENCODER_INV false 
-#define MOTOR4_ENCODER_INV false 
+#define MOTOR1_ENCODER_INV false
+#define MOTOR2_ENCODER_INV false
+#define MOTOR3_ENCODER_INV false
+#define MOTOR4_ENCODER_INV false
 
 // INVERT MOTOR DIRECTIONS
 #define MOTOR1_INV false
@@ -81,39 +90,39 @@ ROBOT ORIENTATION
 #define MOTOR4_INV false
 
 // ENCODER PINS
-#define MOTOR1_ENCODER_A 14
-#define MOTOR1_ENCODER_B 15 
+#define MOTOR1_ENCODER_A 34
+#define MOTOR1_ENCODER_B 35
 
-#define MOTOR2_ENCODER_A 11
-#define MOTOR2_ENCODER_B 12 
+#define MOTOR2_ENCODER_A 16
+#define MOTOR2_ENCODER_B 27
 
-#define MOTOR3_ENCODER_A 17
-#define MOTOR3_ENCODER_B 16 
+#define MOTOR3_ENCODER_A -1
+#define MOTOR3_ENCODER_B -1
 
-#define MOTOR4_ENCODER_A 9
-#define MOTOR4_ENCODER_B 10
+#define MOTOR4_ENCODER_A -1
+#define MOTOR4_ENCODER_B -1
 
 // MOTOR PINS
 #ifdef USE_GENERIC_2_IN_MOTOR_DRIVER
-  #define MOTOR1_PWM 21 //Pin no 21 is not a PWM pin on Teensy 4.x, you can swap it with pin no 1 instead.
-  #define MOTOR1_IN_A 20
-  #define MOTOR1_IN_B 1 
+  #define MOTOR1_PWM 25 //Pin no 21 is not a PWM pin on Teensy 4.x, you can swap it with pin no 1 instead.
+  #define MOTOR1_IN_A 21
+  #define MOTOR1_IN_B 17
 
-  #define MOTOR2_PWM 5
-  #define MOTOR2_IN_A 6
-  #define MOTOR2_IN_B 8
+  #define MOTOR2_PWM 26
+  #define MOTOR2_IN_A 22
+  #define MOTOR2_IN_B 23
 
-  #define MOTOR3_PWM 22
-  #define MOTOR3_IN_A 23
-  #define MOTOR3_IN_B 0
+  #define MOTOR3_PWM -1
+  #define MOTOR3_IN_A -1
+  #define MOTOR3_IN_B -1
 
-  #define MOTOR4_PWM 4
-  #define MOTOR4_IN_A 3
-  #define MOTOR4_IN_B 2
+  #define MOTOR4_PWM -1
+  #define MOTOR4_IN_A -1
+  #define MOTOR4_IN_B -1
 
   #define PWM_MAX pow(2, PWM_BITS) - 1
   #define PWM_MIN -PWM_MAX
-#endif 
+#endif
 
 #ifdef USE_GENERIC_1_IN_MOTOR_DRIVER
   #define MOTOR1_PWM 21 //Pin no 21 is not a PWM pin on Teensy 4.x, you can use pin no 1 instead.
@@ -134,24 +143,24 @@ ROBOT ORIENTATION
 
   #define PWM_MAX pow(2, PWM_BITS) - 1
   #define PWM_MIN -PWM_MAX
-#endif 
+#endif
 
 #ifdef USE_BTS7960_MOTOR_DRIVER
-  #define MOTOR1_PWM -1 //DON'T TOUCH THIS! This is just a placeholder
-  #define MOTOR1_IN_A 21 // Pin no 21 is not a PWM pin on Teensy 4.x, you can use pin no 1 instead.
-  #define MOTOR1_IN_B 20 // Pin no 20 is not a PWM pin on Teensy 4.x, you can use pin no 0 instead.
+  #define MOTOR1_PWM 25 //DON'T TOUCH THIS! This is just a placeholder
+  #define MOTOR1_IN_A 17
+  #define MOTOR1_IN_B 21
 
-  #define MOTOR2_PWM -1 //DON'T TOUCH THIS! This is just a placeholder
-  #define MOTOR2_IN_A 5
-  #define MOTOR2_IN_B 6
+  #define MOTOR2_PWM 26 //DON'T TOUCH THIS! This is just a placeholder
+  #define MOTOR2_IN_A 23
+  #define MOTOR2_IN_B 22
 
   #define MOTOR3_PWM -1 //DON'T TOUCH THIS! This is just a placeholder
-  #define MOTOR3_IN_A 22
-  #define MOTOR3_IN_B 23
+  #define MOTOR3_IN_A -1
+  #define MOTOR3_IN_B -1
 
   #define MOTOR4_PWM -1 //DON'T TOUCH THIS! This is just a placeholder
-  #define MOTOR4_IN_A 4
-  #define MOTOR4_IN_B 3
+  #define MOTOR4_IN_A -1
+  #define MOTOR4_IN_B -1
 
   #define PWM_MAX pow(2, PWM_BITS) - 1
   #define PWM_MIN -PWM_MAX
@@ -166,7 +175,7 @@ ROBOT ORIENTATION
   #define MOTOR2_IN_A -1 //DON'T TOUCH THIS! This is just a placeholder
   #define MOTOR2_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder
 
-  #define MOTOR3_PWM 22 
+  #define MOTOR3_PWM 22
   #define MOTOR3_IN_A -1 //DON'T TOUCH THIS! This is just a placeholder
   #define MOTOR3_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder
 
@@ -178,29 +187,31 @@ ROBOT ORIENTATION
   #define PWM_MIN -PWM_MAX
 #endif
 
-// #define USE_WIFI_TRANSPORT  // use micro ros wifi transport
 #define AGENT_IP { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define AGENT_PORT 8888
+#define WIFI_SSID "WIFI_SSID"
+#define WIFI_PASSWORD "WIFI_PASSWORD"
 // Enable WiFi with null terminated list of multiple APs SSID and password
 // #define WIFI_AP_LIST {{"WIFI_SSID", "WIFI_PASSWORD"}, {NULL}}
-// #define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
+#define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
 // #define USE_ARDUINO_OTA
 // #define USE_SYSLOG
 #define SYSLOG_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define SYSLOG_PORT 514
-#define DEVICE_HOSTNAME "linorobot2"
+#define DEVICE_HOSTNAME "gendrv"
 #define APP_NAME "hardware"
 // #define USE_LIDAR_UDP  // send lidar data to udp server
 #define LIDAR_RXD 4
+// #define LIDAR_PWM 15
 #define LIDAR_SERIAL 1 // uart number
 #define LIDAR_BAUDRATE 230400
 #define LIDAR_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define LIDAR_PORT 8889
-// #define BAUDRATE 115200
-// #define SDA_PIN 18 // specify I2C pins
-// #define SCL_PIN 19
-#define NODE_NAME "linorobot_base_node"
-// #define TOPIC_PREFIX "myrobot/"
+#define BAUDRATE 921600
+#define SDA_PIN 32 // specify I2C pins
+#define SCL_PIN 33
+#define NODE_NAME "gendrv"
+// #define TOPIC_PREFIX "gendrv/"
 // #define CONTROL_TIMER 20
 // #define BATTERY_TIMER 2000
 
@@ -208,16 +219,23 @@ ROBOT ORIENTATION
 // #define BATTERY_PIN 33
 // 3.3V ref, 12 bits ADC, 33k + 10k voltage divider
 #define BATTERY_ADJUST(v) ((v) * (3.3 / 4096 * (33 + 10) / 10))
-// #define USE_INA219
+#define USE_INA219
 #define BATTERY_DIP 0.98  // battery voltage drop alert
 // #define BATTERY_CAP 2.0  // battery capacity Ah
 // #define BATTERY_MIN 9.0  // battery minimal voltage
 // #define BATTERY_MAX 12.6 // battery maximum voltage
 // #define TRIG_PIN 31 // ultrasonic sensor HC-SR04
 // #define ECHO_PIN 32
-// #define USE_SHORT_BRAKE // for shorter stopping distance
-// #define WDT_TIMEOUT 30 // Sec
-#define BOARD_INIT { Wire.begin(); } // needed for i2cdetect
+#define USE_SHORT_BRAKE // for shorter stopping distance
+// #define WDT_TIMEOUT 60 // Sec
+#define BOARD_INIT { \
+    pinMode(MOTOR1_PWM, OUTPUT); \
+    digitalWrite(MOTOR1_PWM, HIGH); \
+    pinMode(MOTOR2_PWM, OUTPUT); \
+    digitalWrite(MOTOR2_PWM, HIGH); \
+    Wire.begin(SDA_PIN, SCL_PIN); \
+    Wire.setClock(400000); \
+}
 // #define BOARD_INIT_LATE {}
 // #define BOARD_LOOP {}
 // #define JOINT_STATE_SUBSCRIBER "joint_states"
@@ -225,11 +243,11 @@ ROBOT ORIENTATION
 #ifdef USE_SYSLOG
 #define RCCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){ \
     syslog(LOG_ERR, "%s RCCHECK failed %d", __FUNCTION__, temp_rc); \
-    return false; }}
+    }}
 #else
 #define RCCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){ \
     flashLED(3); \
-    return false; }} // do not block
+    }} // do not block
 #endif
 
 #endif

--- a/config/custom/gendrv_wifi_config.h
+++ b/config/custom/gendrv_wifi_config.h
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LINO_BASE_CONFIG_H
-#define LINO_BASE_CONFIG_H
+#ifndef GENDRV_WIFI_CONFIG_H
+#define GENDRV_WIFI_CONFIG_H
 
-#define LED_PIN 13 //used for debugging status
+#define LED_PIN LED_BUILTIN //used for debugging status
 
 //uncomment the base you're building
 #define LINO_BASE DIFFERENTIAL_DRIVE       // 2WD and Tracked robot w/ 2 motors
@@ -23,9 +23,9 @@
 // #define LINO_BASE MECANUM               // Mecanum drive robot
 
 //uncomment the motor driver you're using
-#define USE_GENERIC_2_IN_MOTOR_DRIVER      // Motor drivers with 2 Direction Pins(INA, INB) and 1 PWM(ENABLE) pin ie. L298, L293, VNH5019
+// #define USE_GENERIC_2_IN_MOTOR_DRIVER      // Motor drivers with 2 Direction Pins(INA, INB) and 1 PWM(ENABLE) pin ie. L298, L293, VNH5019
 // #define USE_GENERIC_1_IN_MOTOR_DRIVER   // Motor drivers with 1 Direction Pin(INA) and 1 PWM(ENABLE) pin.
-// #define USE_BTS7960_MOTOR_DRIVER        // BTS7970 Motor Driver
+#define USE_BTS7960_MOTOR_DRIVER        // BTS7970 Motor Driver
 // #define USE_ESC_MOTOR_DRIVER            // Motor ESC for brushless motors
 
 //uncomment the IMU you're using
@@ -40,39 +40,50 @@
 // #define USE_AK09918_MAG
 // #define USE_QMC5883L_MAG
 // #define MAG_BIAS { 0, 0, 0 }
+// #define IMU_TWEAK {}
+// #define MAG_TWEAK {}
 
 #define K_P 0.6                             // P constant
 #define K_I 0.8                             // I constant
 #define K_D 0.5                             // D constant
 
+#define ACCEL_COV { 0.01, 0.01, 0.01 }
+#define GYRO_COV { 0.001, 0.001, 0.001 }
+#define ORI_COV { 0.01, 0.01, 0.01 }
+#define MAG_COV { 1e-12, 1e-12, 1e-12 }
+#define POSE_COV { 0.001, 0.001, 0.001, 0.001, 0.001, 0.001 }
+#define TWIST_COV { 0.001, 0.001, 0.001, 0.003, 0.003, 0.003 }
+
 /*
 ROBOT ORIENTATION
          FRONT
     MOTOR1  MOTOR2  (2WD/ACKERMANN)
-    MOTOR3  MOTOR4  (4WD/MECANUM)  
+    MOTOR3  MOTOR4  (4WD/MECANUM)
          BACK
 */
 
 //define your robot' specs here
-#define MOTOR_MAX_RPM 140                   // motor's max RPM          
-#define MAX_RPM_RATIO 0.85                  // max RPM allowed for each MAX_RPM_ALLOWED = MOTOR_MAX_RPM * MAX_RPM_RATIO          
-#define MOTOR_OPERATING_VOLTAGE 24          // motor's operating voltage (used to calculate max RPM)
+#define MOTOR_MAX_RPM 150                   // motor's max RPM
+#define MAX_RPM_RATIO 0.85                  // max RPM allowed for each MAX_RPM_ALLOWED = MOTOR_MAX_RPM * MAX_RPM_RATIO
+#define MOTOR_OPERATING_VOLTAGE 12          // motor's operating voltage (used to calculate max RPM)
 #define MOTOR_POWER_MAX_VOLTAGE 12          // max voltage of the motor's power source (used to calculate max RPM)
 #define MOTOR_POWER_MEASURED_VOLTAGE 12     // current voltage reading of the power connected to the motor (used for calibration)
-#define COUNTS_PER_REV1 144000              // wheel1 encoder's no of ticks per rev
-#define COUNTS_PER_REV2 144000              // wheel2 encoder's no of ticks per rev
-#define COUNTS_PER_REV3 144000              // wheel3 encoder's no of ticks per rev
-#define COUNTS_PER_REV4 144000              // wheel4 encoder's no of ticks per rev
-#define WHEEL_DIAMETER 0.152                // wheel's diameter in meters
-#define LR_WHEELS_DISTANCE 0.271            // distance between left and right wheels
-#define PWM_BITS 10                          // PWM Resolution of the microcontroller
+#define COUNTS_PER_REV1 450                 // wheel1 encoder's no of ticks per rev
+#define COUNTS_PER_REV2 450                 // wheel2 encoder's no of ticks per rev
+#define COUNTS_PER_REV3 450                 // wheel3 encoder's no of ticks per rev
+#define COUNTS_PER_REV4 450                 // wheel4 encoder's no of ticks per rev
+#define WHEEL_DIAMETER 0.0560               // wheel's diameter in meters
+#define LR_WHEELS_DISTANCE 0.224            // distance between left and right wheels
+#define PWM_BITS 10                         // PWM Resolution of the microcontroller
 #define PWM_FREQUENCY 20000                 // PWM Frequency
+#define SERVO_BITS 12                       // Servo PWM resolution
+#define SERVO_FREQ 50                       // Servo PWM frequency
 
 // INVERT ENCODER COUNTS
-#define MOTOR1_ENCODER_INV false 
-#define MOTOR2_ENCODER_INV false 
-#define MOTOR3_ENCODER_INV false 
-#define MOTOR4_ENCODER_INV false 
+#define MOTOR1_ENCODER_INV false
+#define MOTOR2_ENCODER_INV false
+#define MOTOR3_ENCODER_INV false
+#define MOTOR4_ENCODER_INV false
 
 // INVERT MOTOR DIRECTIONS
 #define MOTOR1_INV false
@@ -81,39 +92,39 @@ ROBOT ORIENTATION
 #define MOTOR4_INV false
 
 // ENCODER PINS
-#define MOTOR1_ENCODER_A 14
-#define MOTOR1_ENCODER_B 15 
+#define MOTOR1_ENCODER_A 34
+#define MOTOR1_ENCODER_B 35
 
-#define MOTOR2_ENCODER_A 11
-#define MOTOR2_ENCODER_B 12 
+#define MOTOR2_ENCODER_A 16
+#define MOTOR2_ENCODER_B 27
 
-#define MOTOR3_ENCODER_A 17
-#define MOTOR3_ENCODER_B 16 
+#define MOTOR3_ENCODER_A -1
+#define MOTOR3_ENCODER_B -1
 
-#define MOTOR4_ENCODER_A 9
-#define MOTOR4_ENCODER_B 10
+#define MOTOR4_ENCODER_A -1
+#define MOTOR4_ENCODER_B -1
 
 // MOTOR PINS
 #ifdef USE_GENERIC_2_IN_MOTOR_DRIVER
-  #define MOTOR1_PWM 21 //Pin no 21 is not a PWM pin on Teensy 4.x, you can swap it with pin no 1 instead.
-  #define MOTOR1_IN_A 20
-  #define MOTOR1_IN_B 1 
+  #define MOTOR1_PWM 25 //Pin no 21 is not a PWM pin on Teensy 4.x, you can swap it with pin no 1 instead.
+  #define MOTOR1_IN_A 21
+  #define MOTOR1_IN_B 17
 
-  #define MOTOR2_PWM 5
-  #define MOTOR2_IN_A 6
-  #define MOTOR2_IN_B 8
+  #define MOTOR2_PWM 26
+  #define MOTOR2_IN_A 22
+  #define MOTOR2_IN_B 23
 
-  #define MOTOR3_PWM 22
-  #define MOTOR3_IN_A 23
-  #define MOTOR3_IN_B 0
+  #define MOTOR3_PWM -1
+  #define MOTOR3_IN_A -1
+  #define MOTOR3_IN_B -1
 
-  #define MOTOR4_PWM 4
-  #define MOTOR4_IN_A 3
-  #define MOTOR4_IN_B 2
+  #define MOTOR4_PWM -1
+  #define MOTOR4_IN_A -1
+  #define MOTOR4_IN_B -1
 
   #define PWM_MAX pow(2, PWM_BITS) - 1
   #define PWM_MIN -PWM_MAX
-#endif 
+#endif
 
 #ifdef USE_GENERIC_1_IN_MOTOR_DRIVER
   #define MOTOR1_PWM 21 //Pin no 21 is not a PWM pin on Teensy 4.x, you can use pin no 1 instead.
@@ -134,24 +145,24 @@ ROBOT ORIENTATION
 
   #define PWM_MAX pow(2, PWM_BITS) - 1
   #define PWM_MIN -PWM_MAX
-#endif 
+#endif
 
 #ifdef USE_BTS7960_MOTOR_DRIVER
-  #define MOTOR1_PWM -1 //DON'T TOUCH THIS! This is just a placeholder
-  #define MOTOR1_IN_A 21 // Pin no 21 is not a PWM pin on Teensy 4.x, you can use pin no 1 instead.
-  #define MOTOR1_IN_B 20 // Pin no 20 is not a PWM pin on Teensy 4.x, you can use pin no 0 instead.
+  #define MOTOR1_PWM 25 //DON'T TOUCH THIS! This is just a placeholder
+  #define MOTOR1_IN_A 17
+  #define MOTOR1_IN_B 21
 
-  #define MOTOR2_PWM -1 //DON'T TOUCH THIS! This is just a placeholder
-  #define MOTOR2_IN_A 5
-  #define MOTOR2_IN_B 6
+  #define MOTOR2_PWM 26 //DON'T TOUCH THIS! This is just a placeholder
+  #define MOTOR2_IN_A 23
+  #define MOTOR2_IN_B 22
 
   #define MOTOR3_PWM -1 //DON'T TOUCH THIS! This is just a placeholder
-  #define MOTOR3_IN_A 22
-  #define MOTOR3_IN_B 23
+  #define MOTOR3_IN_A -1
+  #define MOTOR3_IN_B -1
 
   #define MOTOR4_PWM -1 //DON'T TOUCH THIS! This is just a placeholder
-  #define MOTOR4_IN_A 4
-  #define MOTOR4_IN_B 3
+  #define MOTOR4_IN_A -1
+  #define MOTOR4_IN_B -1
 
   #define PWM_MAX pow(2, PWM_BITS) - 1
   #define PWM_MIN -PWM_MAX
@@ -166,7 +177,7 @@ ROBOT ORIENTATION
   #define MOTOR2_IN_A -1 //DON'T TOUCH THIS! This is just a placeholder
   #define MOTOR2_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder
 
-  #define MOTOR3_PWM 22 
+  #define MOTOR3_PWM 22
   #define MOTOR3_IN_A -1 //DON'T TOUCH THIS! This is just a placeholder
   #define MOTOR3_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder
 
@@ -178,29 +189,28 @@ ROBOT ORIENTATION
   #define PWM_MIN -PWM_MAX
 #endif
 
-// #define USE_WIFI_TRANSPORT  // use micro ros wifi transport
 #define AGENT_IP { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define AGENT_PORT 8888
 // Enable WiFi with null terminated list of multiple APs SSID and password
-// #define WIFI_AP_LIST {{"WIFI_SSID", "WIFI_PASSWORD"}, {NULL}}
-// #define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
-// #define USE_ARDUINO_OTA
-// #define USE_SYSLOG
+#define WIFI_AP_LIST {{"WIFI_SSID", "WIFI_PASSWORD"}, {NULL}}
+#define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
+#define USE_ARDUINO_OTA
+#define USE_SYSLOG
 #define SYSLOG_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define SYSLOG_PORT 514
-#define DEVICE_HOSTNAME "linorobot2"
+#define DEVICE_HOSTNAME "gendrv_wifi"
 #define APP_NAME "hardware"
-// #define USE_LIDAR_UDP  // send lidar data to udp server
+#define USE_LIDAR_UDP  // send lidar data to udp server
 #define LIDAR_RXD 4
 #define LIDAR_SERIAL 1 // uart number
 #define LIDAR_BAUDRATE 230400
 #define LIDAR_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define LIDAR_PORT 8889
-// #define BAUDRATE 115200
-// #define SDA_PIN 18 // specify I2C pins
-// #define SCL_PIN 19
-#define NODE_NAME "linorobot_base_node"
-// #define TOPIC_PREFIX "myrobot/"
+#define BAUDRATE 921600
+#define SDA_PIN 32 // specify I2C pins
+#define SCL_PIN 33
+#define NODE_NAME "gendrv_wifi"
+// #define TOPIC_PREFIX "gendrv_wifi/"
 // #define CONTROL_TIMER 20
 // #define BATTERY_TIMER 2000
 
@@ -208,16 +218,23 @@ ROBOT ORIENTATION
 // #define BATTERY_PIN 33
 // 3.3V ref, 12 bits ADC, 33k + 10k voltage divider
 #define BATTERY_ADJUST(v) ((v) * (3.3 / 4096 * (33 + 10) / 10))
-// #define USE_INA219
+#define USE_INA219
 #define BATTERY_DIP 0.98  // battery voltage drop alert
 // #define BATTERY_CAP 2.0  // battery capacity Ah
 // #define BATTERY_MIN 9.0  // battery minimal voltage
 // #define BATTERY_MAX 12.6 // battery maximum voltage
 // #define TRIG_PIN 31 // ultrasonic sensor HC-SR04
 // #define ECHO_PIN 32
-// #define USE_SHORT_BRAKE // for shorter stopping distance
-// #define WDT_TIMEOUT 30 // Sec
-#define BOARD_INIT { Wire.begin(); } // needed for i2cdetect
+#define USE_SHORT_BRAKE // for shorter stopping distance
+// #define WDT_TIMEOUT 60 // Sec
+#define BOARD_INIT { \
+    pinMode(MOTOR1_PWM, OUTPUT); \
+    digitalWrite(MOTOR1_PWM, HIGH); \
+    pinMode(MOTOR2_PWM, OUTPUT); \
+    digitalWrite(MOTOR2_PWM, HIGH); \
+    Wire.begin(SDA_PIN, SCL_PIN); \
+    Wire.setClock(400000); \
+}
 // #define BOARD_INIT_LATE {}
 // #define BOARD_LOOP {}
 // #define JOINT_STATE_SUBSCRIBER "joint_states"

--- a/firmware/lib/lidar/lidar.cpp
+++ b/firmware/lib/lidar/lidar.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2023 Thomas Chou
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Push lidar data to a UDP server, which will push laser scan message
+// TODO: add PWM closed loop control the scan frequency
+// TODO: add TCP for reliable data packet sequence
+//
+#include <Arduino.h>
+#include "config.h"
+#include "syslog.h"
+
+#ifdef USE_LIDAR_UDP
+#include <HardwareSerial.h>
+#include <WiFiUdp.h>
+#define BUFSIZE 512
+
+HardwareSerial comm(LIDAR_SERIAL);
+WiFiUDP udp;
+uint8_t buf[BUFSIZE];
+
+void rx_err_callback(hardwareSerial_error_t err)
+{
+  syslog(LOG_INFO, "%s err %d", __FUNCTION__, err);
+}
+
+size_t len = 0;
+void rx_callback(void)
+{
+  size_t cc = comm.read(buf + len, BUFSIZE - len);
+  // syslog(LOG_INFO, "%s recv %d", __FUNCTION__, cc);
+  // send larger UDP packet
+  if ((len += cc) && (len > 128)) {
+      udp.beginPacket(LIDAR_SERVER, LIDAR_PORT);
+      udp.write(buf, len);
+      udp.endPacket();
+      // syslog(LOG_INFO, "%s send %d", __FUNCTION__, len);
+      len = 0;
+  }
+}
+
+void poweronLidar(void)
+{
+#ifdef LIDAR_POWEROFF
+    digitalWrite(LIDAR_POWEROFF, LOW);
+#endif
+}
+
+void poweroffLidar(void)
+{
+#ifdef LIDAR_POWEROFF
+    digitalWrite(LIDAR_POWEROFF, HIGH);
+#endif
+}
+
+void initLidar(void) {
+  pinMode(LIDAR_RXD, INPUT);
+#ifdef LIDAR_POWEROFF
+  pinMode(LIDAR_POWEROFF, OUTPUT);
+#endif
+  poweronLidar();
+  comm.setRxBufferSize(1024);
+  comm.onReceiveError(rx_err_callback);
+  comm.onReceive(rx_callback);
+  comm.begin(LIDAR_BAUDRATE, SERIAL_8N1, LIDAR_RXD);
+};
+#else
+void initLidar(void) {};
+void poweronLidar(void) {};
+void poweroffLidar(void) {};
+#endif

--- a/firmware/lib/lidar/lidar.h
+++ b/firmware/lib/lidar/lidar.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 Thomas Chou
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LIDAR_H
+#define LIDAR_H
+
+void poweronLidar(void);
+void poweroffLidar(void);
+void initLidar(void);
+
+#endif

--- a/firmware/lib/syslog/syslog.cpp
+++ b/firmware/lib/syslog/syslog.cpp
@@ -1,0 +1,15 @@
+#include <Arduino.h>
+#include "config.h"
+
+#ifdef USE_SYSLOG
+#include <WiFiUdp.h>
+#include <Syslog.h>
+WiFiUDP udpClient;
+Syslog syslogv(udpClient, SYSLOG_SERVER, SYSLOG_PORT, DEVICE_HOSTNAME, APP_NAME, LOG_KERN);
+void syslog(uint16_t priority, const char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  syslogv.vlogf(priority, fmt, args);
+  va_end(args);
+};
+#endif

--- a/firmware/lib/syslog/syslog.h
+++ b/firmware/lib/syslog/syslog.h
@@ -1,0 +1,13 @@
+#ifndef SYSLOG_H_
+#define SYSLOG_H_ 
+
+#include <Syslog.h>
+#include "config.h"
+
+#ifdef USE_SYSLOG
+void syslog(uint16_t priority, const char *fmt, ...);
+#else
+#define syslog(...)
+#endif
+
+#endif

--- a/firmware/lib/wifi/ota.cpp
+++ b/firmware/lib/wifi/ota.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2023 Thomas Chou
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <Arduino.h>
+#include "config.h"
+#include "syslog.h"
+
+#ifdef USE_ARDUINO_OTA
+#include <ArduinoOTA.h>
+
+void initOta(void)
+{
+    // Port defaults to 3232
+    // Port defaults to 8266
+    // ArduinoOTA.setPort(8266);
+
+    // Hostname defaults to esp3232-[MAC]
+    // Hostname defaults to esp8266-[ChipID]
+    // ArduinoOTA.setHostname("myesp8266");
+
+    // No authentication by default
+    // ArduinoOTA.setPassword("admin");
+
+    // Password can be set with it's md5 value as well
+    // MD5(admin) = 21232f297a57a5a743894a0e4a801fc3
+    // ArduinoOTA.setPasswordHash("21232f297a57a5a743894a0e4a801fc3");
+
+    ArduinoOTA.onStart([]() {
+      String type;
+      if (ArduinoOTA.getCommand() == U_FLASH) {
+	type = "sketch";
+      } else {  // U_FS
+	type = "filesystem";
+      }
+
+      // NOTE: if updating FS this would be the place to unmount FS using FS.end()
+      Serial.println("Start updating " + type);
+    });
+    ArduinoOTA.onEnd([]() {
+      Serial.println("\nEnd");
+    });
+    ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
+      Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
+    });
+    ArduinoOTA.onError([](ota_error_t error) {
+      Serial.printf("Error[%u]: ", error);
+      if (error == OTA_AUTH_ERROR) {
+	Serial.println("Auth Failed");
+      } else if (error == OTA_BEGIN_ERROR) {
+	Serial.println("Begin Failed");
+      } else if (error == OTA_CONNECT_ERROR) {
+	Serial.println("Connect Failed");
+      } else if (error == OTA_RECEIVE_ERROR) {
+	Serial.println("Receive Failed");
+      } else if (error == OTA_END_ERROR) {
+	Serial.println("End Failed");
+      }
+    });
+    ArduinoOTA.begin();
+}
+
+void runOta(void)
+{
+    ArduinoOTA.handle();
+}
+
+#endif // USE_ARDUINO_OTA

--- a/firmware/lib/wifi/ota.h
+++ b/firmware/lib/wifi/ota.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 Thomas Chou
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef OTA_H
+#define OTA_H
+
+#ifdef USE_ARDUINO_OTA
+void initOta(void);
+void runOta(void);
+#else
+#define initOta()
+#define runOta()
+#endif
+
+#endif

--- a/firmware/lib/wifi/wifis.cpp
+++ b/firmware/lib/wifi/wifis.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2023 Thomas Chou
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <Arduino.h>
+#include "config.h"
+#include "syslog.h"
+#include "wifis.h"
+
+#ifdef WIFI_AP_LIST
+#include <WiFi.h>
+#include <WiFiMulti.h>
+#define EXECUTE_EVERY_N_MS(MS, X)  do { \
+  static volatile unsigned long init = millis(); \
+  if (millis() - init > MS) { X; init = millis();} \
+} while (0)
+
+const char *wifi_ap_list[][2] = WIFI_AP_LIST;
+WiFiMulti wifiMulti;
+
+void initWifis(void)
+{
+    for (int i = 0; wifi_ap_list[i][0] != NULL; i++) {
+        wifiMulti.addAP(wifi_ap_list[i][0], wifi_ap_list[i][1]);
+    }
+    while (wifiMulti.run() != WL_CONNECTED) {
+        delay(500);
+    }
+    Serial.println("WIFI connected");
+    Serial.print("IP address: ");
+    Serial.println(WiFi.localIP());
+    syslog(LOG_INFO, "%s ssid %s rssi %d ip %s", __FUNCTION__, WiFi.SSID(), WiFi.RSSI(),
+	   WiFi.localIP().toString().c_str());
+}
+
+void runWifis(void)
+{
+    static uint8_t dis_bssid[6]; // check previous disconnected bssid to avoid repeated disconnection
+    uint8_t *bssid;
+    uint8_t bssidv[6];
+
+#ifdef WIFI_MONITOR
+    EXECUTE_EVERY_N_MS(WIFI_MONITOR * 60 * 1000, syslog(LOG_INFO, "%s ssid %s rssi %d", \
+							__FUNCTION__, WiFi.SSID(), WiFi.RSSI()));
+#endif
+#ifdef PICO // WiFi.BSSID api is different
+    // when wifi signal is too weak, disconnect current ap and scan for strongest signal
+    EXECUTE_EVERY_N_MS(2000, (WiFi.RSSI() < LOW_RSSI && (bssid = WiFi.BSSID(bssidv), memcmp(dis_bssid, bssid, 6))) ? \
+		       (memcpy(dis_bssid, bssid, 6), WiFi.disconnect()) : 0);
+#else
+    // when wifi signal is too weak, disconnect current ap and scan for strongest signal
+    EXECUTE_EVERY_N_MS(2000, (WiFi.RSSI() < LOW_RSSI && (bssid = WiFi.BSSID(), memcmp(dis_bssid, bssid, 6))) ? \
+		       (memcpy(dis_bssid, bssid, 6), WiFi.disconnect()) : 0);
+#endif
+    wifiMulti.run();
+}
+#endif // WIFI_AP_LIST

--- a/firmware/lib/wifi/wifis.h
+++ b/firmware/lib/wifi/wifis.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2023 Thomas Chou
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef WIFIS_H
+#define WIFIS_H
+
+#if defined(USE_WIFI_TRANSPORT) && !defined(WIFI_AP_LIST) // fixup old wifi config
+#define WIFI_AP_LIST {{WIFI_SSID, WIFI_PASSWORD}, {NULL}}
+#endif
+#ifndef LOW_RSSI
+#define LOW_RSSI -75 // when wifi signal is too low, disconnect current ap and scan for strongest signal
+#endif
+
+#ifdef WIFI_AP_LIST
+void initWifis(void);
+void runWifis(void);
+#else
+#define initWifis()
+#define runWifis()
+#endif
+
+#endif

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -12,16 +12,23 @@ platform = teensy
 framework = arduino
 upload_port = /dev/ttyACM0
 upload_protocol = teensy-cli
-board_microros_transport = serial
+board_microros_transport = serial # or wifi
 board_microros_distro = ${sysenv.ROS_DISTRO}
 lib_deps = https://github.com/micro-ROS/micro_ros_platformio
+    mcauser/i2cdetect
     jrowberg/I2Cdevlib-Core
     jrowberg/I2Cdevlib-ADXL345
     jrowberg/I2Cdevlib-AK8975
+    jrowberg/I2Cdevlib-HMC5843
     jrowberg/I2Cdevlib-HMC5883L
     jrowberg/I2Cdevlib-ITG3200
     jrowberg/I2Cdevlib-MPU6050
     https://github.com/dthain/QMC5883L
+    https://github.com/wollewald/INA219_WE
+    https://github.com/arcao/Syslog
+    SPI
+    adafruit/Adafruit BusIO
+    adafruit/Adafruit PWM Servo Driver Library
 build_flags = -I ../config
 
 [env:teensy41] 
@@ -62,6 +69,55 @@ build_flags =
     -I ../config
     -D USE_VATTENKAR_CONFIG
 
+[env:gendrv]
+platform = espressif32
+board = nodemcu-32s
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
+board_build.partitions = min_spiffs.csv
+monitor_speed = 921600
+monitor_port = /dev/ttyUSB0
+upload_port = /dev/ttyUSB0
+upload_protocol = esptool
+; upload_protocol = espota
+; upload_port = 192.168.1.101
+; board_microros_transport = wifi
+; board_microros_distro = humble
+; board_microros_user_meta = action.meta
+lib_deps =
+    ${env.lib_deps}
+    madhephaestus/ESP32Servo
+    madhephaestus/ESP32Encoder
+build_flags =
+    -I ../config
+    -D __PGMSPACE_H_
+    -D USE_GENDRV_CONFIG
+
+[env:gendrv_wifi]
+platform = espressif32
+board = nodemcu-32s
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
+board_build.partitions = min_spiffs.csv
+monitor_speed = 921600
+monitor_port = /dev/ttyUSB0
+upload_port = /dev/ttyUSB0
+upload_protocol = esptool
+; upload_protocol = espota
+; upload_port = 192.168.1.101
+board_microros_transport = wifi
+; board_microros_distro = humble
+; board_microros_user_meta = action.meta
+lib_deps =
+    ${env.lib_deps}
+    madhephaestus/ESP32Servo
+    madhephaestus/ESP32Encoder
+build_flags =
+    -I ../config
+    -D __PGMSPACE_H_
+    -D USE_GENDRV_WIFI_CONFIG
+    -D USE_STAY_CONNECTED
+
 [env:esp32]
 platform = espressif32
 board = nodemcu-32s
@@ -85,11 +141,36 @@ build_flags =
     -D __PGMSPACE_H_
     -D USE_ESP32_CONFIG
 
+[env:esp32_wifi]
+platform = espressif32
+board = nodemcu-32s
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
+board_build.partitions = min_spiffs.csv
+monitor_speed = 921600
+monitor_port = /dev/ttyUSB0
+upload_port = /dev/ttyUSB0
+upload_protocol = esptool
+; upload_protocol = espota
+; upload_port = 192.168.1.101
+board_microros_transport = wifi
+; board_microros_distro = humble
+; board_microros_user_meta = action.meta
+lib_deps =
+    ${env.lib_deps}
+    madhephaestus/ESP32Servo
+    madhephaestus/ESP32Encoder
+build_flags =
+    -I ../config
+    -D __PGMSPACE_H_
+    -D USE_ESP32_WIFI_CONFIG
+    -D USE_STAY_CONNECTED
+
 [env:esp32s2]
 platform = espressif32
 board = esp32-s2-saola-1
-board_build.f_flash = 80000000L
-board_build.flash_mode = qio
+; board_build.f_flash = 80000000L
+; board_build.flash_mode = qio
 ; board_build.partitions = min_spiffs.csv
 monitor_speed = 921600
 monitor_port = /dev/ttyUSB0
@@ -108,6 +189,33 @@ build_flags =
 ;    -D ARDUINO_USB_CDC_ON_BOOT
     -D __PGMSPACE_H_
     -D USE_ESP32S2_CONFIG
+
+[env:esp32s2_wifi]
+platform = espressif32
+board = esp32-s2-saola-1
+; board_build.f_flash = 80000000L
+; board_build.flash_mode = qio
+; board_build.partitions = min_spiffs.csv
+monitor_speed = 921600
+monitor_port = /dev/ttyACM0
+upload_port = /dev/ttyACM0
+; upload_port = /dev/ttyusb0
+upload_protocol = esptool
+; upload_protocol = espota
+; upload_port = 192.168.1.101
+board_microros_transport = wifi
+; board_microros_distro = humble
+; board_microros_user_meta = action.meta
+lib_deps =
+    ${env.lib_deps}
+    madhephaestus/ESP32Servo
+    madhephaestus/ESP32Encoder
+build_flags =
+    -I ../config
+    -D ARDUINO_USB_CDC_ON_BOOT
+    -D __PGMSPACE_H_
+    -D USE_ESP32S2_WIFI_CONFIG
+    -D USE_STAY_CONNECTED
 
 [env:esp32s3]
 platform = espressif32
@@ -132,6 +240,32 @@ build_flags =
     -D ARDUINO_USB_CDC_ON_BOOT
     -D __PGMSPACE_H_
     -D USE_ESP32S3_CONFIG
+
+[env:esp32s3_wifi]
+platform = espressif32
+board = esp32-s3-devkitc-1
+; board_build.f_flash = 80000000L
+; board_build.flash_mode = qio
+; board_build.partitions = min_spiffs.csv
+monitor_speed = 921600
+monitor_port = /dev/ttyACM0
+upload_port = /dev/ttyACM0
+upload_protocol = esptool
+; upload_protocol = espota
+; upload_port = 192.168.1.101
+board_microros_transport = wifi
+; board_microros_distro = humble
+; board_microros_user_meta = action.meta
+lib_deps =
+    ${env.lib_deps}
+    madhephaestus/ESP32Servo
+    madhephaestus/ESP32Encoder
+build_flags =
+    -I ../config
+    -D ARDUINO_USB_CDC_ON_BOOT
+    -D __PGMSPACE_H_
+    -D USE_ESP32S3_WIFI_CONFIG
+    -D USE_STAY_CONNECTED
 
 [env:pico2]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
@@ -162,3 +296,9 @@ build_flags =
     -I ../config
     -D PICO
     -D USE_PICO_CONFIG
+
+; add maintainer configurations above this line
+; this barrier helps to reduce user merge conflict
+; add user configurations below this line
+
+

--- a/firmware/src/firmware.ino
+++ b/firmware/src/firmware.ino
@@ -27,6 +27,7 @@
 #include <geometry_msgs/msg/vector3.h>
 
 #include "config.h"
+#include "syslog.h"
 #include "motor.h"
 #include "kinematics.h"
 #include "pid.h"
@@ -36,6 +37,32 @@
 #define ENCODER_USE_INTERRUPTS
 #define ENCODER_OPTIMIZE_INTERRUPTS
 #include "encoder.h"
+#include "lidar.h"
+#include "wifis.h"
+#include "ota.h"
+
+#ifdef MICRO_ROS_TRANSPORT_ARDUINO_WIFI
+// remove wifi initialization code from wifi transport
+static inline void set_microros_net_transports(IPAddress agent_ip, uint16_t agent_port)
+{
+    static struct micro_ros_agent_locator locator;
+    locator.address = agent_ip;
+    locator.port = agent_port;
+
+    rmw_uros_set_custom_transport(
+        false,
+        (void *) &locator,
+        platformio_transport_open,
+        platformio_transport_close,
+        platformio_transport_write,
+        platformio_transport_read
+    );
+}
+#endif
+
+#ifndef NODE_NAME
+#define NODE_NAME "linorobot_base_node"
+#endif
 
 #ifndef RCCHECK
 #define RCCHECK(fn) { rcl_ret_t temp_rc = fn; if((temp_rc != RCL_RET_OK)){rclErrorLoop();}}
@@ -112,28 +139,54 @@ void setup()
 {
     pinMode(LED_PIN, OUTPUT);
     Serial.begin(BAUDRATE);
-#ifdef BOARD_INIT // board specific setup
-    BOARD_INIT
+#ifdef ESP32
+    Serial.setRxBufferSize(1024);
 #endif
 
+#ifdef BOARD_INIT // board specific setup, must include Wire.begin
+    BOARD_INIT
+#else
+    Wire.begin();
+#endif
+
+    initWifis();
+    initOta();
     bool imu_ok = imu.init();
-    if(!imu_ok)
+    if (!imu_ok) // take IMU failure as fatal
     {
-        while(1)
+        Serial.println("IMU init failed");
+        syslog(LOG_INFO, "%s IMU init failed %lu", __FUNCTION__, millis());
+        while (1)
         {
-            flashLED(3);
+            flashLED(3); // flash 3 times
+            runWifis();
+            runOta();
         }
     }
-    mag.init();
+    bool mag_ok = mag.init();
+    if (!mag_ok) // take mag failure as fatal
+    {
+        Serial.println("MAG init failed");
+        syslog(LOG_INFO, "%s MAG init failed %lu", __FUNCTION__, millis());
+        while (1)
+        {
+            flashLED(4); // flash 4 times
+            runWifis();
+            runOta();
+        }
+    }
+    initLidar(); // after wifi connected
 
 #ifdef MICRO_ROS_TRANSPORT_ARDUINO_WIFI
-    set_microros_wifi_transports(WIFI_SSID, WIFI_PASSWORD, AGENT_IP, AGENT_PORT);
+    set_microros_net_transports(AGENT_IP, AGENT_PORT);
 #else
     set_microros_serial_transports(Serial);
 #endif
+
 #ifdef BOARD_INIT_LATE // board specific setup
     BOARD_INIT_LATE
 #endif
+    syslog(LOG_INFO, "%s Ready %lu", __FUNCTION__, millis());
 }
 
 void loop() {
@@ -143,6 +196,7 @@ void loop() {
             EXECUTE_EVERY_N_MS(500, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1)) ? AGENT_AVAILABLE : WAITING_AGENT;);
             break;
         case AGENT_AVAILABLE:
+            syslog(LOG_INFO, "%s agent available %lu", __FUNCTION__, millis());
             state = (true == createEntities()) ? AGENT_CONNECTED : WAITING_AGENT;
             if (state == WAITING_AGENT) 
             {
@@ -150,19 +204,28 @@ void loop() {
             }
             break;
         case AGENT_CONNECTED:
+#ifndef USE_STAY_CONNECTED // Stay connected. Do not ping.
             EXECUTE_EVERY_N_MS(200, state = (RMW_RET_OK == rmw_uros_ping_agent(100, 1)) ? AGENT_CONNECTED : AGENT_DISCONNECTED;);
+#endif
             if (state == AGENT_CONNECTED) 
             {
                 rclc_executor_spin_some(&executor, RCL_MS_TO_NS(100));
             }
             break;
         case AGENT_DISCONNECTED:
+            syslog(LOG_INFO, "%s agent disconnected %lu", __FUNCTION__, millis());
+            fullStop();
             destroyEntities();
             state = WAITING_AGENT;
             break;
         default:
             break;
     }
+    runWifis();
+    runOta();
+#ifdef WDT_TIMEOUT
+    esp_task_wdt_reset();
+#endif
 #ifdef BOARD_LOOP // board specific loop
     BOARD_LOOP
 #endif
@@ -187,11 +250,12 @@ void twistCallback(const void * msgin)
 
 bool createEntities()
 {
+    syslog(LOG_INFO, "%s %lu", __FUNCTION__, millis());
     allocator = rcl_get_default_allocator();
     //create init_options
     RCCHECK(rclc_support_init(&support, 0, NULL, &allocator));
     // create node
-    RCCHECK(rclc_node_init_default(&node, "linorobot_base_node", "", &support));
+    RCCHECK(rclc_node_init_default(&node, NODE_NAME, "", &support));
     // create odometry publisher
     RCCHECK(rclc_publisher_init_default( 
         &odom_publisher, 
@@ -204,6 +268,7 @@ bool createEntities()
         &imu_publisher, 
         &node,
         ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, Imu),
+    // if we have magnetomter, use imu/data_raw for madgwick filter
 #ifndef USE_FAKE_MAG
         "imu/data_raw"
 #else
@@ -227,11 +292,12 @@ bool createEntities()
     ));
     // create timer for actuating the motors at 50 Hz (1000/20)
     const unsigned int control_timeout = 20;
-    RCCHECK(rclc_timer_init_default( 
+    RCCHECK(rclc_timer_init_default2( 
         &control_timer, 
         &support,
         RCL_MS_TO_NS(control_timeout),
-        controlCallback
+        controlCallback,
+        true
     ));
     executor = rclc_executor_get_zero_initialized_executor();
     RCCHECK(rclc_executor_init(&executor, &support.context, 2, & allocator));
@@ -256,16 +322,16 @@ bool destroyEntities()
     rmw_context_t * rmw_context = rcl_context_get_rmw_context(&support.context);
     (void) rmw_uros_set_context_entity_destroy_session_timeout(rmw_context, 0);
 
-    rcl_publisher_fini(&odom_publisher, &node);
-    rcl_publisher_fini(&imu_publisher, &node);
+    RCSOFTCHECK(rcl_publisher_fini(&odom_publisher, &node));
+    RCSOFTCHECK(rcl_publisher_fini(&imu_publisher, &node));
 #ifndef USE_FAKE_MAG
-    rcl_publisher_fini(&mag_publisher, &node);
+    RCSOFTCHECK(rcl_publisher_fini(&mag_publisher, &node));
 #endif
-    rcl_subscription_fini(&twist_subscriber, &node);
-    rcl_node_fini(&node);
-    rcl_timer_fini(&control_timer);
-    rclc_executor_fini(&executor);
-    rclc_support_fini(&support);
+    RCSOFTCHECK(rcl_subscription_fini(&twist_subscriber, &node));
+    RCSOFTCHECK(rcl_timer_fini(&control_timer));
+    RCSOFTCHECK(rclc_executor_fini(&executor));
+    RCSOFTCHECK(rcl_node_fini(&node))
+    RCSOFTCHECK(rclc_support_fini(&support));
 
     digitalWrite(LED_PIN, HIGH);
     
@@ -366,25 +432,42 @@ void publishData()
     RCSOFTCHECK(rcl_publish(&odom_publisher, &odom_msg, NULL));
 }
 
-void syncTime()
+bool syncTime()
 {
+    const int timeout_ms = 1000;
+    if (rmw_uros_epoch_synchronized()) return true; // synchronized previously
     // get the current time from the agent
-    unsigned long now = millis();
-    RCCHECK(rmw_uros_sync_session(10));
-    unsigned long long ros_time_ms = rmw_uros_epoch_millis(); 
+    RCCHECK(rmw_uros_sync_session(timeout_ms));
+    if (rmw_uros_epoch_synchronized()) {
+#if (_POSIX_TIMERS > 0)
+        // Get time in milliseconds or nanoseconds
+        int64_t time_ns = rmw_uros_epoch_nanos();
+    timespec tp;
+    tp.tv_sec = time_ns / 1000000000;
+    tp.tv_nsec = time_ns % 1000000000;
+    clock_settime(CLOCK_REALTIME, &tp);
+#else
+    unsigned long long ros_time_ms = rmw_uros_epoch_millis();
     // now we can find the difference between ROS time and uC time
-    time_offset = ros_time_ms - now;
+    time_offset = ros_time_ms - millis();
+#endif
+    return true;
+    }
+    return false;
 }
 
 struct timespec getTime()
 {
     struct timespec tp = {0};
+#if (_POSIX_TIMERS > 0)
+    clock_gettime(CLOCK_REALTIME, &tp);
+#else
     // add time difference between uC time and ROS time to
     // synchronize time with ROS
     unsigned long long now = millis() + time_offset;
     tp.tv_sec = now / 1000;
     tp.tv_nsec = (now % 1000) * 1000000;
-
+#endif
     return tp;
 }
 


### PR DESCRIPTION

This is a port of the wifi functionality from Thomas' repo. This PR brings the following functionality from Thomas' repo:

ESP32 wifi support
config files for esp32_wifi_config, gendrv_wifi_config, etc
OTA update
syslog support
lidar over wifi
micro-ros over wifi
It does not bring the following features from Thomas' repo:

battery_state
sonar
LED library or pwm library in pio
watchdog timer
i2cdetect
joint stat subscriber
Topic Prefix
The reason for omitting features that are in Thomas' repo is to contain the scope of changes for this PR. Juan had asked for a half-dozen files changed per PR, and there are 16 here, that are all needed to make wifi work in a comprehensive way. The scope of this PR is wifi support, not full-blown feature transfer from Thomas' repo, which may be addressed incrementally in subsequent PRs.

I have tested SLAM & navigation using both serial-connection (to an RPi, to ensure no regressions), and wifi connection from minniebot ESP32 to my laptop. I tested OTA update. I have tested that the configs I can't test on-robot (e.g. esp32s2 & friends) do at least build.