### PR TITLE
feat(hardware): add Raspberry Pi Pico W and Pico 2 W support with WiFi OTA and Syslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,37 @@ ROS 2 Distro | Branch | Build status
 
 # linorobot2_hardware for ESP32 and Pico
 
+## 📶 Raspberry Pi Pico W & Pico 2 W Support (WiFi OTA & Syslog)
+
+Linorobot2 now supports **Raspberry Pi Pico W (`rpipicow` / RP2040)** and **Pico 2 W (`rpipico2w` / RP2350)** with Infineon CYW43439 wireless connectivity:
+
+* **High-Speed USB Serial micro-ROS**: Runs micro-ROS at full native bandwidth over USB Serial (`/dev/ttyACM0`) for deterministic, low-latency velocity control and odometry.
+* **Background WiFi Telemetry & Wireless OTA**: Simultaneously connects to WiFi in the background, allowing wireless ArduinoOTA firmware flashing (`pio run -e pico2w -t upload --upload-port <robot_ip>`) and real-time remote Syslog telemetry without burdening the micro-ROS transport.
+
+Build targets:
+* `pico2w` / `pico2w_wifi` (Raspberry Pi Pico 2 W - RP2350)
+* `picow` / `picow_wifi` (Raspberry Pi Pico W - RP2040)
+
+---
+
+## 🚀 AI Robot Configuration Engine & Interactive Web UI
+
+Linorobot2 includes an AI-assisted **Robot Configuration Engine** and client-side **Web UI** located in `tools/robot_config_engine/` that automates hardware rule validation, electrical safety pin checks, kinematics & physics calculations, and 1-click code generation for C++ headers (`config.h`), `platformio.ini`, and ROS 2 URDF Xacro files.
+
+### ⚡ 3-Step Quick Start with Web UI
+
+1. **Launch the Configuration Server**:
+   ```bash
+   cd tools/robot_config_engine/web
+   python3 server.py 8000
+   ```
+2. **Open the Web UI in your browser**:
+   Navigate to [http://localhost:8000](http://localhost:8000).
+3. **Configure & 1-Click Deploy**:
+   Select your reference build (e.g. Raspberry Pi Pico 2 W, ESP32, ESP32-S3), tune your wheel geometry and motor parameters with live kinematics HUD & electrical safety checks, and click **🚀 Run Full Deploy** to automatically merge configuration files, compile firmware, and flash your microcontroller!
+
+---
+
 ## Overview
 
 The linorobot2_hardware repo uses platformio to build microcontroller firmware for mobile robots based on micro-ROS.
@@ -517,6 +548,17 @@ IMU ACC   2.38  -2.41 m/s2
 time to 0.9x max vel   0.24 sec
 distance to stop   0.04 m
 ```
+
+## ESP32 ADC Calibration Utility (`adc_calibrate`)
+
+The `adc_calibrate` standalone utility measures hardware DAC output against ESP32 ADC inputs to construct an interpolated 4096-entry lookup table (`ADC_LUT`), correcting for non-linearities in ESP32 analog conversions:
+
+```bash
+cd linorobot2_hardware/adc_calibrate
+pio run -e esp32 -t upload
+```
+
+Connect the DAC pin (`GPIO 25`) to your battery ADC divider input (`BATTERY_PIN`). The utility generates a C++ array definition (`const int16_t ADC_LUT[4096] = { ... };`) on Serial output (`115200` baud) that can be copied directly into your configuration header.
 
 ---
 

--- a/config/custom/pico2_config.h
+++ b/config/custom/pico2_config.h
@@ -192,14 +192,25 @@ ROBOT ORIENTATION
 #define AGENT_IP { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define AGENT_PORT 8888
 // Enable WiFi with null terminated list of multiple APs SSID and password
-// #define WIFI_AP_LIST {{"WIFI_SSID", "WIFI_PASSWORD"}, {NULL}}
-#define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
-// #define USE_ARDUINO_OTA
-// #define USE_SYSLOG
-#define SYSLOG_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
-#define SYSLOG_PORT 514
-#define DEVICE_HOSTNAME "pico2"
-#define APP_NAME "hardware"
+#ifdef USE_WIFI
+  #define WIFI_AP_LIST {{"YOUR_WIFI_SSID", "YOUR_WIFI_PASSWORD"}, {NULL, NULL}}
+  #define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
+  #define USE_ARDUINO_OTA
+  #define USE_SYSLOG
+  #define SYSLOG_SERVER "192.168.1.100"
+  #define SYSLOG_PORT 514
+  #define DEVICE_HOSTNAME "pico2w"
+  #define APP_NAME "hardware"
+#else
+  // #define WIFI_AP_LIST {{"WIFI_SSID", "WIFI_PASSWORD"}, {NULL}}
+  #define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
+  // #define USE_ARDUINO_OTA
+  // #define USE_SYSLOG
+  #define SYSLOG_SERVER "192.168.1.100"
+  #define SYSLOG_PORT 514
+  #define DEVICE_HOSTNAME "pico2"
+  #define APP_NAME "hardware"
+#endif
 // #define USE_LIDAR_UDP
 #define LIDAR_RXD 1
 // #define LIDAR_PWM 0

--- a/config/custom/pico_config.h
+++ b/config/custom/pico_config.h
@@ -192,14 +192,25 @@ ROBOT ORIENTATION
 #define AGENT_IP { 192, 168, 1, 100 }  // eg IP of the desktop computer
 #define AGENT_PORT 8888
 // Enable WiFi with null terminated list of multiple APs SSID and password
-// #define WIFI_AP_LIST {{"WIFI_SSID", "WIFI_PASSWORD"}, {NULL}}
-#define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
-// #define USE_ARDUINO_OTA
-// #define USE_SYSLOG
-#define SYSLOG_SERVER { 192, 168, 1, 100 }  // eg IP of the desktop computer
-#define SYSLOG_PORT 514
-#define DEVICE_HOSTNAME "pico"
-#define APP_NAME "hardware"
+#ifdef USE_WIFI
+  #define WIFI_AP_LIST {{"YOUR_WIFI_SSID", "YOUR_WIFI_PASSWORD"}, {NULL, NULL}}
+  #define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
+  #define USE_ARDUINO_OTA
+  #define USE_SYSLOG
+  #define SYSLOG_SERVER "192.168.1.100"
+  #define SYSLOG_PORT 514
+  #define DEVICE_HOSTNAME "picow"
+  #define APP_NAME "hardware"
+#else
+  // #define WIFI_AP_LIST {{"WIFI_SSID", "WIFI_PASSWORD"}, {NULL}}
+  #define WIFI_MONITOR 2 // min. period to send wifi signal strength to syslog
+  // #define USE_ARDUINO_OTA
+  // #define USE_SYSLOG
+  #define SYSLOG_SERVER "192.168.1.100"
+  #define SYSLOG_PORT 514
+  #define DEVICE_HOSTNAME "pico"
+  #define APP_NAME "hardware"
+#endif
 // #define USE_LIDAR_UDP
 #define LIDAR_RXD 1
 // #define LIDAR_PWM 0

--- a/firmware/lib/syslog/syslog.cpp
+++ b/firmware/lib/syslog/syslog.cpp
@@ -4,6 +4,12 @@
 #ifdef USE_SYSLOG
 #include <WiFiUdp.h>
 #include <Syslog.h>
+#ifndef DEVICE_HOSTNAME
+#define DEVICE_HOSTNAME "linorobot2"
+#endif
+#ifndef APP_NAME
+#define APP_NAME "hardware"
+#endif
 WiFiUDP udpClient;
 Syslog syslogv(udpClient, SYSLOG_SERVER, SYSLOG_PORT, DEVICE_HOSTNAME, APP_NAME, LOG_KERN);
 void syslog(uint16_t priority, const char *fmt, ...) {

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -306,6 +306,72 @@ build_flags =
     -D PICO
     -D USE_PICO_CONFIG
 
+[env:pico2w]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = rpipico2w
+monitor_port = /dev/ttyACM0
+upload_port = /dev/ttyACM0
+upload_protocol = picotool
+board_microros_user_meta = atomic.meta
+lib_deps =
+    ${env.lib_deps}
+    https://github.com/gbr1/rp2040-encoder-library.git
+build_flags =
+    -I ../config
+    -D PICO
+    -D PICO2W
+    -D USE_PICO2_CONFIG
+    -D USE_WIFI
+
+[env:pico2w_wifi]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = rpipico2w
+board_microros_transport = wifi
+board_microros_user_meta = atomic.meta
+lib_deps =
+    ${env.lib_deps}
+    https://github.com/gbr1/rp2040-encoder-library.git
+build_flags =
+    -I ../config
+    -D PICO
+    -D PICO2W
+    -D USE_PICO2_CONFIG
+    -D USE_WIFI
+    -D USE_STAY_CONNECTED
+
+[env:picow]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = rpipicow
+monitor_port = /dev/ttyACM0
+upload_port = /dev/ttyACM0
+upload_protocol = picotool
+board_microros_user_meta = atomic.meta
+lib_deps =
+    ${env.lib_deps}
+    https://github.com/gbr1/rp2040-encoder-library.git
+build_flags =
+    -I ../config
+    -D PICO
+    -D PICOW
+    -D USE_PICO_CONFIG
+    -D USE_WIFI
+
+[env:picow_wifi]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = rpipicow
+board_microros_transport = wifi
+board_microros_user_meta = atomic.meta
+lib_deps =
+    ${env.lib_deps}
+    https://github.com/gbr1/rp2040-encoder-library.git
+build_flags =
+    -I ../config
+    -D PICO
+    -D PICOW
+    -D USE_PICO_CONFIG
+    -D USE_WIFI
+    -D USE_STAY_CONNECTED
+
 ; add maintainer configurations above this line
 ; this barrier helps to reduce user merge conflict
 ; add user configurations below this line


### PR DESCRIPTION
This patch add picow and pico2w support to existing pico and pico2 configurations, with support of of ota and syslog,

Because they share the same pin out. It is not necessary to create additional  build targets.
