### PR TITLE
feat(build): update micro_ros_platformio library repository and CI environment

### DIFF
--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -26,6 +26,8 @@ jobs:
   build-tools:
     name: Build Diagnostics & Tools on ROS ${{ inputs.ros_distro }}
     runs-on: ${{ inputs.os }}
+    env:
+      ROS_DISTRO: ${{ inputs.ros_distro }}
 
     steps:
       # Check out the repository
@@ -99,6 +101,7 @@ jobs:
       - name: Build ADC Calibration (adc_calibrate)
         shell: bash
         run: |
+          source /opt/ros/${{ inputs.ros_distro }}/setup.bash
           export PATH=$PATH:~/.platformio/penv/bin
           if [ -d "repo/adc_calibrate" ]; then
             cd repo/adc_calibrate

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -14,7 +14,7 @@ upload_port = /dev/ttyACM0
 upload_protocol = teensy-cli
 board_microros_transport = serial # or wifi
 board_microros_distro = ${sysenv.ROS_DISTRO}
-lib_deps = https://github.com/micro-ROS/micro_ros_platformio
+lib_deps = https://github.com/hippo5329/micro_ros_platformio
     mcauser/i2cdetect
     jrowberg/I2Cdevlib-Core
     jrowberg/I2Cdevlib-ADXL345


### PR DESCRIPTION
Update `micro_ros_platformio` library dependency to `https://github.com/hippo5329/micro_ros_platformio` to enable multi-distro micro-ROS support across ROS 2 distributions (Humble, Jazzy, Lyrical, Rolling).

Also defines `ROS_DISTRO` in `.github/workflows/reusable-platformio-ci.yml` for the `build-tools` job and `adc_calibrate` step to ensure diagnostics and calibration tools build cleanly in CI.