### PR TITLE
Jazzy pr159 patch1 rolling support

### DIFF
--- a/firmware/src/firmware.ino
+++ b/firmware/src/firmware.ino
@@ -336,15 +336,13 @@ bool createEntities()
         TOPIC_PREFIX "cmd_vel"
     ));
     // create timer for actuating the motors at 50 Hz (1000/20)
-    // Deprecation Note: rclc_timer_init_default is retained for multi-distro compatibility with ROS 2 Humble
-    // (rclc_timer_init_default2 was introduced in Jazzy). (rcl_timer_callback_t) cast satisfies stricter
-    // callback signatures in Rolling. This commit should be reverted on May 2027 upon Humble End-of-Life.
     const unsigned int control_timeout = 20;
-    RCCHECK(rclc_timer_init_default( 
+    RCCHECK(rclc_timer_init_default2( 
         &control_timer, 
         &support,
         RCL_MS_TO_NS(control_timeout),
-        (rcl_timer_callback_t) controlCallback
+        (rcl_timer_callback_t) controlCallback,
+        true
     ));
     executor = rclc_executor_get_zero_initialized_executor();
     RCCHECK(rclc_executor_init(&executor, &support.context, 2, & allocator));

--- a/firmware/src/firmware.ino
+++ b/firmware/src/firmware.ino
@@ -336,13 +336,15 @@ bool createEntities()
         TOPIC_PREFIX "cmd_vel"
     ));
     // create timer for actuating the motors at 50 Hz (1000/20)
+    // Deprecation Note: rclc_timer_init_default is retained for multi-distro compatibility with ROS 2 Humble
+    // (rclc_timer_init_default2 was introduced in Jazzy). (rcl_timer_callback_t) cast satisfies stricter
+    // callback signatures in Rolling. This commit should be reverted on May 2027 upon Humble End-of-Life.
     const unsigned int control_timeout = 20;
-    RCCHECK(rclc_timer_init_default2( 
+    RCCHECK(rclc_timer_init_default( 
         &control_timer, 
         &support,
         RCL_MS_TO_NS(control_timeout),
-        controlCallback,
-        true
+        (rcl_timer_callback_t) controlCallback
     ));
     executor = rclc_executor_get_zero_initialized_executor();
     RCCHECK(rclc_executor_init(&executor, &support.context, 2, & allocator));


### PR DESCRIPTION
This is a change to patch 1 in PR159 done under consultation with @hippo5329 

- Add explicit cast (rcl_timer_callback_t) to callback argument to satisfy stricter timer callback signatures in ROS 2 Rolling.

Compared to patch 1 in PR #159 this merge does not support humble. This is because humble is what it is - it will not be brought up to jazzy level, because that would entail removing Teensy support (which anyone using this repo on humble would be running).