### PR TITLE
Security enhancement: Add wifi config to #include file that's gitignored

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -34,6 +34,10 @@
     #include "custom/esp32_config.h"
 #endif
 
+#ifdef USE_ESP32_WIFI_CONFIG
+    #include "custom/esp32_wifi_config.h"
+#endif
+
 #ifdef USE_ESP32S2_CONFIG
     #include "custom/esp32s2_config.h"
 #endif

--- a/config/custom/.gitignore
+++ b/config/custom/.gitignore
@@ -1,0 +1,1 @@
+wifi_config.h

--- a/config/custom/esp32_config.h
+++ b/config/custom/esp32_config.h
@@ -187,16 +187,31 @@ ROBOT ORIENTATION
   #define PWM_MIN -PWM_MAX
 #endif
 
-#define AGENT_IP { 192, 168, 1, 100 }  // eg IP of the desktop computer
-#define AGENT_PORT 8888
-#define WIFI_SSID "WIFI_SSID"
-#define WIFI_PASSWORD "WIFI_PASSWORD"
-// Enable WiFi with null terminated list of multiple APs SSID and password
-// #define WIFI_AP_LIST {{"WIFI_SSID", "WIFI_PASSWORD"}, {NULL}}
-#define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
+// Wifi network settings
+// Option 1: Enable WiFi by copying wifi_config.h.template in this directory
+// to wifi_config.h and filling in your wifi credentials and IP addresses.
+// wifi_config.h will be ignored by git, so your credentials will not be pushed to github,
+// and will be private to you. This is the recommended option.
+// Option 2: Enable WiFi below by filling in your wifi credentials and IP addresses.
+// WARNING: if you push this file to git, your credentials will be public!
+
+#if __has_include("wifi_config.h")
+  #include "wifi_config.h"
+#else
+  // Enable WiFi with null terminated list of multiple APs SSID and password
+  // #define WIFI_AP_LIST {{"WIFI_SSID", "WIFI_PASSWORD"}, {NULL}}
+  #define AGENT_IP { 192, 168, 1, 100 }
+  #define SYSLOG_SERVER { 192, 168, 1, 100 }
+  #define LIDAR_SERVER { 192, 168, 1, 100 }
+#endif
+
+// Uncomment the line below to enable Arduino OTA updates.
 // #define USE_ARDUINO_OTA
+// Uncomment the line below to enable syslog for debugging over wifi.
 // #define USE_SYSLOG
-#define SYSLOG_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
+
+#define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
+#define AGENT_PORT 8888
 #define SYSLOG_PORT 514
 #define DEVICE_HOSTNAME "esp32"
 #define APP_NAME "hardware"
@@ -205,7 +220,6 @@ ROBOT ORIENTATION
 // #define LIDAR_PWM 15
 #define LIDAR_SERIAL 1 // uart number
 #define LIDAR_BAUDRATE 230400
-#define LIDAR_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define LIDAR_PORT 8889
 #define BAUDRATE 921600
 #define SDA_PIN 21 // specify I2C pins

--- a/config/custom/esp32_wifi_config.h
+++ b/config/custom/esp32_wifi_config.h
@@ -189,14 +189,31 @@ ROBOT ORIENTATION
   #define PWM_MIN -PWM_MAX
 #endif
 
-#define AGENT_IP { 192, 168, 1, 100 }  // eg IP of the desktop computer
-#define AGENT_PORT 8888
-// Enable WiFi with null terminated list of multiple APs SSID and password
-#define WIFI_AP_LIST {{"wifi_ssid", "wifi_passwd"}, {NULL}}
+// Wifi network settings
+// Option 1: Enable WiFi by copying wifi_config.h.template in this directory
+// to wifi_config.h and filling in your wifi credentials and IP addresses.
+// wifi_config.h will be ignored by git, so your credentials will not be pushed to github,
+// and will be private to you. This is the recommended option.
+// Option 2: Enable WiFi below by filling in your wifi credentials and IP addresses.
+// WARNING: if you push this file to git, your credentials will be public!
+
+#if __has_include("wifi_config.h")
+  #include "wifi_config.h"
+#else
+  // Enable WiFi with null terminated list of multiple APs SSID and password
+  // #define WIFI_AP_LIST {{"WIFI_SSID", "WIFI_PASSWORD"}, {NULL}}
+  #define AGENT_IP { 192, 168, 1, 100 }  // home wifi
+  #define SYSLOG_SERVER { 192, 168, 1, 100 }
+  #define LIDAR_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
+#endif
+
+// Uncomment the line below to enable Arduino OTA updates.
+// #define USE_ARDUINO_OTA
+// Uncomment the line below to enable syslog for debugging over wifi.
+// #define USE_SYSLOG
+
 #define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
