### PR TITLE
firmware: allow LED_PIN -1 to mean no addressable status LED

### DIFF
--- a/config/custom/gendrv_config.h
+++ b/config/custom/gendrv_config.h
@@ -15,7 +15,7 @@
 #ifndef GENDRV_CONFIG_H
 #define GENDRV_CONFIG_H
 
-#define LED_PIN LED_BUILTIN //used for debugging status
+#define LED_PIN -1 //no addressable status LED on the GenDrv board
 
 //uncomment the base you're building
 #define LINO_BASE DIFFERENTIAL_DRIVE       // 2WD and Tracked robot w/ 2 motors

--- a/firmware/src/firmware.ino
+++ b/firmware/src/firmware.ino
@@ -158,9 +158,53 @@ MAG mag;
 #define BAUDRATE 921600
 #endif
 
+// ---------------------------------------------------------------------------
+// LED helpers.
+//
+// Boards without an addressable status LED (e.g. Waveshare GenDrv) set
+// #define LED_PIN -1 in their config header. On such boards the helpers
+// compile to no-ops so no spurious GPIO is touched and nothing is written.
+//
+// The guard is positive (enabled when defined && >= 0). The preprocessor
+// folds integer constants in #if expressions:
+//   - #define LED_PIN 25      -> 25 >= 0  true  -> LED enabled
+//   - #define LED_PIN -1      -> -1 >= 0  false -> LED disabled (no wiring)
+//   - #define LED_PIN LED_BUILTIN -> LED_BUILTIN is a non-macro identifier
+//     (a static const in the core pins_arduino.h), so the preprocessor treats
+//     it as 0 -> 0 >= 0 true  -> LED enabled, and digitalWrite(LED_BUILTIN,..)
+//     still resolves to the core pin at link time.
+//   - LED_PIN undefined       -> disabled (no reference, safe to compile)
+// ---------------------------------------------------------------------------
+#if (defined(LED_PIN) && LED_PIN >= 0)
+#define LED_ENABLED 1
+#else
+#define LED_ENABLED 0
+#endif
+
+static inline void ledInit() {
+#if LED_ENABLED
+    pinMode(LED_PIN, OUTPUT);
+    digitalWrite(LED_PIN, LOW);
+#endif
+}
+
+static inline void ledWrite(bool level) {
+#if LED_ENABLED
+    digitalWrite(LED_PIN, level ? HIGH : LOW);
+#endif
+}
+
+static inline bool ledRead() {
+#if LED_ENABLED
+    return digitalRead(LED_PIN) == HIGH;
+#else
+    return false;
+#endif
+}
+
 void setup() 
 {
-    pinMode(LED_PIN, OUTPUT);
+    ledInit();
     Serial.begin(BAUDRATE);
 #ifdef ESP32
     Serial.setRxBufferSize(1024);
@@ -270,7 +314,7 @@ void controlCallback(rcl_timer_t * timer, int64_t last_call_time)
 
 void twistCallback(const void * msgin) 
 {
-    digitalWrite(LED_PIN, !digitalRead(LED_PIN));
+    ledWrite(!ledRead());
 
     prev_cmd_time = millis();
 }
@@ -357,7 +401,7 @@ bool createEntities()
 
     // synchronize time with the agent
     syncTime();
-    digitalWrite(LED_PIN, HIGH);
+    ledWrite(HIGH);
 
     return true;
 }
@@ -385,8 +429,8 @@ bool destroyEntities()
     RCSOFTCHECK(rcl_node_fini(&node))
     RCSOFTCHECK(rclc_support_fini(&support));
 
-    digitalWrite(LED_PIN, HIGH);
-    
+    ledWrite(HIGH);
+
     return true;
 }
 
@@ -411,7 +455,7 @@ void moveBase()
         twist_msg.linear.y = 0.0;
         twist_msg.angular.z = 0.0;
 
