### PR TITLE
Upstream pr/test motors

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,26 @@ The micro-ROS wifi transport is selected with a setting in firmare/platformio.in
 
     board_microros_transport = wifi
 
+## Motor Diagnostics Utility (`test_motors`)
+
+The `test_motors` standalone firmware utility tests each motor sequentially, verifies encoder direction and counts per revolution (CPR), and measures maximum linear speed ($m/s$) and stopping distance.
+
+```bash
+cd linorobot2_hardware/test_motors
+pio run -e <your_board> -t upload
+```
+
+Supported board environments: `pico`, `pico2`, `esp32`, `esp32s2`, `esp32s3`, `gendrv`.
+
+When flashed, the firmware spins each motor forward and in reverse for a controlled cycle, printing real-time RPM, max linear velocity, and calculated stopping distance via Serial (`115200` baud) and Syslog:
+
+```text
+MOTOR1 FWD RPM    280.5      0.0      0.0      0.0
+MOTOR1 SPEED   0.45 m/s STOP  0.035 m
+```
+
+---
+
 ## Calibration
 Before proceeding, **ensure that your robot is elevated and the wheels aren't touching the ground**. 
 5.1

--- a/test_motors/src/firmware.cpp
+++ b/test_motors/src/firmware.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2021 Juan Miguel Jimeno
-// Copyright (c) 2023 Thomas Chou
+// Copyright (c) 2026 Thomas Chou
+// Copyright (c) 2026 Linorobot contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test_motors/src/firmware.cpp
+++ b/test_motors/src/firmware.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2026 Thomas Chou
+// Copyright (c) 2026 Paul Bouchier
 // Copyright (c) 2026 Linorobot contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## 📋 Summary
Introduces the standalone `test_motors` diagnostic utility to test motor rotation, verify encoder counts per revolution (CPR) and direction inversion, and measure real-time linear speed ($m/s$) and stopping distance before running full navigation stacks.

---

## ✨ Key Features
- **Sequential Motor Testing**: Automatically tests each motor individually forward and in reverse for a controlled 8-second cycle at configured test speeds.
- **CPR & Direction Verification**: Confirms positive encoder counts during forward rotation and valid CPR reporting.
- **Stopping Distance Profiler**: Measures deceleration dynamics and calculates stopping distance based on encoder tick decay.
- **Network Telemetry & OTA**: Real-time logging via USB Serial (`115200` baud) and Syslog with wireless ArduinoOTA update support.
- **Inherited Configuration**: Uses `extra_configs = ../firmware/platformio.ini` for zero-redundancy configuration sharing.
- **Documentation**: Documented usage and build commands in `README.md`.

---

## 🧪 Verification & Build Status
Verified 100% build pass across all supported MCU targets on ROS 2 Jazzy:
- `pico` & `pico2` (RP2040 / RP2350) ➔ **SUCCESS**
- `esp32` & `esp32s3` ➔ **SUCCESS**
- `gendrv` (ESP32 Robot Driver) ➔ **SUCCESS**

---

## 👥 Co-authors & Contributors
- Thomas Chou
- Paul Bouchier (@PaulBouchier)
- Linorobot contributors