-#define USE_ARDUINO_OTA
-#define USE_SYSLOG
-#define SYSLOG_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
+#define AGENT_PORT 8888
 #define SYSLOG_PORT 514
 #define DEVICE_HOSTNAME "esp32_wifi"
 #define APP_NAME "hardware"
@@ -204,7 +221,6 @@ ROBOT ORIENTATION
 #define LIDAR_RXD 14
 #define LIDAR_SERIAL 1 // uart number
 #define LIDAR_BAUDRATE 230400
-#define LIDAR_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define LIDAR_PORT 8889
 #define BAUDRATE 921600
 #define SDA_PIN 21 // specify I2C pins

--- a/config/custom/wifi_config.h.template
+++ b/config/custom/wifi_config.h.template
@@ -1,0 +1,10 @@
+// Wifi network settings
+// Copy this file to wifi_config.h and edit the settings for your wifi network
+// and ROS2 linux computer IP address
+
+// Enable WiFi with null terminated list of multiple APs SSID and password
+// and set IP of the ROS2 linux computer for the various services
+#define WIFI_AP_LIST {{"WIFI_SSID", "WIFI_PASSWORD"}, {NULL}}
+#define AGENT_IP { 192, 168, 1, 100 }
+#define SYSLOG_SERVER { 192, 168, 1, 100 }
+#define LIDAR_SERVER { 192, 168, 1, 100 }

--- a/test_motors/platformio.ini
+++ b/test_motors/platformio.ini
@@ -1,0 +1,7 @@
+[platformio]
+extra_configs =
+    ../firmware/platformio.ini
+
+[env]
+lib_extra_dirs =
+    ../firmware/lib