-        digitalWrite(LED_PIN, HIGH);
+        ledWrite(HIGH);
     }
     // get the required rpm for each motor based on required velocities, and base used
     Kinematics::rpm req_rpm = kinematics.getRPM(
@@ -563,9 +607,9 @@ void flashLED(int n_times)
 {
     for(int i=0; i<n_times; i++)
     {
-        digitalWrite(LED_PIN, HIGH);
+        ledWrite(HIGH);
         delay(150);
-        digitalWrite(LED_PIN, LOW);
+        ledWrite(LOW);
         delay(150);
     }
     delay(1000);

--- a/test_acc/src/firmware.cpp
+++ b/test_acc/src/firmware.cpp
@@ -85,7 +85,7 @@ unsigned total_motors = 4;
 void setup()
 {
     Serial.begin(BAUDRATE);
-#ifdef LED_PIN
+#if (defined(LED_PIN) && LED_PIN >= 0)
     pinMode(LED_PIN, OUTPUT);
 #endif
 #ifdef BOARD_INIT // board specific setup
@@ -211,7 +211,7 @@ void loop() {
         idx = 0;
         imu_max_acc_x = 0;
         imu_min_acc_x = 0;
-#ifdef LED_PIN
+#if (defined(LED_PIN) && LED_PIN >= 0)
         digitalWrite(LED_PIN, HIGH);
 #endif
         motor1_controller.spin((runs & 1) ? current_pwm_max : current_pwm_min);
@@ -220,7 +220,7 @@ void loop() {
         motor4_controller.spin(current_pwm_max);
         record(run_time / ticks);
 
-#ifdef LED_PIN
+#if (defined(LED_PIN) && LED_PIN >= 0)
         digitalWrite(LED_PIN, LOW);
 #endif
         motor1_controller.spin(0);
@@ -229,7 +229,7 @@ void loop() {
         motor4_controller.spin(0);
         record(run_time / ticks);
 
-#ifdef LED_PIN
+#if (defined(LED_PIN) && LED_PIN >= 0)
         digitalWrite(LED_PIN, HIGH);
 #endif
         motor1_controller.spin((runs & 1) ? current_pwm_min : current_pwm_max);
@@ -238,7 +238,7 @@ void loop() {
         motor4_controller.spin(current_pwm_min);
         record(run_time / ticks);
 
-#ifdef LED_PIN
+#if (defined(LED_PIN) && LED_PIN >= 0)
         digitalWrite(LED_PIN, LOW);
 #endif
         motor1_controller.spin(0);

--- a/test_motors/src/firmware.cpp
+++ b/test_motors/src/firmware.cpp
@@ -52,16 +52,22 @@ geometry_msgs__msg__Twist twist_msg;
 sensor_msgs__msg__BatteryState battery_msg;
 sensor_msgs__msg__Range range_msg;
 
+#if (defined(LED_PIN) && LED_PIN >= 0)
+#define LED_ENABLED 1
+#else
+#define LED_ENABLED 0
+#endif
+
 void setLed(int value)
 {
-#ifdef LED_PIN
+#if LED_ENABLED
     digitalWrite(LED_PIN, value);
 #endif
 }
 
 int getLed(void)
 {
-#ifdef LED_PIN
+#if LED_ENABLED
     return digitalRead(LED_PIN);
 #else
     return 0;
@@ -70,7 +76,7 @@ int getLed(void)
 
 void initLed(void)
 {
-#ifdef LED_PIN
+#if LED_ENABLED
     pinMode(LED_PIN, OUTPUT);
 #endif
 }


### PR DESCRIPTION
## What

Let a board config declare `#define LED_PIN -1` to mean "no addressable status LED", and compile out every LED write in the firmware so no spurious GPIO is touched.

The Waveshare General Driver board has no addressable status LED on its pin header, so the previous `#define LED_PIN LED_BUILTIN` in `config/custom/gendrv_config.h` was dead code (the ESP32 internal blue LED is not reachable there).

## Changes

- **`config/custom/gendrv_config.h`**: `LED_PIN LED_BUILTIN` → `LED_PIN -1`.
- **`firmware/src/firmware.ino`**: add `ledInit()` / `ledWrite()` / `ledRead()` helpers guarded by `#if (defined(LED_PIN) && LED_PIN >= 0)`, and route every `pinMode` / `digitalWrite` / `digitalRead` on `LED_PIN` through them.
- **`test_motors/`, `test_acc/`**: the same positive guard on the existing `#ifdef LED_PIN` sites.

`LED_BUILTIN` is a non-macro identifier (a `static const` in the core `pins_arduino.h`), so the preprocessor treats it as `0` in the `#if` — boards that use `LED_PIN LED_BUILTIN` keep the LED enabled and `digitalWrite` still resolves to the core pin at link time.

## Behaviour

| `LED_PIN` value | result |
| --- | --- |
| `25` | helper enabled |
| `-1` | helper disabled — no `pinMode` / `digitalWrite` emitted |
| `LED_BUILTIN` | helper enabled (core resolves at link time) |
| undefined | helper disabled (safe) |