--- a/test_motors/src/firmware.cpp
+++ b/test_motors/src/firmware.cpp
@@ -1,0 +1,182 @@
+// Copyright (c) 2021 Juan Miguel Jimeno
+// Copyright (c) 2023 Thomas Chou
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <Arduino.h>
+#include <micro_ros_platformio.h>
+#include <stdio.h>
+#include <i2cdetect.h>
+
+#include <nav_msgs/msg/odometry.h>
+#include <sensor_msgs/msg/imu.h>
+#include <sensor_msgs/msg/magnetic_field.h>
+#include <sensor_msgs/msg/battery_state.h>
+#include <sensor_msgs/msg/range.h>
+#include <geometry_msgs/msg/twist.h>
+#include <geometry_msgs/msg/vector3.h>
+
+#include "config.h"
+#include "syslog.h"
+#include "motor.h"
+#include "kinematics.h"
+#include "pid.h"
+#include "odometry.h"
+#include "imu.h"
+#include "mag.h"
+#define ENCODER_USE_INTERRUPTS
+#define ENCODER_OPTIMIZE_INTERRUPTS
+#include "encoder.h"
+#include "battery.h"
+#include "range.h"
+#include "lidar.h"
+#include "wifis.h"
+#include "ota.h"
+#include "pwm.h"
+
+#ifndef BAUDRATE
+#define BAUDRATE 115200
+#endif
+
+nav_msgs__msg__Odometry odom_msg;
+sensor_msgs__msg__Imu imu_msg;
+sensor_msgs__msg__MagneticField mag_msg;
+geometry_msgs__msg__Twist twist_msg;
+sensor_msgs__msg__BatteryState battery_msg;
+sensor_msgs__msg__Range range_msg;
+
+void setLed(int value)
+{
+#ifdef LED_PIN
+    digitalWrite(LED_PIN, value);
+#endif
+}
+
+int getLed(void)
+{
+#ifdef LED_PIN
+    return digitalRead(LED_PIN);
+#else
+    return 0;
+#endif
+}
+
+void initLed(void)
+{
+#ifdef LED_PIN
+    pinMode(LED_PIN, OUTPUT);
+#endif
+}
+
+Encoder motor1_encoder(MOTOR1_ENCODER_A, MOTOR1_ENCODER_B, COUNTS_PER_REV1, MOTOR1_ENCODER_INV);
+Encoder motor2_encoder(MOTOR2_ENCODER_A, MOTOR2_ENCODER_B, COUNTS_PER_REV2, MOTOR2_ENCODER_INV);
+Encoder motor3_encoder(MOTOR3_ENCODER_A, MOTOR3_ENCODER_B, COUNTS_PER_REV3, MOTOR3_ENCODER_INV);
+Encoder motor4_encoder(MOTOR4_ENCODER_A, MOTOR4_ENCODER_B, COUNTS_PER_REV4, MOTOR4_ENCODER_INV);
+
+Motor motor1_controller(PWM_FREQUENCY, PWM_BITS, MOTOR1_INV, MOTOR1_PWM, MOTOR1_IN_A, MOTOR1_IN_B);
+Motor motor2_controller(PWM_FREQUENCY, PWM_BITS, MOTOR2_INV, MOTOR2_PWM, MOTOR2_IN_A, MOTOR2_IN_B);
+Motor motor3_controller(PWM_FREQUENCY, PWM_BITS, MOTOR3_INV, MOTOR3_PWM, MOTOR3_IN_A, MOTOR3_IN_B);
+Motor motor4_controller(PWM_FREQUENCY, PWM_BITS, MOTOR4_INV, MOTOR4_PWM, MOTOR4_IN_A, MOTOR4_IN_B);
+
+PID motor1_pid(PWM_MIN, PWM_MAX, K_P, K_I, K_D);
+PID motor2_pid(PWM_MIN, PWM_MAX, K_P, K_I, K_D);
+PID motor3_pid(PWM_MIN, PWM_MAX, K_P, K_I, K_D);
+PID motor4_pid(PWM_MIN, PWM_MAX, K_P, K_I, K_D);
+
+Odometry odometry;
+IMU imu;
+MAG mag;
+unsigned total_motors = 4;
+
+void setup()
+{
+    Serial.begin(BAUDRATE);
+    initLed();
+#ifdef BOARD_INIT // board specific setup
+    BOARD_INIT;
+#endif
+
+    initWifis();
+    initOta();
+    i2cdetect();  // default range from 0x03 to 0x77
+    initPwm();
+    motor1_controller.begin();
+    motor2_controller.begin();
+    motor3_controller.begin();
+    motor4_controller.begin();
+    imu.init();
+    mag.init();
+    initBattery();
+    initRange();
+
+    if(Kinematics::LINO_BASE == Kinematics::DIFFERENTIAL_DRIVE)
+    {
+        total_motors = 2;
+    }
+    motor1_encoder.getRPM();
+    motor2_encoder.getRPM();
+    motor3_encoder.getRPM();
+    motor4_encoder.getRPM();
+
+#ifdef BOARD_INIT_LATE // board specific setup
+    BOARD_INIT_LATE;
+#endif
+    syslog(LOG_INFO, "%s Ready %lu", __FUNCTION__, millis());
+}
+
+void loop() {
+    static unsigned tk = 0; // tick
+    const unsigned run_time = 8; // run time of each motor
+    const unsigned cycle = run_time * total_motors;
+    unsigned current_motor = tk / run_time % total_motors;
+    unsigned direction = tk / cycle % 2; // 0 forward, 1 reverse
+    const int pwm_max = (1 << PWM_BITS) - 1;
+    static float max_rpm, stopping;
+
+    setLed(direction ? LOW : HIGH);
+    motor1_controller.spin((current_motor == 0) ? (direction ? -pwm_max : pwm_max) : 0);
+    motor2_controller.spin((current_motor == 1) ? (direction ? -pwm_max : pwm_max) : 0);
+    motor3_controller.spin((current_motor == 2) ? (direction ? -pwm_max : pwm_max) : 0);
+    motor4_controller.spin((current_motor == 3) ? (direction ? -pwm_max : pwm_max) : 0);
+
+    delay(1000);
+    float current_rpm1 = motor1_encoder.getRPM();
+    float current_rpm2 = motor2_encoder.getRPM();
+    float current_rpm3 = motor3_encoder.getRPM();
+    float current_rpm4 = motor4_encoder.getRPM();
+    if (current_motor == 0 && tk % run_time == run_time - 1) max_rpm = current_rpm1;
+    if (current_motor == 1 && tk % run_time == 0) stopping = current_rpm1;
+    if (current_motor == 1 && tk % run_time == run_time - 1) max_rpm = current_rpm2;
+    if (total_motors == 2 && current_motor == 0 && tk % run_time == 0) stopping = current_rpm2;
+    if (current_motor == 2 && tk % run_time == 0) stopping = current_rpm2;
+    if (current_motor == 2 && tk % run_time == run_time - 1) max_rpm = current_rpm3;
+    if (current_motor == 3 && tk % run_time == 0) stopping = current_rpm3;
+    if (current_motor == 3 && tk % run_time == run_time - 1) max_rpm = current_rpm4;
+    if (total_motors == 4 && current_motor == 0 && tk % run_time == 0) stopping = current_rpm4;
+    if (tk && tk % run_time == 0) {
+        float max_linear_speed = max_rpm / 60.0 * PI * WHEEL_DIAMETER; // m/s = rps * circumference
+
+        Serial.printf("MOTOR%d SPEED %6.2f m/s STOP %6.3f m\n", current_motor ? current_motor : total_motors,
+	       max_linear_speed, max_linear_speed * stopping / max_rpm);
+        syslog(LOG_INFO, "MOTOR%d SPEED %6.2f m/s STOP %6.3f m\n", current_motor ? current_motor : total_motors,
+	       max_linear_speed, max_linear_speed * stopping / max_rpm);
+    }
+    Serial.printf("MOTOR%d %s RPM %8.1f %8.1f %8.1f %8.1f\n",
+	   current_motor + 1, direction ? "REV" : "FWD",
+	   current_rpm1, current_rpm2, current_rpm3, current_rpm4);
+    syslog(LOG_INFO, "MOTOR%d %s RPM %8.1f %8.1f %8.1f %8.1f\n",
+	   current_motor + 1, direction ? "REV" : "FWD",
+	   current_rpm1, current_rpm2, current_rpm3, current_rpm4);
+    tk++;
+    runWifis();
+    runOta();
+}

--- a/test_motors/src/firmware.cpp
+++ b/test_motors/src/firmware.cpp
@@ -36,12 +36,9 @@
 #define ENCODER_USE_INTERRUPTS
 #define ENCODER_OPTIMIZE_INTERRUPTS
 #include "encoder.h"
-#include "battery.h"
-#include "range.h"
 #include "lidar.h"
 #include "wifis.h"
 #include "ota.h"
-#include "pwm.h"
 
 #ifndef BAUDRATE
 #define BAUDRATE 115200
@@ -108,15 +105,8 @@ void setup()
     initWifis();
     initOta();
     i2cdetect();  // default range from 0x03 to 0x77
-    initPwm();
-    motor1_controller.begin();
-    motor2_controller.begin();
-    motor3_controller.begin();
-    motor4_controller.begin();
     imu.init();
     mag.init();
-    initBattery();
-    initRange();
 
     if(Kinematics::LINO_BASE == Kinematics::DIFFERENTIAL_DRIVE)
     {


### PR DESCRIPTION
Enhance wifi configuration security in config files by removing wifi credentials and workstation IP from config files and putting them in a file that's #included if it exists. This means users can push their config files to their github fork without sending their wifi credentials with it. Separating wifi config from robot config also means teams of users can use the same robot config while retaining individual wifi configs.