### PR TITLE
tools: Robot Configuration Engine (browser studio + CLI) + i2c_detect

### DIFF
--- a/.github/workflows/config-engine-ci.yml
+++ b/.github/workflows/config-engine-ci.yml
@@ -1,0 +1,79 @@
+name: Robot Config Engine & i2c_detect CI
+
+# Standalone CI for the browser Robot Configuration Engine and the i2c_detect
+# scanner. Deliberately independent of the firmware / diagnostics build matrix:
+# it only runs the config-engine unit tests and a PlatformIO compile of
+# tools/i2c_detect, and only when files under tools/ (or this workflow) change.
+
+on:
+  pull_request:
+    paths:
+      - 'tools/robot_config_engine/**'
+      - 'tools/i2c_detect/**'
+      - '.github/workflows/config-engine-ci.yml'
+  push:
+    paths:
+      - 'tools/robot_config_engine/**'
+      - 'tools/i2c_detect/**'
+      - '.github/workflows/config-engine-ci.yml'
+  workflow_dispatch:
+
+jobs:
+  config-engine-tests:
+    name: Robot Config Engine unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run unit tests (stdlib only)
+        working-directory: tools/robot_config_engine
+        run: python3 -m unittest discover -v
+
+      - name: Generator / validator CLI smoke test
+        working-directory: tools/robot_config_engine
+        run: |
+          for spec in examples/*.json; do
+            echo "== $spec =="
+            python3 generate_config.py "$spec" > /dev/null
+          done
+
+      - name: Byte-compile all engine + server sources
+        working-directory: tools/robot_config_engine
+        run: python3 -m compileall -q .
+
+      - name: Web UI static asset sanity
+        working-directory: tools/robot_config_engine/web
+        run: |
+          test -f index.html && test -f app.js && test -f style.css && test -f server.py
+          # server.py must import cleanly without starting the listener
+          python3 -c "import ast; ast.parse(open('server.py').read())"
+          node --check app.js
+
+  i2c-detect-build:
+    name: Build tools/i2c_detect (PlatformIO)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: repo
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio-i2c-detect
+
+      - name: Install PlatformIO
+        uses: ./repo/.github/actions/platformio-env
+
+      - name: Compile i2c_detect for pico2 / esp32 / gendrv
+        shell: bash
+        working-directory: repo/tools/i2c_detect
+        run: |
+          export PATH=$PATH:~/.platformio/penv/bin
+          pio run -e pico2 -e esp32 -e gendrv

--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -156,6 +156,10 @@ jobs:
           PLATFORMIO_BUILD_FLAGS="-D USE_MPU9250_IMU -D USE_AK8963_MAG -D LINO_BASE=MECANUM -D USE_GENERIC_2_IN_MOTOR_DRIVER" pio run -e esp32s3
           echo "== Matrix 6: ESP32 WiFi with LiDAR UDP Forwarding =="
           PLATFORMIO_BUILD_FLAGS="-D USE_LIDAR_UDP" pio run -e esp32_wifi
+          echo "== Matrix 7: Pico 2 Bare Module Simulation (Fake Wheel + Fake LD19) =="
+          PLATFORMIO_BUILD_FLAGS="-D USE_FAKE_WHEEL -D USE_FAKE_LD19 -D FAKE_WALL_OBSTACLE=1" pio run -e pico2
+          echo "== Matrix 8: GenDrv Bare Module Simulation (Fake Wheel + Fake LD19) =="
+          PLATFORMIO_BUILD_FLAGS="-D USE_FAKE_WHEEL -D USE_FAKE_LD19 -D FAKE_WALL_OBSTACLE=1 -D BAUDRATE=1500000" pio run -e gendrv
 
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .pio
 .swp
 .vscode
+
+# Local workflow and engine state
+.workflow_settings.json
+config/custom/.*.json
+config/custom/*.json

--- a/README.md
+++ b/README.md
@@ -25,6 +25,44 @@ Supported targets:
 
 ---
 
+## Robot Configuration Engine & Web UI Studio
+
+`tools/robot_config_engine/` contains a browser-based configuration studio and a
+Python engine that generate a `linorobot2_hardware` setup from a guided form:
+hardware-rule validation, ADC divider / voltage safety checks, kinematics
+figures, and code generation for the C++ config header, the `[env:<robot>]`
+`platformio.ini` section, and the ROS 2 URDF xacro.
+
+### 3-step quick start
+
+1. **Start the server** (stdlib only, ~30-40 MB RAM):
+   ```bash
+   cd tools/robot_config_engine/web
+   python3 server.py 8000
+   ```
+2. **Open the studio** at `http://localhost:8000` (or `http://<robot-ip>:8000`
+   from another machine on the network).
+3. **Configure and deploy.** Pick a board or let it auto-detect from the USB
+   VID:PID, set wheel geometry, driver, sensors and pins with a live preview of
+   the generated code, then **Run Full Deploy** to merge the config, build the
+   firmware, flash the MCU and start `micro_ros_agent`.
+
+The generated `config/custom/<robot>_config.h` remains the single source of
+truth; WiFi credentials are written only to the git-ignored
+`config/custom/wifi_config.h`.
+
+There is also a CLI:
+
+```bash
+python3 tools/robot_config_engine/generate_config.py spec.json --out-dir ./out/
+python3 tools/robot_config_engine/generate_config.py spec.json --merge
+```
+
+See `tools/robot_config_engine/README.md` and `schema.json` for the spec format,
+and `examples/` for sample specs.
+
+---
+
 ## Overview
 
 The linorobot2_hardware repo uses platformio to build microcontroller firmware for mobile robots based on micro-ROS.
@@ -535,6 +573,34 @@ IMU ACC   2.38  -2.41 m/s2
 time to 0.9x max vel   0.24 sec
 distance to stop   0.04 m
 ```
+
+## I2C Sensor Scanner (`tools/i2c_detect`)
+
+`tools/i2c_detect/` is a small PlatformIO sketch that scans the I2C bus at
+400 kHz, probes `WHO_AM_I` / ID registers for the common robotics sensors, and
+prints the result (human-readable and as JSON) over serial. Use it to bring up a
+bare board before any sensor is configured.
+
+```bash
+cd tools/i2c_detect
+pio run -e <your_board> -t upload   # pico2 / pico / esp32 / esp32s3 / gendrv
+```
+
+Recognised signatures include: IMUs `QMI8658`, `MPU6050/9250/6500`,
+`BNO085/BNO080`, `BNO055`, `ADXL345`+`ITG3200` (GY-85); magnetometers `AK09918`,
+`AK8963/AK8975`, `QMC5883L`, `HMC5883L`; power monitors `INA219`/`INA226`
+(incl. the Waveshare GenDrv at `0x42`); barometers `BMP280`/`BME280`.
+
+In the Web UI studio, **Tab 3 → Auto-Detect Sensors** runs this probe and
+selects the matching drivers automatically.
+
+### UDP syslog viewer
+
+The studio server can also run a UDP syslog receiver for boards configured with
+wireless telemetry: `POST /api/syslog/start` (default port 514, falls back to
+5140 when unprivileged), `POST /api/syslog/stop`, `GET /api/syslog/status`,
+`GET /api/syslog/stream` (SSE), `GET /api/syslog/logs`. Received datagrams are
+streamed to the console and written to `logs/syslog_YYYYMMDD.log`.
 
 ## ESP32 ADC Calibration Utility (`adc_calibrate`)
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,91 @@ Micro-ROS over wifi is supported by the downstream hippo5329
 and [linorobot2_hardware](https://github.com/hippo5329/linorobot2_hardware)
 repos.
 
+---
+
+## Robot Configuration Engine & Web UI Studio
+
+`tools/robot_config_engine/` contains a browser-based configuration studio and a
+Python engine that generate a `linorobot2_hardware` setup from a guided form:
+hardware-rule validation, ADC divider / voltage safety checks, kinematics
+figures, and code generation for the C++ config header, the `[env:<robot>]`
+`platformio.ini` section, and the ROS 2 URDF xacro.
+
+### 3-step quick start
+
+1. **Start the server** (stdlib only, ~30-40 MB RAM):
+   ```bash
+   cd tools/robot_config_engine/web
+   python3 server.py 8000
+   ```
+2. **Open the studio** at `http://localhost:8000` (or `http://<robot-ip>:8000`
+   from another machine on the network).
+3. **Configure and deploy.** Pick a board or let it auto-detect from the USB
+   VID:PID, set wheel geometry, driver, sensors and pins with a live preview of
+   the generated code, then **Run Full Deploy** to merge the config, build the
+   firmware, flash the MCU and start `micro_ros_agent`.
+
+The generated `config/custom/<robot>_config.h` remains the single source of
+truth; WiFi credentials are written only to the git-ignored
+`config/custom/wifi_config.h`.
+
+### Start with a simulated robot, before you wire anything
+
+You do not need motors, encoders or a LiDAR to get a robot driving and mapping.
+Every reference build starts in **simulation mode**, and two designs are set up
+for a board sitting on a desk with nothing attached to it:
+
+| Reference build | Transport | Gives you |
+| :--- | :--- | :--- |
+| **Simulated Robot · Waveshare GenDrv** | USB serial | Simulated wheels + simulated LD19 scan over the LiDAR UART |
+| **Simulated Robot · ESP32** | WiFi + LiDAR UDP | The same, with the scan delivered over WiFi UDP — no LiDAR pin or cable at all |
+
+The firmware simulates the drivetrain (`USE_FAKE_WHEEL`) and the LiDAR
+(`USE_FAKE_LD19`): `cmd_vel` drives modelled wheels whose encoders report back
+through the real PID, and a raycaster produces a `/scan` of a simple room. So
+`/odom/unfiltered`, `/imu/data` and `/scan` all behave like a real robot.
+
+The simulated scan reaches ROS 2 one of two ways. Over **WiFi UDP** it needs no
+wiring at all. Over **serial** it is transmitted as ordinary LD19 packets from
+the `LIDAR_RXD` pin — the same line a real LD19 would feed in on — so read it
+with a USB-TTL adapter on that pin. The studio warns you if fake LD19 is on with
+neither route configured, because the firmware would run happily and never
+publish a scan.
+
+Flash one of these, then open the **[Linorobot2
+Console](https://github.com/linorobot/linorobot2)** on the robot computer and go
+straight to **teleop, SLAM and Nav2** — drive it with the on-screen virtual
+gamepad, watch it in the Teleop RViz view, build a map and save it. Nothing is
+wired, and the whole ROS 2 stack is exercised end to end.
+
+That gives you a working baseline before hardware is involved, so when a real
+motor later misbehaves you already know the software side is sound.
+
+> [!WARNING]
+> **Turn simulation off before flashing a real robot.** A simulated config looks
+> completely normal from the outside and publishes plausible topics, so a wired
+> robot flashed with it will sit still while `/odom` insists it is driving.
+> Untick **Fake wheel mode** and **Fake LD19 LiDAR Mode** in *Robot Geometry →
+> Simulation* (or press **Turn off simulation** in the orange banner) once the
+> drivetrain and LiDAR are actually connected. The generated header also carries
+> a `SIMULATION MODE IS ENABLED` warning while either is on.
+
+A newly detected module defaults to fake wheel mode for the same reason — a
+board that was just plugged in is rarely a wired robot yet. Your own choice is
+never overridden once you touch either simulation control.
+
+There is also a CLI:
+
+```bash
+python3 tools/robot_config_engine/generate_config.py spec.json --out-dir ./out/
+python3 tools/robot_config_engine/generate_config.py spec.json --merge
+```
+
+See `tools/robot_config_engine/README.md` and `schema.json` for the spec format,
+and `examples/` for sample specs.
+
+---
+
 ## Installation
 All software mentioned in this guide must be installed on the robot computer.
 
@@ -417,6 +502,100 @@ Constants' Meaning:
 
 - **PWM_FREQUENCY** - Frequency of the PWM signals used to control the motor drivers. You can use the default value if you're unsure what to put here. More info [here](https://www.pjrc.com/teensy/td_pulse.html).
 
+### FAKE WHEEL MODE (SIMULATED DRIVETRAIN)
+
+- **USE_FAKE_WHEEL** - Simulate the drivetrain on the board itself, so a bare module with no
+motors, drivers or encoders attached behaves like a robot. `cmd_vel` drives simulated wheels
+whose encoders report back to the PID, so `/odom/unfiltered` and `/imu/data` move as they would
+on real hardware and you can run teleop, SLAM or navigation against the board alone. Undefined by
+default; the motor drivers still receive their PWM, and the kinematics, PID and odometry are all
+still exercised.
+
+Each wheel is modelled as a DC motor driving a share of the robot's mass: driving torque falls
+off as back-EMF rises, acceleration is limited, friction opposes motion, and a stall band keeps a
+weak duty from creeping. So the wheels accelerate from rest, tail off near top speed, and coast
+down when power is cut, more slowly on a heavier robot. The reported RPM carries noise, which
+gives the PID real error to correct and makes the odometry drift as it does on hardware. The
+simulated IMU is derived from the same motion, so the accelerometer and gyroscope agree with the
+wheel encoders.
+
+        #define USE_FAKE_WHEEL
+
+Optional tuning, all with defaults:
+
+- **FAKE_ROBOT_MASS** - Simulated mass in kg. Defaults to `ROBOT_WEIGHT` when defined, so a
+heavier robot accelerates more slowly.
+- **FAKE_WHEEL_TAU_MS** - Spin-up time constant in milliseconds at the reference mass.
+- **FAKE_WHEEL_MAX_ACCEL_RPM** - Traction and current limit, in RPM per second.
+- **FAKE_WHEEL_FRICTION** - Viscous drag, as a fraction of the current RPM per second.
+- **FAKE_WHEEL_NOISE_RPM** - Peak encoder noise in RPM.
+- **FAKE_IMU_ACCEL_NOISE** / **FAKE_IMU_GYRO_NOISE** - Peak simulated IMU noise.
+
+Encoder pins still select which wheels exist: a motor whose encoder pins are unset stays at zero
+RPM, so a 2WD configuration simulates two wheels and not four.
+
+### FAKE LD19 LIDAR MODE (SIMULATED LASER)
+
+- **USE_FAKE_LD19** - Embeds a real-time, 2D geometric raycasting LiDAR emulator in the
+firmware. Raycasts against a configurable rectangular room and optional interior obstacle
+wall, outputting authentic 47-byte LDROBOT LD19 binary packets (`0x54 0x2C` header, 12 distance
+points, start/end angles, CRC8 checksum) at 10 Hz / 230,400 baud over `LIDAR_RXD` (or over Wi-Fi
+UDP port 8889 if `USE_LIDAR_UDP` is defined).
+
+When combined with `USE_FAKE_WHEEL`, the laser scan updates dynamically as the robot navigates
+in response to `cmd_vel`, allowing complete SLAM mapping, map saving, and Nav2 navigation on a
+bare module without physical motors, drivers or LiDAR.
+
+        #define USE_FAKE_LD19
+
+Optional room and obstacle parameters, all with defaults:
+
+- **FAKE_MAP_WIDTH** / **FAKE_MAP_HEIGHT** - Dimensions of the simulated boundary room in meters
+  (defaults: 6.0m x 4.0m, centered at origin).
+- **FAKE_WALL_OBSTACLE** - Set to 1 to enable the interior obstacle wall, 0 to disable (default: 1).
+- **FAKE_WALL_X1**, **FAKE_WALL_Y1**, **FAKE_WALL_X2**, **FAKE_WALL_Y2** - Coordinates of the obstacle
+  wall in meters (defaults: from (1.0, -0.8) to (1.0, 0.8), a 1.6m barrier positioned 1.0m ahead).
+- **LIDAR_RXD** - Microcontroller pin used to emit the packet stream (defaults to board LiDAR RXD pin).
+- **LIDAR_BAUDRATE** - Serial baud rate (default: 230400).
+
+#### Application: Waveshare GenDrv as a Self-Contained Fake Robot
+
+The Waveshare General Driver Board (`gendrv` ESP32) is ideal for fake robot bench testing because
+it includes two onboard USB serial bridges:
+- **Port 1 (`/dev/ttyUSB0`)**: micro-ROS high-speed serial transport @ 1.5M baud (`-D BAUDRATE=1500000`).
+- **Port 2 (`/dev/ttyUSB1`)**: LD19 LiDAR serial stream @ 230,400 baud (`LIDAR_BAUDRATE 230400`).
+
+With the same physical wiring as LiDAR UDP forwarding (GPIO 4 connected to the onboard second USB
+bridge RX, or streamed over Wi-Fi UDP), a bare GenDrv board acts as a complete simulated robot:
+
+1. **Dual-Channel Serial Mode (1.5M Baud)**:
+   - micro-ROS agent runs over USB serial at 1.5M baud:
+     ```bash
+     ros2 run micro_ros_agent micro_ros_agent serial --dev /dev/ttyUSB0 -b 1500000
+     ```
+   - Standard `ldlidar_stl_ros2` node connects to `/dev/ttyUSB1` @ 230,400 baud:
+     ```bash
+     ros2 run ldlidar_stl_ros2 ldlidar_stl_ros2_node --ros-args \
+       -p product_name:=LDLiDAR_LD19 -p port_name:=/dev/ttyUSB1 -p port_baudrate:=230400 \
+       -p frame_id:=laser -p topic_name:=scan
+     ```
+
+2. **Wireless Wi-Fi UDP Transport Mode**:
+   - micro-ROS bridges over Wi-Fi UDP to port 8888:
+     ```bash
+     ros2 run micro_ros_agent micro_ros_agent udp4 --port 8888
+     ```
+   - Fake LD19 streams batched UDP packets (141 bytes = 3 packets/frame) to port 8889:
+     ```bash
+     ros2 run ldlidar_stl_ros2 ldlidar_stl_ros2_node --ros-args \
+       -p product_name:=LDLiDAR_LD19 -p comm_mode:=udp_server \
+       -p server_ip:=0.0.0.0 -p server_port:=8889 \
+       -p frame_id:=laser -p topic_name:=scan
+     ```
+
+3. **Autonomous Navigation**:
+   Launch `slam_toolbox` or Nav2 directly on your workstation or robot SBC. Driving the fake robot via `/cmd_vel` advances odometry and updates the simulated laser scan against the room walls and barrier obstacle in real time.
+
 ### 2. Hardware Pin Assignments
 Only modify the pin assignments under the motor driver constant that you are using ie. `#ifdef USE_GENERIC_2_IN_MOTOR_DRIVER`. You can check out PJRC's [pinout page](https://www.pjrc.com/teensy/pinout.html) for each board's pin layout.
 
@@ -535,6 +714,34 @@ IMU ACC   2.38  -2.41 m/s2
 time to 0.9x max vel   0.24 sec
 distance to stop   0.04 m
 ```
+
+## I2C Sensor Scanner (`tools/i2c_detect`)
+
+`tools/i2c_detect/` is a small PlatformIO sketch that scans the I2C bus at
+400 kHz, probes `WHO_AM_I` / ID registers for the common robotics sensors, and
+prints the result (human-readable and as JSON) over serial. Use it to bring up a
+bare board before any sensor is configured.
+
+```bash
+cd tools/i2c_detect
+pio run -e <your_board> -t upload   # pico2 / pico / esp32 / esp32s3 / gendrv
+```
+
+Recognised signatures include: IMUs `QMI8658`, `MPU6050/9250/6500`,
+`BNO085/BNO080`, `BNO055`, `ADXL345`+`ITG3200` (GY-85); magnetometers `AK09918`,
+`AK8963/AK8975`, `QMC5883L`, `HMC5883L`; power monitors `INA219`/`INA226`
+(incl. the Waveshare GenDrv at `0x42`); barometers `BMP280`/`BME280`.
+
+In the Web UI studio, **Tab 3 → Auto-Detect Sensors** runs this probe and
+selects the matching drivers automatically.
+
+### UDP syslog server
+
+The studio server can also run a UDP syslog receiver for boards configured with
+wireless telemetry: `POST /api/syslog/start` (default port 514, falls back to
+5140 when unprivileged), `POST /api/syslog/stop`, `GET /api/syslog/status`,
+`GET /api/syslog/stream` (SSE), `GET /api/syslog/logs`. Received datagrams are
+streamed to the console and written to `logs/syslog_YYYYMMDD.log`.
 
 ## ESP32 ADC Calibration Utility (`adc_calibrate`)
 

--- a/config/custom/gendrv_config.h
+++ b/config/custom/gendrv_config.h
@@ -15,7 +15,7 @@
 #ifndef GENDRV_CONFIG_H
 #define GENDRV_CONFIG_H
 
-#define LED_PIN LED_BUILTIN //used for debugging status
+#define LED_PIN -1 //no addressable status LED on the GenDrv board
 
 //uncomment the base you're building
 #define LINO_BASE DIFFERENTIAL_DRIVE       // 2WD and Tracked robot w/ 2 motors

--- a/config/custom/gendrv_config.h
+++ b/config/custom/gendrv_config.h
@@ -12,7 +12,7 @@
 #ifndef GENDRV_CONFIG_H
 #define GENDRV_CONFIG_H
 
-#define LED_PIN LED_BUILTIN //used for debugging status
+#define LED_PIN -1 //no addressable status LED on the GenDrv board
 
 //uncomment the base you're building
 #define LINO_BASE DIFFERENTIAL_DRIVE       // 2WD and Tracked robot w/ 2 motors

--- a/firmware/lib/encoder/fake_wheel.h
+++ b/firmware/lib/encoder/fake_wheel.h
@@ -1,0 +1,403 @@
+// Copyright (c) 2021 Juan Miguel Jimeno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FAKE_WHEEL_H
+#define FAKE_WHEEL_H
+
+#include <Arduino.h>
+
+// Simulated drivetrain for a bare module with no motors or encoders attached.
+//
+// Each wheel is modelled as a DC motor driving a share of the robot's mass:
+//
+//   duty      = pwm / PWM_MAX                 commanded power
+//   no_load   = duty * MOTOR_MAX_RPM          speed the motor would settle at
+//   torque   ~= no_load - rpm                 back-EMF: torque falls as it spins up
+//   d(rpm)/dt = torque / tau_eff              tau_eff scales with robot mass
+//
+// so the wheel accelerates hard when the error is large, tails off as it
+// approaches speed, coasts down against friction when power is cut, and takes
+// longer to do all of it on a heavier robot. Acceleration is clamped to a
+// traction/current limit, and a stall band keeps a weak duty from creeping.
+// The reported RPM carries white noise, so the PID has something real to
+// correct against and the odometry drifts the way it does on real hardware.
+
+// The robot's total weight is optional robot data from the config engine, which
+// emits it as ROBOT_WEIGHT. Use it when it is there, so the simulated robot has
+// the inertia of the one that was configured.
+#ifndef FAKE_ROBOT_MASS
+    #ifdef ROBOT_WEIGHT
+        #define FAKE_ROBOT_MASS ROBOT_WEIGHT
+    #else
+        #define FAKE_ROBOT_MASS 3.5     // simulated robot mass (kg)
+    #endif
+#endif
+
+#ifndef FAKE_WHEEL_TAU_MS
+#define FAKE_WHEEL_TAU_MS 150       // spin-up time constant (ms) at FAKE_WHEEL_REF_MASS
+#endif
+
+#ifndef FAKE_WHEEL_REF_MASS
+#define FAKE_WHEEL_REF_MASS 3.5     // mass FAKE_WHEEL_TAU_MS was measured at (kg)
+#endif
+
+#ifndef FAKE_WHEEL_MAX_ACCEL_RPM
+#define FAKE_WHEEL_MAX_ACCEL_RPM 900.0  // traction/current limit (RPM per second)
+#endif
+
+#ifndef FAKE_WHEEL_FRICTION
+#define FAKE_WHEEL_FRICTION 0.06    // viscous drag, fraction of current RPM per second
+#endif
+
+#ifndef FAKE_WHEEL_STALL_DUTY
+#define FAKE_WHEEL_STALL_DUTY 0.04  // duty below which the motor cannot break static friction
+#endif
+
+#ifndef FAKE_WHEEL_NOISE_RPM
+#define FAKE_WHEEL_NOISE_RPM 1.0    // +/- peak white noise on the reported RPM
+#endif
+
+// +/- peak white noise, scaled by amplitude
+static inline float fakeWheelNoise(float amplitude)
+{
+    return ((float)random(-1000, 1001) / 1000.0) * amplitude;
+}
+
+class FakeEncoder
+{
+private:
+    int counts_per_rev_ = -1;
+    bool invert_ = false;
+    float duty_ = 0.0;              // commanded duty cycle, -1.0 .. 1.0
+    float wheel_rpm_ = 0.0;         // simulated wheel speed
+    double ticks_ = 0.0;            // simulated tick accumulator
+    unsigned long prev_update_time_ = 0;
+
+    // advance the wheel model to now
+    void integrate()
+    {
+        unsigned long current_time = micros();
+        unsigned long dt = current_time - prev_update_time_;
+        prev_update_time_ = current_time;
+        // first call, or a micros() rollover: seed the clock, don't step the model
+        if (dt == 0 || dt > 1000000UL) return;
+        float dts = (float)dt / 1000000.0;
+
+        // heavier robot, more inertia per wheel, slower response
+        float tau = (FAKE_WHEEL_TAU_MS / 1000.0) *
+                    ((float)FAKE_ROBOT_MASS / (float)FAKE_WHEEL_REF_MASS);
+        if (tau < 0.001) tau = 0.001;
+
+        float no_load_rpm = duty_ * (float)MOTOR_MAX_RPM;
+        // below the stall band the motor cannot hold the wheel against friction
+        if (fabsf(duty_) < (float)FAKE_WHEEL_STALL_DUTY) no_load_rpm = 0.0;
+
+        // back-EMF: driving torque is proportional to the remaining speed error
+        float accel = (no_load_rpm - wheel_rpm_) / tau;
+        // viscous friction always opposes motion
+        accel -= wheel_rpm_ * (float)FAKE_WHEEL_FRICTION;
+        // traction and current limit the achievable acceleration
+        if (accel > (float)FAKE_WHEEL_MAX_ACCEL_RPM) accel = (float)FAKE_WHEEL_MAX_ACCEL_RPM;
+        if (accel < -(float)FAKE_WHEEL_MAX_ACCEL_RPM) accel = -(float)FAKE_WHEEL_MAX_ACCEL_RPM;
+
+        wheel_rpm_ += accel * dts;
+        // an unpowered wheel settles rather than creeping forever
+        if (no_load_rpm == 0.0 && fabsf(wheel_rpm_) < 0.5) wheel_rpm_ = 0.0;
+
+        // accumulate ticks so read() stays consistent with getRPM()
+        ticks_ += (double)wheel_rpm_ / 60.0 * counts_per_rev_ * dts;
+    }
+
+public:
+    FakeEncoder(int pin1, int pin2, int counts_per_rev, bool invert = false)
+    {
+        // The pins are deliberately ignored. Fake wheel mode exists for boards
+        // with nothing wired, where the encoder pins are normally left unset
+        // (-1); keying off them would leave every simulated wheel at 0 RPM,
+        // which is the one case this class is for. Nothing here touches GPIO.
+        // Which wheels actually count is the kinematics' decision, not the pin
+        // map: Kinematics::getVelocities() zeroes motors 3 and 4 on a
+        // differential base regardless of what the encoders report.
+        (void)pin1;
+        (void)pin2;
+        counts_per_rev_ = (counts_per_rev > 0) ? counts_per_rev : 1;
+        invert_ = invert;
+    }
+
+    // called by the control loop with the PWM just handed to the motor driver
+    void feed(int pwm)
+    {
+        if (counts_per_rev_ < 0) return;
+        integrate();
+        if (invert_) pwm *= -1;
+        // PWM_MAX expands to an unparenthesized expression (`pow(2, PWM_BITS) - 1`),
+        // so it has to be wrapped before dividing or the `- 1` escapes the cast and
+        // lands outside the division, turning a small duty into nearly full reverse.
+        float duty = (float)pwm / (float)(PWM_MAX);
+        if (duty > 1.0) duty = 1.0;
+        if (duty < -1.0) duty = -1.0;
+        duty_ = duty;
+    }
+
+    float getRPM()
+    {
+        if (counts_per_rev_ < 0) return 0.0;
+        integrate();
+        return wheel_rpm_ + fakeWheelNoise((float)FAKE_WHEEL_NOISE_RPM);
+    }
+
+    inline int32_t read()
+    {
+        if (counts_per_rev_ < 0) return 0;
+        integrate();
+        return (int32_t)ticks_;
+    }
+
+    inline void write(int32_t p)
+    {
+        if (counts_per_rev_ < 0) return;
+        ticks_ = (double)p;
+    }
+};
+
+#ifndef FAKE_IMU_GRAVITY
+#define FAKE_IMU_GRAVITY 9.81       // specific force reported on Z when level
+#endif
+
+#ifndef FAKE_IMU_ACCEL_TAU_MS
+#define FAKE_IMU_ACCEL_TAU_MS 60    // accelerometer band limit (ms)
+#endif
+
+#ifndef FAKE_IMU_ACCEL_NOISE
+#define FAKE_IMU_ACCEL_NOISE 0.05   // +/- peak accelerometer noise (m/s^2)
+#endif
+
+// A real MEMS IMU is not a clean derivative of the truth: it has a fixed bias,
+// a bias that wanders slowly with temperature, a scale-factor error, and white
+// noise on top. Fusion (madgwick, the EKF) exists to fight exactly that, so a
+// perfect simulated IMU would make the whole estimation stack look better than
+// it is on hardware.
+#ifndef FAKE_IMU_GYRO_BIAS
+#define FAKE_IMU_GYRO_BIAS 0.004f       // fixed gyro bias (rad/s)
+#endif
+
+#ifndef FAKE_IMU_GYRO_DRIFT
+#define FAKE_IMU_GYRO_DRIFT 0.0015f     // gyro bias random walk (rad/s per sqrt(s))
+#endif
+
+#ifndef FAKE_IMU_ACCEL_BIAS
+#define FAKE_IMU_ACCEL_BIAS 0.03f       // fixed accelerometer bias (m/s^2)
+#endif
+
+#ifndef FAKE_IMU_ACCEL_DRIFT
+#define FAKE_IMU_ACCEL_DRIFT 0.01f      // accelerometer bias random walk (m/s^2 per sqrt(s))
+#endif
+
+#ifndef FAKE_IMU_SCALE_ERROR
+#define FAKE_IMU_SCALE_ERROR 0.01f      // scale-factor error, fraction of reading
+#endif
+
+#ifndef FAKE_MAG_FIELD_T
+#define FAKE_MAG_FIELD_T 50e-6f     // Simulated field strength (Tesla, ~Earth)
+#endif
+
+#ifndef FAKE_MAG_ROOM_HEADING
+#define FAKE_MAG_ROOM_HEADING 0.0f  // Heading (rad) of the room's +X axis vs the field
+#endif
+
+#ifndef FAKE_MAG_NOISE_T
+#define FAKE_MAG_NOISE_T 0.5e-6f    // +/- peak magnetometer noise (Tesla)
+#endif
+
+// Hard-iron offset. A magnetometer mounted on a robot always sits next to
+// motors, batteries and steel, which add a fixed vector to every reading and
+// pull the heading round with the robot. Simulating it means the magnetometer
+// calibration routine has a real offset to discover and remove, instead of
+// converging on zero and proving nothing.
+#ifndef FAKE_MAG_BIAS_X
+#define FAKE_MAG_BIAS_X 6.0e-6f
+#endif
+#ifndef FAKE_MAG_BIAS_Y
+#define FAKE_MAG_BIAS_Y -4.0e-6f
+#endif
+#ifndef FAKE_MAG_BIAS_Z
+#define FAKE_MAG_BIAS_Z 2.5e-6f
+#endif
+
+#ifndef FAKE_IMU_GYRO_NOISE
+#define FAKE_IMU_GYRO_NOISE 0.005   // +/- peak gyroscope noise (rad/s)
+#endif
+
+// Derives IMU readings from the simulated body motion, so the accelerometer
+// and gyroscope agree with the wheel encoders instead of reading zero.
+// Hold a wandering bias inside a plausible envelope.
+static inline float clampBias(float v, float limit)
+{
+    if (limit < 0.0f) limit = -limit;
+    if (v >  limit) return  limit;
+    if (v < -limit) return -limit;
+    return v;
+}
+
+class FakeIMUFromWheels
+{
+private:
+    float linear_x_ = 0.0;          // latest body velocities
+    float linear_y_ = 0.0;
+    float angular_z_ = 0.0;
+    float accel_x_ = 0.0;           // smoothed body accelerations
+    float accel_y_ = 0.0;
+    float heading_ = 0.0;           // simulated yaw, for the magnetometer
+    // slowly wandering sensor biases, seeded to a fixed offset and then walked
+    // Start calibrated. A real IMU has its static bias measured and subtracted
+    // at startup -- IMUInterface::init() calls calibrateGyro(), which averages
+    // 40 samples and stores the offset. Fake wheel mode never calls that (there
+    // is no chip to talk to), so seeding these with the full bias simulated an
+    // IMU that had skipped its own calibration: the gyro read a steady offset
+    // forever, the EKF integrated it, and yaw walked away from the wheels.
+    float gyro_bias_z_ = 0.0f;
+    float accel_bias_x_ = 0.0f;
+    float accel_bias_y_ = 0.0f;
+
+public:
+    // With no real IMU on the bus, imu.getData() / mag.getData() are never
+    // called, and the two messages never get the frame and covariances those
+    // calls would have filled in. Set them once here instead: without a
+    // frame_id the messages are dropped by tf, and with zero covariance the
+    // EKF treats the simulated sensor as exact.
+    void initMsgs(sensor_msgs__msg__Imu &imu_msg,
+                  sensor_msgs__msg__MagneticField &mag_msg)
+    {
+        const float accel_cov[3] = ACCEL_COV;
+        const float gyro_cov[3] = GYRO_COV;
+        const float ori_cov[3] = ORI_COV;
+        const float mag_cov[3] = MAG_COV;
+
+        imu_msg.header.frame_id =
+            micro_ros_string_utilities_set(imu_msg.header.frame_id, "imu_link");
+        mag_msg.header.frame_id =
+            micro_ros_string_utilities_set(mag_msg.header.frame_id, "imu_link");
+
+        for (int i = 0; i < 3; i++)
+        {
+            const int d = i * 4;    // 0, 4, 8: the diagonal of a 3x3 row-major
+            imu_msg.linear_acceleration_covariance[d] = accel_cov[i];
+            imu_msg.angular_velocity_covariance[d] = gyro_cov[i];
+            imu_msg.orientation_covariance[d] = ori_cov[i];
+            mag_msg.magnetic_field_covariance[d] = mag_cov[i];
+        }
+    }
+
+    // fed from the body velocities the kinematics derived from the wheels
+    void update(float linear_x, float linear_y, float angular_z, float dt)
+    {
+        if (dt > 0.0)
+        {
+            // differencing velocity at the loop rate is spiky; a real
+            // accelerometer is band limited, so ease into the new value
+            float raw_x = (linear_x - linear_x_) / dt;
+            float raw_y = (linear_y - linear_y_) / dt;
+            float alpha = 1.0 - expf(-dt / (FAKE_IMU_ACCEL_TAU_MS / 1000.0));
+            accel_x_ += (raw_x - accel_x_) * alpha;
+            accel_y_ += (raw_y - accel_y_) * alpha;
+
+            // Random walk: the step scales with sqrt(dt), so the drift rate is
+            // independent of how often this happens to be called.
+            //
+            // Bounded, because a free random walk has no bound and this one had
+            // none: the longer the board ran, the further the bias wandered,
+            // and it does not come back. Measured after a long session the
+            // stationary gyro read 0.01813 rad/s -- 4.5x the nominal bias --
+            // and the EKF turned that into 0.87 deg/s of yaw drift, 52 deg in a
+            // minute while the robot stood still. Real parts do not do that:
+            // bias instability wanders within an envelope. Clamping to the
+            // nominal bias keeps the drift a filter has to cope with, without
+            // letting uptime decide whether SLAM works.
+            const float rw = sqrtf(dt);
+            gyro_bias_z_  += fakeWheelNoise((float)FAKE_IMU_GYRO_DRIFT) * rw;
+            accel_bias_x_ += fakeWheelNoise((float)FAKE_IMU_ACCEL_DRIFT) * rw;
+            accel_bias_y_ += fakeWheelNoise((float)FAKE_IMU_ACCEL_DRIFT) * rw;
+            gyro_bias_z_  = clampBias(gyro_bias_z_,  (float)FAKE_IMU_GYRO_BIAS);
+            accel_bias_x_ = clampBias(accel_bias_x_, (float)FAKE_IMU_ACCEL_BIAS);
+            accel_bias_y_ = clampBias(accel_bias_y_, (float)FAKE_IMU_ACCEL_BIAS);
+        }
+        linear_x_ = linear_x;
+        linear_y_ = linear_y;
+        angular_z_ = angular_z;
+    }
+
+    // The simulated robot turns, so a magnetometer stuck at a constant vector
+    // would disagree with the yaw the wheels report and drag any heading fusion
+    // (madgwick, EKF) away from the truth. Rotate a fixed world field into the
+    // body frame instead, so the mag agrees with the simulated room: the field
+    // points along the room's +X axis, offset by FAKE_MAG_ROOM_HEADING.
+    void setHeading(float heading) { heading_ = heading; }
+
+    void applyMag(sensor_msgs__msg__MagneticField &mag_msg)
+    {
+        const float theta = heading_ - (float)FAKE_MAG_ROOM_HEADING;
+        const float b = (float)FAKE_MAG_FIELD_T;
+        // The world field points along +Y, i.e. North in the ENU frame ROS uses,
+        // because that is the direction imu_filter_madgwick assumes when it
+        // derives heading from the magnetometer. Pointing it along +X instead
+        // is physically just as valid but leaves the fused yaw a fixed ~90 deg
+        // from the wheel odometry's, and the EKF then has two heading sources
+        // that disagree by a quarter turn: it splits the difference, drags the
+        // pose sideways during a pure rotation, and the SLAM map comes out
+        // sheared. Measured before this: /odom translated 3.9 m while the robot
+        // only spun in place.
+        //
+        // Rotating the world vector (0, b) into the body frame by -theta:
+        //   x =  b sin(theta)      y =  b cos(theta)
+        // then spoiled by the hard-iron offset calibration is meant to find,
+        // and white noise.
+        mag_msg.magnetic_field.x =
+            b * sinf(theta) + (float)FAKE_MAG_BIAS_X + fakeWheelNoise((float)FAKE_MAG_NOISE_T);
+        mag_msg.magnetic_field.y =
+            b * cosf(theta) + (float)FAKE_MAG_BIAS_Y + fakeWheelNoise((float)FAKE_MAG_NOISE_T);
+        mag_msg.magnetic_field.z =
+            (float)FAKE_MAG_BIAS_Z + fakeWheelNoise((float)FAKE_MAG_NOISE_T);
+    }
+
+    void apply(sensor_msgs__msg__Imu &imu_msg)
+    {
+        // a real accelerometer measures specific force: body accel, plus the
+        // centripetal term while turning, plus gravity held up by the floor
+        // true specific force, then spoiled the way a real sensor spoils it:
+        // scale error on the signal, a wandering bias, then white noise
+        const float k = 1.0f + (float)FAKE_IMU_SCALE_ERROR;
+        const float ax = accel_x_ - angular_z_ * linear_y_;
+        const float ay = accel_y_ + angular_z_ * linear_x_;
+
+        imu_msg.linear_acceleration.x =
+            ax * k + accel_bias_x_ + fakeWheelNoise((float)FAKE_IMU_ACCEL_NOISE);
+        imu_msg.linear_acceleration.y =
+            ay * k + accel_bias_y_ + fakeWheelNoise((float)FAKE_IMU_ACCEL_NOISE);
+        imu_msg.linear_acceleration.z =
+            (float)FAKE_IMU_GRAVITY + fakeWheelNoise((float)FAKE_IMU_ACCEL_NOISE);
+
+        imu_msg.angular_velocity.x = fakeWheelNoise((float)FAKE_IMU_GYRO_NOISE);
+        imu_msg.angular_velocity.y = fakeWheelNoise((float)FAKE_IMU_GYRO_NOISE);
+        imu_msg.angular_velocity.z =
+            angular_z_ * k + gyro_bias_z_ + fakeWheelNoise((float)FAKE_IMU_GYRO_NOISE);
+    }
+};
+
+#ifdef USE_FAKE_WHEEL
+    #define ENCODER FakeEncoder
+#else
+    #define ENCODER Encoder
+#endif
+
+#endif

--- a/firmware/lib/lidar/fake_ld19.h
+++ b/firmware/lib/lidar/fake_ld19.h
@@ -1,0 +1,482 @@
+// Copyright (c) 2026 Linorobot contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FAKE_LD19_H
+#define FAKE_LD19_H
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#endif
+#include <math.h>
+#include <stdint.h>
+
+#ifdef USE_LIDAR_UDP
+#include <WiFiUdp.h>
+#endif
+
+#ifndef FAKE_MAP_WIDTH
+#define FAKE_MAP_WIDTH 10.0f    // Simulated room width (meters, -5.0 to +5.0)
+#endif
+
+#ifndef FAKE_MAP_HEIGHT
+#define FAKE_MAP_HEIGHT 6.0f    // Simulated room height (meters, -3.0 to +3.0)
+#endif
+
+// TX ring buffer for the emitted stream, in bytes (ESP32 only -- RP2040 and
+// RP2350 have no TX ring). One revolution is PACKS_PER_REV * 47 = 1786 bytes,
+// so 2048 absorbs a whole scan and write() never waits on the wire.
+#ifndef FAKE_LD19_TX_BUFFER
+#define FAKE_LD19_TX_BUFFER 2048
+#endif
+
+// An LD19 sees 12 m. Beyond that it reports no measurement, not a reading at
+// its limit. The default room is kept inside that reach: 10 x 6 m has an
+// 11.66 m diagonal, so every wall is visible from every corner. A room larger
+// than the sensor leaves whole sectors returning nothing, scan matching goes
+// under-constrained, and odometry drift stops being corrected -- measured on a
+// 16 x 12 room, the map smeared to a 41 x 37 m span with the walls nowhere
+// near where they belong. Enlarging it is allowed, but that is the trade.
+// Where the LiDAR sits on the robot, forward of base_footprint. The shipped
+// linorobot2 URDF puts it at x = 0.12 m, and the emulator has to raycast from
+// there rather than from the robot's centre: ROS transforms every scan by
+// base_footprint -> laser before using it, so measuring from the centre puts
+// each wall 12 cm too far out along whatever heading the robot has. Standing
+// still that is a uniform 12 cm error; turning, it sweeps a 24 cm circle and
+// the walls smear. Measured effect on a finished map: 0.196 m median distance
+// from the true walls, down to a few cm once the origin is right.
+#ifndef FAKE_LIDAR_OFFSET_X
+#define FAKE_LIDAR_OFFSET_X 0.12f
+#endif
+
+#ifndef FAKE_LD19_MAX_RANGE_M
+#define FAKE_LD19_MAX_RANGE_M 12.0f
+#endif
+
+#ifndef FAKE_SCAN_HZ
+#define FAKE_SCAN_HZ 10         // Simulated LiDAR revolutions per second
+#endif
+
+#ifndef FAKE_SONAR_CONE_DEG
+#define FAKE_SONAR_CONE_DEG 30.0f   // Ultrasonic beam width, full angle
+#endif
+
+#ifndef FAKE_ROBOT_RADIUS
+#define FAKE_ROBOT_RADIUS 0.20f // Keeps the robot off the wall rather than in it
+#endif
+
+#ifndef FAKE_WALL_OBSTACLE
+#define FAKE_WALL_OBSTACLE 1    // 1 to include obstacle wall
+#endif
+
+#ifndef FAKE_WALL_X1
+#define FAKE_WALL_X1 2.0f       // Obstacle wall start X (m)
+#endif
+#ifndef FAKE_WALL_Y1
+#define FAKE_WALL_Y1 -1.5f      // Obstacle wall start Y (m)
+#endif
+#ifndef FAKE_WALL_X2
+#define FAKE_WALL_X2 2.0f       // Obstacle wall end X (m)
+#endif
+#ifndef FAKE_WALL_Y2
+#define FAKE_WALL_Y2 1.5f       // Obstacle wall end Y (m)
+#endif
+
+#ifndef LIDAR_BAUDRATE
+#define LIDAR_BAUDRATE 230400
+#endif
+
+#ifndef LIDAR_SERIAL
+#define LIDAR_SERIAL 1
+#endif
+
+class FakeLD19
+{
+private:
+    struct Segment {
+        float x1, y1, x2, y2;
+    };
+
+    static const uint16_t POINTS_PER_PACK = 12;
+    static const uint16_t POINTS_PER_REV  = 456;
+    static const uint16_t PACKS_PER_REV   = POINTS_PER_REV / POINTS_PER_PACK; // 38
+    static constexpr float DEG_PER_POINT  = 360.0f / 456.0f;                  // ~0.78947 deg
+    // Scan rate is a bandwidth decision. Each revolution is 38 packets of 47
+    // bytes, so 10 Hz needs ~17.9 kB/s of the ~23 kB/s that 230400 baud
+    // carries -- 78% of the wire, which the TX ring buffer below absorbs
+    // without ever stalling the control loop (measured on ESP32: odometry
+    // holds 50.0 Hz at a 10 Hz scan). Going much above this has no headroom
+    // left to give.
+    static const uint16_t SPEED_DPS       = (uint16_t)(FAKE_SCAN_HZ * 360);
+    static const uint32_t PACK_PERIOD_US  = (uint32_t)(1000000UL / (PACKS_PER_REV * FAKE_SCAN_HZ));
+    // How many packets one step() may hand the UART. On ESP32 the TX ring
+    // buffer absorbs them and write() returns at once, so a burst is free. On
+    // RP2040/RP2350 there is no TX ring at all -- SerialUART::write() calls
+    // uart_putc_raw() and spins once the 32-byte hardware FIFO fills, and its
+    // availableForWrite() reports a bare 0/1 rather than a byte count, so
+    // there is nothing to test before writing. One packet per step is the
+    // bound there: the loop runs far faster than the ~380 packets/s a 10 Hz
+    // scan needs, so pacing costs no scan rate and caps the stall at the 15
+    // bytes that do not fit the FIFO (~0.65 ms).
+#if defined(ESP32)
+    static const uint8_t  MAX_PACKS_PER_STEP = 8;
+#else
+    static const uint8_t  MAX_PACKS_PER_STEP = 1;
+#endif
+    // Lag beyond which the schedule is resynced instead of burst through. Tied
+    // to the scan, not to the per-step budget -- a platform that emits one
+    // packet per step is not thereby behind.
+    static const uint32_t RESYNC_LAG_US = PACK_PERIOD_US * 8;
+
+    // Current robot pose in global world frame
+    float pose_x_ = 0.0f;
+    float pose_y_ = 0.0f;
+    float pose_theta_ = 0.0f;
+
+    uint16_t point_idx_ = 0;
+    uint32_t next_pack_us_ = 0;
+    Stream *out_stream_ = nullptr;
+    int tx_pin_ = -1;
+    bool enabled_ = false;
+
+#ifdef USE_LIDAR_UDP
+    WiFiUDP udp_;
+    bool udp_enabled_ = false;
+    uint8_t udp_buf_[256];
+    uint16_t udp_buf_len_ = 0;
+#endif
+
+    // CalCRC8 lookup table (poly 0x4D), LDROBOT LD19 standard
+    static uint8_t crc8(const uint8_t *data, int len)
+    {
+        static const uint8_t table[256] = {
+          0x00,0x4d,0x9a,0xd7,0x79,0x34,0xe3,0xae,0xf2,0xbf,0x68,0x25,0x8b,0xc6,0x11,0x5c,
+          0xa9,0xe4,0x33,0x7e,0xd0,0x9d,0x4a,0x07,0x5b,0x16,0xc1,0x8c,0x22,0x6f,0xb8,0xf5,
+          0x1f,0x52,0x85,0xc8,0x66,0x2b,0xfc,0xb1,0xed,0xa0,0x77,0x3a,0x94,0xd9,0x0e,0x43,
+          0xb6,0xfb,0x2c,0x61,0xcf,0x82,0x55,0x18,0x44,0x09,0xde,0x93,0x3d,0x70,0xa7,0xea,
+          0x3e,0x73,0xa4,0xe9,0x47,0x0a,0xdd,0x90,0xcc,0x81,0x56,0x1b,0xb5,0xf8,0x2f,0x62,
+          0x97,0xda,0x0d,0x40,0xee,0xa3,0x74,0x39,0x65,0x28,0xff,0xb2,0x1c,0x51,0x86,0xcb,
+          0x21,0x6c,0xbb,0xf6,0x58,0x15,0xc2,0x8f,0xd3,0x9e,0x49,0x04,0xaa,0xe7,0x30,0x7d,
+          0x88,0xc5,0x12,0x5f,0xf1,0xbc,0x6b,0x26,0x7a,0x37,0xe0,0xad,0x03,0x4e,0x99,0xd4,
+          0x7c,0x31,0xe6,0xab,0x05,0x48,0x9f,0xd2,0x8e,0xc3,0x14,0x59,0xf7,0xba,0x6d,0x20,
+          0xd5,0x98,0x4f,0x02,0xac,0xe1,0x36,0x7b,0x27,0x6a,0xbd,0xf0,0x5e,0x13,0xc4,0x89,
+          0x63,0x2e,0xf9,0xb4,0x1a,0x57,0x80,0xcd,0x91,0xdc,0x0b,0x46,0xe8,0xa5,0x72,0x3f,
+          0xca,0x87,0x50,0x1d,0xb3,0xfe,0x29,0x64,0x38,0x75,0xa2,0xef,0x41,0x0c,0xdb,0x96,
+          0x42,0x0f,0xd8,0x95,0x3b,0x76,0xa1,0xec,0xb0,0xfd,0x2a,0x67,0xc9,0x84,0x53,0x1e,
+          0xeb,0xa6,0x71,0x3c,0x92,0xdf,0x08,0x45,0x19,0x54,0x83,0xce,0x60,0x2d,0xfa,0xb7,
+          0x5d,0x10,0xc7,0x8a,0x24,0x69,0xbe,0xf3,0xaf,0xe2,0x35,0x78,0xd6,0x9b,0x4c,0x01,
+          0xf4,0xb9,0x6e,0x23,0x8d,0xc0,0x17,0x5a,0x06,0x4b,0x9c,0xd1,0x7f,0x32,0xe5,0xa8
+        };
+        uint8_t c = 0;
+        while (len--) c = table[(c ^ *data++) & 0xff];
+        return c;
+    }
+
+    static inline void put16(uint8_t *p, uint16_t v) {
+        p[0] = (uint8_t)(v & 0xff);
+        p[1] = (uint8_t)(v >> 8);
+    }
+
+public:
+    FakeLD19() {}
+
+    void setStream(Stream *stream)
+    {
+        out_stream_ = stream;
+        enabled_ = true;
+    }
+
+    void begin(int tx_pin = -1, uint32_t baud = LIDAR_BAUDRATE)
+    {
+        tx_pin_ = tx_pin;
+        if (tx_pin >= 0)
+        {
+#if defined(ESP32)
+            HardwareSerial *serial = new HardwareSerial(LIDAR_SERIAL);
+            // Give the UART a TX ring buffer big enough for a whole
+            // revolution. Without one, write() has only the 128-byte hardware
+            // FIFO behind it, and a catch-up burst of MAX_PACKS_PER_STEP
+            // packets (376 bytes) blocks the control loop until the wire
+            // drains it -- 16 ms at 230400, most of a 20 ms control period.
+            // The buffer is drained by the UART interrupt, so write() returns
+            // immediately and the emission costs the loop nothing but the
+            // memcpy. Must be called before begin() to take effect.
+            serial->setTxBufferSize(FAKE_LD19_TX_BUFFER);
+            // On ESP32, configure UART with TX pin on LIDAR_RXD
+            serial->begin(baud, SERIAL_8N1, -1, tx_pin);
+            out_stream_ = serial;
+            enabled_ = true;
+#elif defined(ARDUINO_ARCH_RP2040)
+#if defined(LIDAR_SERIAL) && LIDAR_SERIAL == 2
+            Serial2.setTX(tx_pin);
+            Serial2.begin(baud);
+            out_stream_ = &Serial2;
+#else
+            Serial1.setTX(tx_pin);
+            Serial1.begin(baud);
+            out_stream_ = &Serial1;
+#endif
+            enabled_ = true;
+#endif
+        }
+
+#ifdef USE_LIDAR_UDP
+        udp_enabled_ = true;
+        enabled_ = true;
+#endif
+        next_pack_us_ = micros() + PACK_PERIOD_US;
+    }
+
+    // Update the simulator with the robot odometry pose (meters and radians)
+    // Hold a pose inside the room. The simulated drivetrain has no notion of
+    // collision, so a robot driven at a wall sails straight through it and out
+    // of the map -- the scan jumps to max range and SLAM has nothing to build
+    // from. Stopping at the wall is also what a real robot does: the wheels
+    // keep turning, the robot does not move, and odometry stops advancing.
+    // Returns true when the pose had to be moved.
+    bool clampToRoom(float &x, float &y) const
+    {
+        const float lim_x = (float)FAKE_MAP_WIDTH * 0.5f - (float)FAKE_ROBOT_RADIUS;
+        const float lim_y = (float)FAKE_MAP_HEIGHT * 0.5f - (float)FAKE_ROBOT_RADIUS;
+        const float in_x = x, in_y = y;
+        if (x > lim_x) x = lim_x;
+        if (x < -lim_x) x = -lim_x;
+        if (y > lim_y) y = lim_y;
+        if (y < -lim_y) y = -lim_y;
+
+#if FAKE_WALL_OBSTACLE
+        // The obstacle wall is solid too. Raycasting it but not colliding with
+        // it lets the robot drive straight through the one thing in the room,
+        // and the scan then shows that wall *behind* it -- which quietly makes
+        // any obstacle-avoidance test meaningless, because nothing stops a plan
+        // that goes through it.
+        pushOffSegment(x, y,
+                       (float)FAKE_WALL_X1, (float)FAKE_WALL_Y1,
+                       (float)FAKE_WALL_X2, (float)FAKE_WALL_Y2);
+#endif
+        return (x != in_x) || (y != in_y);
+    }
+
+    // Push a point out to FAKE_ROBOT_RADIUS from a segment, along the shortest
+    // way out, if it is inside. Approach direction does not matter: the robot
+    // leaves by the side it came in on.
+    static void pushOffSegment(float &x, float &y,
+                               float x1, float y1, float x2, float y2)
+    {
+        const float r = (float)FAKE_ROBOT_RADIUS;
+        const float sx = x2 - x1, sy = y2 - y1;
+        const float len2 = sx * sx + sy * sy;
+
+        // closest point on the segment, with the parameter clamped to its ends
+        float t = (len2 > 1e-9f) ? ((x - x1) * sx + (y - y1) * sy) / len2 : 0.0f;
+        if (t < 0.0f) t = 0.0f;
+        if (t > 1.0f) t = 1.0f;
+        const float cx = x1 + t * sx, cy = y1 + t * sy;
+
+        float nx = x - cx, ny = y - cy;
+        float d = sqrtf(nx * nx + ny * ny);
+        if (d >= r) return;             // already clear
+
+        if (d < 1e-6f)
+        {
+            // dead on the segment: no direction to push along, so use its
+            // normal and pick a side rather than dividing by zero
+            if (len2 > 1e-9f) { nx = -sy; ny = sx; d = sqrtf(len2); }
+            else              { nx = 1.0f; ny = 0.0f; d = 1.0f; }
+        }
+        x = cx + nx / d * r;
+        y = cy + ny / d * r;
+    }
+
+    // What a forward-facing ultrasonic sensor would read: the nearest return
+    // inside a cone, not a single ray. Gives the robot actual feedback that
+    // something is ahead, rather than leaving it to be inferred from odometry
+    // that has stopped advancing.
+    float rangeAheadM(float cone_deg = (float)FAKE_SONAR_CONE_DEG)
+    {
+        const float half = cone_deg * 0.5f;
+        uint16_t nearest = 0xFFFF;
+        for (float d = -half; d <= half; d += 2.0f)
+        {
+            uint16_t r = raycastRangeMm(d < 0.0f ? d + 360.0f : d);
+            if (r > 0 && r < nearest) nearest = r;
+        }
+        // -1 means "no reading", matching what the firmware's
+        // rangeAheadOrNegative() expects. Returning 0.0 here would read as an
+        // obstacle touching the robot and hold the safety stop on permanently
+        // whenever the path ahead is simply open beyond the sensor's reach.
+        return (nearest == 0xFFFF) ? -1.0f : (float)nearest / 1000.0f;
+    }
+
+    void updatePose(float x, float y, float theta)
+    {
+        pose_x_ = x;
+        pose_y_ = y;
+        pose_theta_ = theta;
+    }
+
+    // Raycast distance for a given beam angle (in degrees, 0..360)
+    uint16_t raycastRangeMm(float beam_deg)
+    {
+        // Global ray angle in radians: robot yaw MINUS the beam angle, because
+        // an LD19's angle field increases the way the head physically turns,
+        // which is clockwise seen from above -- the opposite of the
+        // right-handed convention ROS uses. ldlidar_stl_ros2 negates it again
+        // to produce a proper counter-clockwise LaserScan, so emitting the
+        // mathematically positive direction here leaves that flip unmatched and
+        // publishes a mirror image of the room.
+        //
+        // Nothing looks wrong: the scan is the right shape and the right size,
+        // and while the robot is still it is even self-consistent. Only when it
+        // turns does the mirrored scan rotate against the odometry, so scan
+        // matching fights the wheels and the map inflates. Measured against a
+        // ground-truth raycast of the room: 1.305 m mean error as emitted,
+        // 0.019 m once mirrored.
+        float ray_rad = pose_theta_ - (beam_deg * 0.0174532925f);
+        float dx = cosf(ray_rad);
+        float dy = sinf(ray_rad);
+
+        // the beam leaves the sensor, which is mounted ahead of the robot's centre
+        const float ox = pose_x_ + cosf(pose_theta_) * (float)FAKE_LIDAR_OFFSET_X;
+        const float oy = pose_y_ + sinf(pose_theta_) * (float)FAKE_LIDAR_OFFSET_X;
+
+        // Define room perimeter boundaries centered at (0,0)
+        const float half_w = (float)FAKE_MAP_WIDTH * 0.5f;
+        const float half_h = (float)FAKE_MAP_HEIGHT * 0.5f;
+
+        Segment segs[5] = {
+            {-half_w, -half_h,  half_w, -half_h}, // South wall
+            { half_w, -half_h,  half_w,  half_h}, // East wall
+            { half_w,  half_h, -half_w,  half_h}, // North wall
+            {-half_w,  half_h, -half_w, -half_h}, // West wall
+            {(float)FAKE_WALL_X1, (float)FAKE_WALL_Y1, (float)FAKE_WALL_X2, (float)FAKE_WALL_Y2} // Short obstacle wall
+        };
+
+        int count = FAKE_WALL_OBSTACLE ? 5 : 4;
+        float min_dist = (float)FAKE_LD19_MAX_RANGE_M; // nothing seen yet
+
+        for (int i = 0; i < count; i++)
+        {
+            float sx = segs[i].x2 - segs[i].x1;
+            float sy = segs[i].y2 - segs[i].y1;
+            float denom = dx * sy - dy * sx;
+            if (fabsf(denom) < 1e-6f) continue;
+
+            float px = segs[i].x1 - ox;
+            float py = segs[i].y1 - oy;
+
+            float t = (px * sy - py * sx) / denom;
+            float u = (px * dy - py * dx) / denom;
+
+            if (t > 0.03f && u >= 0.0f && u <= 1.0f)
+            {
+                if (t < min_dist) min_dist = t;
+            }
+        }
+
+        // No segment inside the sensor's reach means no measurement. Reporting
+        // the range limit instead would put a return there, and a real LD19
+        // does not do that -- it reports 0. It matters more than it sounds:
+        // beams that overshoot the far wall would otherwise draw a phantom arc
+        // at exactly 12 m, SLAM would map it as a wall standing inside the
+        // room, and the map comes out larger and sheared. 0 is the protocol's
+        // "no measurement", which the driver turns into an invalid range.
+        if (min_dist >= (float)FAKE_LD19_MAX_RANGE_M) return 0;
+
+        // Add small simulated white noise (+-5 mm)
+        float noise = ((float)(rand() % 11) - 5.0f);
+        float dist_mm = (min_dist * 1000.0f) + noise;
+
+        if (dist_mm < 50.0f) dist_mm = 50.0f;
+        return (uint16_t)dist_mm;
+    }
+
+    // Advance packet generation and stream out if it is time
+    // Emit however many packets the clock says are due, not one per call.
+    //
+    // A 10 Hz LD19 is 380 packets/s, but loop() does not iterate anywhere near
+    // that: the micro-ROS executor dominates each cycle, so one packet per call
+    // yielded roughly 1.5 rev/s -- enough to look like it works, far too slow
+    // for SLAM to build a map from. The budget bounds the catch-up so a long
+    // stall cannot monopolise the loop, and the schedule advances by whole
+    // periods so it does not drift.
+    void step()
+    {
+        if (!enabled_) return;
+
+        for (uint8_t budget = 0; budget < MAX_PACKS_PER_STEP; budget++)
+        {
+            uint32_t now = micros();
+            if ((int32_t)(now - next_pack_us_) < 0) return;
+            // if we fell far behind, resync rather than burst through a backlog
+            if ((int32_t)(now - next_pack_us_) > (int32_t)RESYNC_LAG_US)
+                next_pack_us_ = now;
+            next_pack_us_ += PACK_PERIOD_US;
+            emitPack();
+        }
+    }
+
+private:
+    void emitPack()
+    {
+        uint8_t pkt[47];
+        pkt[0] = 0x54;
+        pkt[1] = 0x2C;
+        put16(&pkt[2], SPEED_DPS);
+
+        float start_deg = point_idx_ * DEG_PER_POINT;
+        float end_deg   = (point_idx_ + POINTS_PER_PACK - 1) * DEG_PER_POINT;
+        put16(&pkt[4], (uint16_t)(fmodf(start_deg, 360.0f) * 100.0f));
+
+        for (int i = 0; i < POINTS_PER_PACK; i++)
+        {
+            float deg = (point_idx_ + i) * DEG_PER_POINT;
+            uint16_t dist = raycastRangeMm(deg);
+            // 0 distance is "no measurement"; a real unit reports no
+            // confidence with it, and drivers use that to reject the point.
+            uint8_t inten = (dist == 0) ? 0
+                          : (dist < 1500) ? 220 : (dist < 4000) ? 180 : 120;
+            put16(&pkt[6 + i * 3], dist);
+            pkt[6 + i * 3 + 2] = inten;
+        }
+
+        put16(&pkt[42], (uint16_t)(fmodf(end_deg, 360.0f) * 100.0f));
+        put16(&pkt[44], (uint16_t)(millis() % 30000));
+        pkt[46] = crc8(pkt, 46);
+
+        if (out_stream_)
+        {
+            out_stream_->write(pkt, 47);
+        }
+
+#ifdef USE_LIDAR_UDP
+        if (udp_enabled_)
+        {
+            memcpy(udp_buf_ + udp_buf_len_, pkt, 47);
+            udp_buf_len_ += 47;
+            if (udp_buf_len_ >= 141)
+            {
+                udp_.beginPacket(LIDAR_SERVER, LIDAR_PORT);
+                udp_.write(udp_buf_, udp_buf_len_);
+                udp_.endPacket();
+                udp_buf_len_ = 0;
+            }
+        }
+#endif
+
+        point_idx_ += POINTS_PER_PACK;
+        if (point_idx_ >= POINTS_PER_REV) point_idx_ -= POINTS_PER_REV;
+    }
+};
+
+#endif

--- a/firmware/lib/lidar/lidar.cpp
+++ b/firmware/lib/lidar/lidar.cpp
@@ -20,7 +20,7 @@
 #include "config.h"
 #include "syslog.h"
 
-#ifdef USE_LIDAR_UDP
+#if defined(USE_LIDAR_UDP) && !defined(USE_FAKE_LD19)
 #include <HardwareSerial.h>
 #include <WiFiUdp.h>
 #define BUFSIZE 512

--- a/firmware/lib/odometry/odometry.h
+++ b/firmware/lib/odometry/odometry.h
@@ -34,6 +34,17 @@ class Odometry
         Odometry();
         void update(float vel_dt, float linear_vel_x, float linear_vel_y, float angular_vel_z);
         nav_msgs__msg__Odometry getData();
+        inline float getX() const { return x_pos_; }
+        inline float getY() const { return y_pos_; }
+        inline float getHeading() const { return heading_; }
+        // Used by simulation modes to hold the robot inside a simulated room,
+        // so the published odometry matches what the simulated LiDAR sees.
+        inline void setPosition(float x, float y) { x_pos_ = x; y_pos_ = y; }
+        // Return the robot to the origin. Simulation modes call this when a new
+        // agent session starts, so that a fresh run gets a fresh robot; a real
+        // robot must not use it, because odometry has to stay continuous across
+        // a reconnect or the transform tree jumps under whatever is localising.
+        inline void reset() { x_pos_ = 0.0f; y_pos_ = 0.0f; heading_ = 0.0f; }
 
     private:
         const void euler_to_quat(float x, float y, float z, float* q);

--- a/firmware/src/firmware.ino
+++ b/firmware/src/firmware.ino
@@ -158,9 +158,55 @@ MAG mag;
 #define BAUDRATE 921600
 #endif
 
+// ---------------------------------------------------------------------------
+// LED helpers.
+//
+// Boards without an addressable status LED (e.g. Waveshare GenDrv) set
+// #define LED_PIN -1 in their config header. On such boards the helpers
+// compile to no-ops so no spurious GPIO is touched and nothing is written.
+//
+// The guard is positive (enabled when defined && >= 0). The preprocessor
+// folds integer constants in #if expressions:
+//   - #define LED_PIN 25      -> 25 >= 0  true  -> LED enabled
+//   - #define LED_PIN -1      -> -1 >= 0  false -> LED disabled (no wiring)
+//   - #define LED_PIN LED_BUILTIN -> LED_BUILTIN is a non-macro identifier
+//     (a static const in the core pins_arduino.h), so the preprocessor treats
+//     it as 0 -> 0 >= 0 true  -> LED enabled, and digitalWrite(LED_BUILTIN,..)
+//     still resolves to the core pin at link time.
+//   - LED_PIN undefined       -> disabled (no reference, safe to compile)
+// ---------------------------------------------------------------------------
+// LED_ACTIVE is defined at most once (no #else branch), so the Arduino .ino ->
+// .cpp prototype pass cannot make it look "redefined".
+#if defined(LED_PIN) && (LED_PIN) >= 0
+#define LED_ACTIVE
+#endif
+
+static inline void ledInit() {
+#ifdef LED_ACTIVE
+    pinMode(LED_PIN, OUTPUT);
+    digitalWrite(LED_PIN, LOW);
+#endif
+}
+
+static inline void ledWrite(bool level) {
+#ifdef LED_ACTIVE
+    digitalWrite(LED_PIN, level ? HIGH : LOW);
+#else
+    (void)level;
+#endif
+}
+
+static inline bool ledRead() {
+#ifdef LED_ACTIVE
+    return digitalRead(LED_PIN) == HIGH;
+#else
+    return false;
+#endif
+}
+
 void setup() 
 {
-    pinMode(LED_PIN, OUTPUT);
+    ledInit();
     Serial.begin(BAUDRATE);
 #ifdef ESP32
     Serial.setRxBufferSize(1024);
@@ -270,7 +316,7 @@ void controlCallback(rcl_timer_t * timer, int64_t last_call_time)
 
 void twistCallback(const void * msgin) 
 {
-    digitalWrite(LED_PIN, !digitalRead(LED_PIN));
+    ledWrite(!ledRead());
 
     prev_cmd_time = millis();
 }
@@ -357,7 +403,7 @@ bool createEntities()
 
     // synchronize time with the agent
     syncTime();
-    digitalWrite(LED_PIN, HIGH);
+    ledWrite(HIGH);
 
     return true;
 }
@@ -385,8 +431,8 @@ bool destroyEntities()
     RCSOFTCHECK(rcl_node_fini(&node))
     RCSOFTCHECK(rclc_support_fini(&support));
 
-    digitalWrite(LED_PIN, HIGH);
-    
+    ledWrite(HIGH);
+
     return true;
 }
 
@@ -411,7 +457,7 @@ void moveBase()
         twist_msg.linear.y = 0.0;
         twist_msg.angular.z = 0.0;
 
-        digitalWrite(LED_PIN, HIGH);
+        ledWrite(HIGH);
     }
     // get the required rpm for each motor based on required velocities, and base used
     Kinematics::rpm req_rpm = kinematics.getRPM(
@@ -563,9 +609,9 @@ void flashLED(int n_times)
 {
     for(int i=0; i<n_times; i++)
     {
-        digitalWrite(LED_PIN, HIGH);
+        ledWrite(HIGH);
         delay(150);
-        digitalWrite(LED_PIN, LOW);
+        ledWrite(LOW);
         delay(150);
     }
     delay(1000);

--- a/firmware/src/firmware.ino
+++ b/firmware/src/firmware.ino
@@ -25,6 +25,7 @@
 #include <sensor_msgs/msg/magnetic_field.h>
 #include <sensor_msgs/msg/battery_state.h>
 #include <sensor_msgs/msg/range.h>
+#include <std_msgs/msg/bool.h>
 #include <geometry_msgs/msg/twist.h>
 #include <geometry_msgs/msg/vector3.h>
 
@@ -39,6 +40,10 @@
 #define ENCODER_USE_INTERRUPTS
 #define ENCODER_OPTIMIZE_INTERRUPTS
 #include "encoder.h"
+#include "fake_wheel.h"
+#ifdef USE_FAKE_LD19
+#include "fake_ld19.h"
+#endif
 #include "battery.h"
 #include "range.h"
 #include "lidar.h"
@@ -92,11 +97,25 @@ static inline void set_microros_net_transports(IPAddress agent_ip, uint16_t agen
   if (uxr_millis() - init > MS) { X; init = uxr_millis();} \
 } while (0)
 
+// mag.h falls back to FakeMAG and defines USE_FAKE_MAG whenever no magnetometer
+// chip is configured, and the topic is then left out entirely. But fake wheel
+// mode synthesises a real field from the simulated heading, hard-iron bias and
+// all, which is exactly what a calibration run needs -- so publish it there
+// even though no chip is present.
+#if !defined(USE_FAKE_MAG) || defined(USE_FAKE_WHEEL)
+#define PUBLISH_MAG
+#endif
+
 rcl_publisher_t odom_publisher;
 rcl_publisher_t imu_publisher;
 rcl_publisher_t mag_publisher;
 rcl_subscription_t twist_subscriber;
 rcl_publisher_t battery_publisher;
+#ifdef USE_SAFETY_STOP
+rcl_publisher_t safety_stop_publisher;
+std_msgs__msg__Bool safety_stop_msg;
+bool safety_stopped = false;
+#endif
 rcl_publisher_t range_publisher;
 
 nav_msgs__msg__Odometry odom_msg;
@@ -112,6 +131,10 @@ rcl_allocator_t allocator;
 rcl_node_t node;
 rcl_timer_t control_timer;
 
+bool syncTime(bool force = false);
+#ifndef TIME_RESYNC_SETTLE_MS
+#define TIME_RESYNC_SETTLE_MS 250 // let entity-creation traffic drain first
+#endif
 unsigned long long time_offset = 0;
 unsigned long prev_cmd_time = 0;
 unsigned long prev_odom_update = 0;
@@ -125,10 +148,17 @@ enum states
   AGENT_DISCONNECTED
 } state;
 
-Encoder motor1_encoder(MOTOR1_ENCODER_A, MOTOR1_ENCODER_B, COUNTS_PER_REV1, MOTOR1_ENCODER_INV);
-Encoder motor2_encoder(MOTOR2_ENCODER_A, MOTOR2_ENCODER_B, COUNTS_PER_REV2, MOTOR2_ENCODER_INV);
-Encoder motor3_encoder(MOTOR3_ENCODER_A, MOTOR3_ENCODER_B, COUNTS_PER_REV3, MOTOR3_ENCODER_INV);
-Encoder motor4_encoder(MOTOR4_ENCODER_A, MOTOR4_ENCODER_B, COUNTS_PER_REV4, MOTOR4_ENCODER_INV);
+#ifdef USE_FAKE_WHEEL
+FakeIMUFromWheels fake_imu;
+#endif
+#ifdef USE_FAKE_LD19
+FakeLD19 fake_ld19;
+#endif
+
+ENCODER motor1_encoder(MOTOR1_ENCODER_A, MOTOR1_ENCODER_B, COUNTS_PER_REV1, MOTOR1_ENCODER_INV);
+ENCODER motor2_encoder(MOTOR2_ENCODER_A, MOTOR2_ENCODER_B, COUNTS_PER_REV2, MOTOR2_ENCODER_INV);
+ENCODER motor3_encoder(MOTOR3_ENCODER_A, MOTOR3_ENCODER_B, COUNTS_PER_REV3, MOTOR3_ENCODER_INV);
+ENCODER motor4_encoder(MOTOR4_ENCODER_A, MOTOR4_ENCODER_B, COUNTS_PER_REV4, MOTOR4_ENCODER_INV);
 
 Motor motor1_controller(PWM_FREQUENCY, PWM_BITS, MOTOR1_INV, MOTOR1_PWM, MOTOR1_IN_A, MOTOR1_IN_B);
 Motor motor2_controller(PWM_FREQUENCY, PWM_BITS, MOTOR2_INV, MOTOR2_PWM, MOTOR2_IN_A, MOTOR2_IN_B);
@@ -220,6 +250,14 @@ void setup()
 
     initWifis();
     initOta();
+#ifdef USE_FAKE_WHEEL
+    // A bare module has nothing on the I2C bus, so probing it would fail and
+    // the fatal loops below would trap the board before it ever connects. The
+    // simulated IMU and magnetometer are computed from the simulated wheels
+    // anyway, and would overwrite whatever a real sensor returned -- so skip
+    // the hardware entirely and just prepare the two messages.
+    fake_imu.initMsgs(imu_msg, mag_msg);
+#else
     bool imu_ok = imu.init();
     if (!imu_ok) // take IMU failure as fatal
     {
@@ -244,9 +282,22 @@ void setup()
             runOta();
         }
     }
+#endif
     initBattery();
     initRange();
+#if defined(USE_FAKE_SONAR) && defined(USE_FAKE_LD19)
+    // initRange() only sets this up when a real sensor is compiled in
+    range_msg.header.frame_id =
+        micro_ros_string_utilities_set(range_msg.header.frame_id, "sonar_link");
+#endif
     initLidar(); // after wifi connected
+#ifdef USE_FAKE_LD19
+#ifdef LIDAR_RXD
+    fake_ld19.begin(LIDAR_RXD, LIDAR_BAUDRATE);
+#else
+    fake_ld19.begin();
+#endif
+#endif
     battery_msg = getBattery();
     prev_voltage = battery_msg.voltage;
 
@@ -262,7 +313,45 @@ void setup()
     syslog(LOG_INFO, "%s Ready %lu", __FUNCTION__, millis());
 }
 
+#ifdef USE_FAKE_LD19
+// Simulated wall contact indicator.
+//
+// LED_PIN may be -1 on boards with no addressable status LED, or LED_BUILTIN,
+// which is a non-macro identifier the preprocessor evaluates as 0 -- so the
+// guard is "defined and >= 0" and LED_BUILTIN boards stay enabled.
+//
+// The flash is timed rather than delayed: this runs inside the 50 Hz control
+// path, and a delay() here would stall the whole loop.
+#if defined(LED_PIN) && (LED_PIN) >= 0
+#define FAKE_WALL_LED
+#endif
+
+static unsigned long fake_wall_led_off_at = 0;
+
+static inline void fakeWallLedOn()
+{
+#ifdef FAKE_WALL_LED
+    digitalWrite(LED_PIN, HIGH);
+    fake_wall_led_off_at = millis() + 120;
+#endif
+}
+
+static inline void fakeWallLedService()
+{
+#ifdef FAKE_WALL_LED
+    if (fake_wall_led_off_at != 0 && (long)(millis() - fake_wall_led_off_at) >= 0)
+    {
+        digitalWrite(LED_PIN, LOW);
+        fake_wall_led_off_at = 0;
+    }
+#endif
+}
+#endif
+
 void loop() {
+#ifdef USE_FAKE_LD19
+    fakeWallLedService();
+#endif
     switch (state) 
     {
         case WAITING_AGENT:
@@ -301,6 +390,9 @@ void loop() {
 #endif
 #ifdef BOARD_LOOP // board specific loop
     BOARD_LOOP
+#endif
+#ifdef USE_FAKE_LD19
+    fake_ld19.step();
 #endif
 }
 
@@ -342,13 +434,13 @@ bool createEntities()
         &node,
         ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, Imu),
     // if we have magnetomter, use imu/data_raw for madgwick filter
-#ifndef USE_FAKE_MAG
+#ifdef PUBLISH_MAG
         TOPIC_PREFIX "imu/data_raw"
 #else
         TOPIC_PREFIX "imu/data"
 #endif
     ));
-#ifndef USE_FAKE_MAG
+#ifdef PUBLISH_MAG
     RCCHECK(rclc_publisher_init_default(
         &mag_publisher,
         &node,
@@ -365,7 +457,18 @@ bool createEntities()
     TOPIC_PREFIX "battery"
     ));
 #endif
-#ifdef ECHO_PIN
+#ifdef USE_SAFETY_STOP
+    // Tells ROS the robot stopped itself. The stop is a firmware reflex -- it
+    // has to keep working when the ROS side is busy, wedged or disconnected --
+    // so this publisher only reports the state, it never decides it.
+    RCCHECK(rclc_publisher_init_default(
+    &safety_stop_publisher,
+    &node,
+    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool),
+    TOPIC_PREFIX "safety_stop"
+    ));
+#endif
+#if defined(ECHO_PIN) || (defined(USE_FAKE_SONAR) && defined(USE_FAKE_LD19))
     // create range pyblisher
     RCCHECK(rclc_publisher_init_default(
     &range_publisher,
@@ -401,9 +504,51 @@ bool createEntities()
     ));
     RCCHECK(rclc_executor_add_timer(&executor, &control_timer));
 
-    // synchronize time with the agent
+    // Synchronize time with the agent -- twice, deliberately.
+    //
+    // time_offset is a single round-trip estimate, and the first one is taken
+    // immediately after this function has pushed ~10 entity creations down the
+    // same link. The reply queues behind that traffic, the round trip is
+    // measured as far longer than it is, and the offset is biased for the whole
+    // session because the old code returned early forever after. Measured on an
+    // ESP32 at 1.5 Mbaud: every board-stamped topic landed 0.34 s in the past
+    // and stayed there.
+    //
+    // Nothing on the robot notices. But the LiDAR is stamped by the robot PC,
+    // not the board, so /scan ends up 0.34 s ahead of the robot's own
+    // transforms; tf2 cannot satisfy a scan within slam_toolbox's 0.2 s
+    // transform_timeout, every scan is dropped with "queue is full", and SLAM
+    // produces no map and no error. That applies to any real LiDAR on the robot
+    // computer just as much as to the simulated one.
+    //
+    // The second sync runs once the link has gone quiet, so it measures a true
+    // round trip. It stays here in createEntities(), outside the executor, where
+    // a blocking call is safe -- doing this periodically from the control loop
+    // is what killed the session.
     syncTime();
+    delay(TIME_RESYNC_SETTLE_MS);
+    syncTime(true);
     ledWrite(HIGH);
+
+#ifdef USE_FAKE_WHEEL
+    // A simulated robot has no way to be picked up and put back at the start,
+    // and its pose is board state: it survives the host container, the agent
+    // and the whole ROS stack being torn down and rebuilt. So a second test run
+    // silently begins wherever the first one parked the robot -- and once that
+    // is against a simulated wall, USE_SAFETY_STOP zeroes forward velocity and
+    // navigation fails as "goal outside map" or "failed to make progress",
+    // neither of which points at inherited state. A new agent session means a
+    // new run, so start it from the origin.
+    //
+    // Real robots deliberately do not do this: odometry must stay continuous
+    // across a reconnect, or the transform tree jumps under whatever is
+    // localising against it.
+    odometry.reset();
+#ifdef USE_FAKE_LD19
+    fake_ld19.updatePose(0.0f, 0.0f, 0.0f);
+#endif
+    syslog(LOG_INFO, "%s simulated pose reset to origin %lu", __FUNCTION__, millis());
+#endif
 
     return true;
 }
@@ -416,13 +561,16 @@ bool destroyEntities()
 
     RCSOFTCHECK(rcl_publisher_fini(&odom_publisher, &node));
     RCSOFTCHECK(rcl_publisher_fini(&imu_publisher, &node));
-#ifndef USE_FAKE_MAG
+#ifdef PUBLISH_MAG
     RCSOFTCHECK(rcl_publisher_fini(&mag_publisher, &node));
 #endif
 #if defined(BATTERY_PIN) || defined(USE_INA219)
     RCSOFTCHECK(rcl_publisher_fini(&battery_publisher, &node));
 #endif
-#ifdef ECHO_PIN
+#ifdef USE_SAFETY_STOP
+    RCSOFTCHECK(rcl_publisher_fini(&safety_stop_publisher, &node));
+#endif
+#if defined(ECHO_PIN) || (defined(USE_FAKE_SONAR) && defined(USE_FAKE_LD19))
     RCSOFTCHECK(rcl_publisher_fini(&range_publisher, &node));
 #endif
     RCSOFTCHECK(rcl_subscription_fini(&twist_subscriber, &node));
@@ -448,6 +596,27 @@ void fullStop()
     motor4_controller.brake();
 }
 
+#ifdef USE_SAFETY_STOP
+#ifndef SAFETY_STOP_RANGE
+#define SAFETY_STOP_RANGE 0.25f     // metres ahead before forward motion is cut
+#endif
+
+// Forward range from whichever sensor is compiled in, or -1 when there is none
+// to consult -- in which case nothing is blocked, because a missing sensor must
+// not brake the robot.
+static inline float rangeAheadOrNegative()
+{
+#if defined(USE_FAKE_SONAR) && defined(USE_FAKE_LD19)
+    return fake_ld19.rangeAheadM();
+#elif defined(ECHO_PIN)
+    const float r = getRange().range;
+    return isfinite(r) ? r : -1.0f;
+#else
+    return -1.0f;
+#endif
+}
+#endif
+
 void moveBase()
 {
     // brake if there's no command received, or when it's only the first command sent
@@ -459,6 +628,32 @@ void moveBase()
 
         ledWrite(HIGH);
     }
+
+#ifdef USE_SAFETY_STOP
+    // Forward hazard stop, decided here rather than in ROS. A stop that has to
+    // travel out on a topic, be reasoned about, and come back as cmd_vel is one
+    // network round trip too slow, and does nothing at all if the ROS side is
+    // wedged or the link drops. This runs every control cycle regardless.
+    //
+    // Only forward motion is blocked: reverse and rotation stay available, or
+    // the robot would be stuck against the obstacle with no way to back off.
+    {
+        const float range = rangeAheadOrNegative();
+        const bool blocked = (range >= 0.0f) && (range < (float)SAFETY_STOP_RANGE);
+        if (blocked && twist_msg.linear.x > 0.0)
+        {
+            twist_msg.linear.x = 0.0;
+            twist_msg.linear.y = 0.0;
+        }
+        if (blocked != safety_stopped)
+        {
+            safety_stopped = blocked;
+            syslog(LOG_INFO, "%s safety stop %s at %.2f m %lu", __FUNCTION__,
+                   blocked ? "engaged" : "cleared", range, millis());
+        }
+    }
+#endif
+
     // get the required rpm for each motor based on required velocities, and base used
     Kinematics::rpm req_rpm = kinematics.getRPM(
         twist_msg.linear.x, 
@@ -474,10 +669,21 @@ void moveBase()
 
     // the required rpm is capped at -/+ MAX_RPM to prevent the PID from having too much error
     // the PWM value sent to the motor driver is the calculated PID based on required RPM vs measured RPM
-    motor1_controller.spin(motor1_pid.compute(req_rpm.motor1, current_rpm1));
-    motor2_controller.spin(motor2_pid.compute(req_rpm.motor2, current_rpm2));
-    motor3_controller.spin(motor3_pid.compute(req_rpm.motor3, current_rpm3));
-    motor4_controller.spin(motor4_pid.compute(req_rpm.motor4, current_rpm4));
+    int pwm1 = motor1_pid.compute(req_rpm.motor1, current_rpm1);
+    int pwm2 = motor2_pid.compute(req_rpm.motor2, current_rpm2);
+    int pwm3 = motor3_pid.compute(req_rpm.motor3, current_rpm3);
+    int pwm4 = motor4_pid.compute(req_rpm.motor4, current_rpm4);
+    motor1_controller.spin(pwm1);
+    motor2_controller.spin(pwm2);
+    motor3_controller.spin(pwm3);
+    motor4_controller.spin(pwm4);
+#ifdef USE_FAKE_WHEEL
+    // close the loop in software: the simulated wheels follow the commanded PWM
+    motor1_encoder.feed(pwm1);
+    motor2_encoder.feed(pwm2);
+    motor3_encoder.feed(pwm3);
+    motor4_encoder.feed(pwm4);
+#endif
 
     Kinematics::velocities current_vel = kinematics.getVelocities(
         current_rpm1, 
@@ -495,17 +701,68 @@ void moveBase()
         current_vel.linear_y, 
         current_vel.angular_z
     );
+#ifdef USE_FAKE_LD19
+    // Stop the simulated robot at the simulated walls, and correct the
+    // odometry to match, so /odom and /scan never disagree about where it is.
+    float fake_x = odometry.getX();
+    float fake_y = odometry.getY();
+    bool hit_wall = fake_ld19.clampToRoom(fake_x, fake_y);
+    if (hit_wall)
+        odometry.setPosition(fake_x, fake_y);
+    fake_ld19.updatePose(fake_x, fake_y, odometry.getHeading());
+#else
+    const bool hit_wall = false;
+#endif
+#ifdef USE_FAKE_WHEEL
+    // The IMU rides on how the body actually moved, which is not what the
+    // wheels claim once the robot is against a wall. Real hardware behaves the
+    // same way: the wheels slip and keep reporting speed, while the IMU feels
+    // no acceleration and the robot goes nowhere. Keeping that disagreement is
+    // the only feedback there is that something was hit -- there is no bump
+    // sensor, and odometry velocity alone never reveals it. Rotation survives,
+    // since a robot pinned against a wall can still turn on the spot.
+    fake_imu.update(
+        hit_wall ? 0.0f : current_vel.linear_x,
+        hit_wall ? 0.0f : current_vel.linear_y,
+        current_vel.angular_z,
+        vel_dt
+    );
+    fake_imu.setHeading(odometry.getHeading());
+#endif
+#ifdef USE_FAKE_LD19
+    // Announce the contact once, on the way in. Driving into a wall holds the
+    // clamp active for as long as the command lasts, so logging every 20 ms
+    // cycle would bury the syslog in identical lines.
+    static bool was_clamped = false;
+    if (hit_wall && !was_clamped)
+    {
+        syslog(LOG_INFO, "%s fake wall contact at x %.2f y %.2f %lu",
+               __FUNCTION__, fake_x, fake_y, millis());
+        fakeWallLedOn();
+    }
+    was_clamped = hit_wall;
+#endif
 }
 
 void publishData()
 {
     static unsigned skip_dip = 0;
     odom_msg = odometry.getData();
+#ifdef USE_FAKE_WHEEL
+    // Every field these would return is overwritten just below, and on a bare
+    // module the reads are two failing I2C transactions per publish, each one
+    // stalling the loop for the bus timeout. Skip them.
+    fake_imu.apply(imu_msg);
+    // Simulated wheels mean a simulated heading, so the magnetometer has to
+    // follow it: a real one left in the loop here would fight the fused yaw.
+    fake_imu.applyMag(mag_msg);
+#else
     imu_msg = imu.getData();
 #ifdef USE_FAKE_IMU
     imu_msg.angular_velocity.z = odom_msg.twist.twist.angular.z;
 #endif
     mag_msg = mag.getData();
+#endif
 #ifdef MAG_BIAS
     const float mag_bias[3] = MAG_BIAS;
     mag_msg.magnetic_field.x -= mag_bias[0];
@@ -521,13 +778,13 @@ void publishData()
     imu_msg.header.stamp.sec = time_stamp.tv_sec;
     imu_msg.header.stamp.nanosec = time_stamp.tv_nsec;
 
-#ifndef USE_FAKE_MAG
+#ifdef PUBLISH_MAG
     mag_msg.header.stamp.sec = time_stamp.tv_sec;
     mag_msg.header.stamp.nanosec = time_stamp.tv_nsec;
 #endif
 
     RCSOFTCHECK(rcl_publish(&imu_publisher, &imu_msg, NULL));
-#ifndef USE_FAKE_MAG
+#ifdef PUBLISH_MAG
     RCSOFTCHECK(rcl_publish(&mag_publisher, &mag_msg, NULL));
 #endif
     RCSOFTCHECK(rcl_publish(&odom_publisher, &odom_msg, NULL));
@@ -548,7 +805,25 @@ void publishData()
         getBatteryPercentage(&battery_msg);
         RCSOFTCHECK(rcl_publish(&battery_publisher, &battery_msg, NULL)) });
 #endif
-#ifdef ECHO_PIN
+#ifdef USE_SAFETY_STOP
+    safety_stop_msg.data = safety_stopped;
+    RCSOFTCHECK(rcl_publish(&safety_stop_publisher, &safety_stop_msg, NULL));
+#endif
+#if defined(USE_FAKE_SONAR) && defined(USE_FAKE_LD19)
+    // A simulated ultrasonic sensor, raycast from the same room the simulated
+    // LiDAR uses. This is the robot's own feedback that something is ahead --
+    // wheel odometry cannot provide it, because the wheels keep turning when
+    // the robot is stopped against something.
+    EXECUTE_EVERY_N_MS(RANGE_TIMER, {
+        range_msg.range = fake_ld19.rangeAheadM();
+        range_msg.field_of_view = (float)FAKE_SONAR_CONE_DEG * (float)DEG_TO_RAD;
+        range_msg.min_range = 0.02;
+        range_msg.max_range = 4.0;
+        range_msg.radiation_type = sensor_msgs__msg__Range__ULTRASOUND;
+        range_msg.header.stamp.sec = time_stamp.tv_sec;
+        range_msg.header.stamp.nanosec = time_stamp.tv_nsec;
+        RCSOFTCHECK(rcl_publish(&range_publisher, &range_msg, NULL)) });
+#elif defined(ECHO_PIN)
     EXECUTE_EVERY_N_MS(RANGE_TIMER, {
         range_msg = getRange();
         range_msg.header.stamp.sec = time_stamp.tv_sec;
@@ -557,10 +832,15 @@ void publishData()
 #endif
 }
 
-bool syncTime()
+bool syncTime(bool force)
 {
+    // Keep the generous timeout. A short one is actively dangerous here: if
+    // rmw_uros_sync_session() gives up and the agent's reply then arrives, it
+    // lands in the XRCE stream as an unexpected message and takes the session
+    // with it -- measured as a board that published for a while and then went
+    // silent, and did not recover across an agent restart.
     const int timeout_ms = 1000;
-    if (rmw_uros_epoch_synchronized()) return true; // synchronized previously
+    if (!force && rmw_uros_epoch_synchronized()) return true;
     // get the current time from the agent
     RCCHECK(rmw_uros_sync_session(timeout_ms));
     if (rmw_uros_epoch_synchronized()) {

--- a/test_acc/src/firmware.cpp
+++ b/test_acc/src/firmware.cpp
@@ -45,6 +45,13 @@
 #define BAUDRATE 921600
 #endif
 
+// LED_ACTIVE is defined at most once (no #else branch): a board with an
+// addressable status LED sets LED_PIN >= 0; LED_PIN -1 (e.g. Waveshare GenDrv)
+// leaves it undefined and the LED writes below compile out.
+#if defined(LED_PIN) && (LED_PIN) >= 0
+#define LED_ACTIVE
+#endif
+
 nav_msgs__msg__Odometry odom_msg;
 sensor_msgs__msg__Imu imu_msg;
 sensor_msgs__msg__MagneticField mag_msg;
@@ -85,7 +92,7 @@ unsigned total_motors = 4;
 void setup()
 {
     Serial.begin(BAUDRATE);
-#ifdef LED_PIN
+#ifdef LED_ACTIVE
     pinMode(LED_PIN, OUTPUT);
 #endif
 #ifdef BOARD_INIT // board specific setup
@@ -211,7 +218,7 @@ void loop() {
         idx = 0;
         imu_max_acc_x = 0;
         imu_min_acc_x = 0;
-#ifdef LED_PIN
+#ifdef LED_ACTIVE
         digitalWrite(LED_PIN, HIGH);
 #endif
         motor1_controller.spin((runs & 1) ? current_pwm_max : current_pwm_min);
@@ -220,7 +227,7 @@ void loop() {
         motor4_controller.spin(current_pwm_max);
         record(run_time / ticks);
 
-#ifdef LED_PIN
+#ifdef LED_ACTIVE
         digitalWrite(LED_PIN, LOW);
 #endif
         motor1_controller.spin(0);
@@ -229,7 +236,7 @@ void loop() {
         motor4_controller.spin(0);
         record(run_time / ticks);
 
-#ifdef LED_PIN
+#ifdef LED_ACTIVE
         digitalWrite(LED_PIN, HIGH);
 #endif
         motor1_controller.spin((runs & 1) ? current_pwm_min : current_pwm_max);
@@ -238,7 +245,7 @@ void loop() {
         motor4_controller.spin(current_pwm_min);
         record(run_time / ticks);
 
-#ifdef LED_PIN
+#ifdef LED_ACTIVE
         digitalWrite(LED_PIN, LOW);
 #endif
         motor1_controller.spin(0);

--- a/test_motors/src/firmware.cpp
+++ b/test_motors/src/firmware.cpp
@@ -52,16 +52,22 @@ geometry_msgs__msg__Twist twist_msg;
 sensor_msgs__msg__BatteryState battery_msg;
 sensor_msgs__msg__Range range_msg;
 
+#if defined(LED_PIN) && (LED_PIN) >= 0
+#define LED_ACTIVE
+#endif
+
 void setLed(int value)
 {
-#ifdef LED_PIN
+#ifdef LED_ACTIVE
     digitalWrite(LED_PIN, value);
+#else
+    (void)value;
 #endif
 }
 
 int getLed(void)
 {
-#ifdef LED_PIN
+#ifdef LED_ACTIVE
     return digitalRead(LED_PIN);
 #else
     return 0;
@@ -70,7 +76,7 @@ int getLed(void)
 
 void initLed(void)
 {
-#ifdef LED_PIN
+#ifdef LED_ACTIVE
     pinMode(LED_PIN, OUTPUT);
 #endif
 }

--- a/tools/i2c_detect/platformio.ini
+++ b/tools/i2c_detect/platformio.ini
@@ -1,0 +1,62 @@
+[platformio]
+default_envs = pico2, esp32, gendrv
+
+[env]
+monitor_speed = 921600
+build_flags =
+    ; i2c_detect lives under tools/, so the repo config/ dir is two levels up
+    -I ../../config
+
+[env:pico2]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = rpipico2
+framework = arduino
+upload_protocol = picotool
+upload_port = /dev/ttyACM0
+build_flags =
+    ${env.build_flags}
+    -D PICO
+    -D PICO2
+    -D USE_PICO_CONFIG
+
+[env:pico]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = rpipico
+framework = arduino
+upload_protocol = picotool
+upload_port = /dev/ttyACM0
+build_flags =
+    ${env.build_flags}
+    -D PICO
+    -D USE_PICO_CONFIG
+
+[env:esp32]
+platform = espressif32
+board = nodemcu-32s
+framework = arduino
+upload_port = /dev/ttyUSB0
+upload_speed = 921600
+build_flags =
+    ${env.build_flags}
+    -D USE_ESP32_CONFIG
+
+[env:esp32s3]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+upload_port = /dev/ttyACM0
+upload_speed = 921600
+build_flags =
+    ${env.build_flags}
+    -D ARDUINO_USB_CDC_ON_BOOT
+    -D USE_ESP32S3_CONFIG
+
+[env:gendrv]
+platform = espressif32
+board = esp32doit-devkit-v1
+framework = arduino
+upload_port = /dev/ttyUSB0
+upload_speed = 921600
+build_flags =
+    ${env.build_flags}
+    -D USE_GENDRV_CONFIG

--- a/tools/i2c_detect/src/firmware.cpp
+++ b/tools/i2c_detect/src/firmware.cpp
@@ -1,0 +1,252 @@
+// Copyright (c) 2026 Linorobot contributors
+// AI-MAINTAINED AUTO-GENERATED FILE. DO NOT MANUALLY EDIT.
+// Generator: Linorobot2 AI Sensor Auto-Detection & Probing Engine
+//
+// Scans the active I2C bus, identifies responding sensor chips via WHO_AM_I
+// and identification registers, and streams machine-readable JSON over serial
+// to enable 1-click automatic driver selection in the Web UI Studio.
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <stdio.h>
+#include "config.h"
+
+#ifndef BAUDRATE
+#define BAUDRATE 921600
+#endif
+
+// Forward declarations for I2C register probing
+uint8_t readRegister8(uint8_t addr, uint8_t reg) {
+    Wire.beginTransmission(addr);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) return 0xFF;
+    Wire.requestFrom((int)addr, 1);
+    if (Wire.available()) return Wire.read();
+    return 0xFF;
+}
+
+uint16_t readRegister16BE(uint8_t addr, uint8_t reg) {
+    Wire.beginTransmission(addr);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) return 0xFFFF;
+    Wire.requestFrom((int)addr, 2);
+    if (Wire.available() >= 2) {
+        uint16_t val = ((uint16_t)Wire.read()) << 8;
+        val |= Wire.read();
+        return val;
+    }
+    return 0xFFFF;
+}
+
+struct DetectedSensor {
+    uint8_t addr;
+    const char* category; // "imu", "mag", "current", "env"
+    const char* model;    // "QMI8658", "MPU6050", "AK09918", "INA219", etc.
+    const char* macro;    // "USE_QMI8658_IMU", "USE_AK09918_MAG", "USE_INA219"
+    const char* desc;     // Human readable
+};
+
+DetectedSensor detected[16];
+int num_detected = 0;
+
+void addDetected(uint8_t addr, const char* category, const char* model, const char* macro, const char* desc) {
+    if (num_detected < 16) {
+        detected[num_detected++] = { addr, category, model, macro, desc };
+    }
+}
+
+void scanAndIdentify() {
+    num_detected = 0;
+    Serial.println("\n=======================================================");
+    Serial.println("  🤖 Linorobot2 AI I2C Sensor Auto-Detection Engine    ");
+    Serial.println("=======================================================");
+#if defined(I2C_SCAN_SDA) && defined(I2C_SCAN_SCL)
+    Serial.printf("Scanning I2C bus @ 400kHz (SDA:%d, SCL:%d)...\n", I2C_SCAN_SDA, I2C_SCAN_SCL);
+#else
+    Serial.println("Scanning I2C bus @ 400kHz (board default pins)...");
+#endif
+
+    uint8_t found_addrs[128];
+    int num_found = 0;
+
+    for (uint8_t addr = 1; addr < 127; addr++) {
+        Wire.beginTransmission(addr);
+        if (Wire.endTransmission() == 0) {
+            found_addrs[num_found++] = addr;
+            Serial.printf(" [0x%02X] Device ACK received\n", addr);
+        }
+    }
+
+    if (num_found == 0) {
+        Serial.println("[-] No I2C devices detected on bus.");
+    }
+
+    // Identify detected devices via WHO_AM_I registers
+    for (int i = 0; i < num_found; i++) {
+        uint8_t addr = found_addrs[i];
+
+        // 1. Check QMI8658 / QMI8658C (0x6B or 0x6A)
+        if (addr == 0x6B || addr == 0x6A) {
+            uint8_t who = readRegister8(addr, 0x00);
+            if (who == 0x05) {
+                addDetected(addr, "imu", "QMI8658", "USE_QMI8658_IMU", "QMI8658 6-Axis IMU (Acc+Gyr)");
+                continue;
+            }
+        }
+
+        // 2. Check MPU6050 / MPU9250 / MPU6500 (0x68 or 0x69)
+        if (addr == 0x68 || addr == 0x69) {
+            uint8_t who = readRegister8(addr, 0x75);
+            if (who == 0x68) {
+                addDetected(addr, "imu", "MPU6050", "USE_MPU6050_IMU", "MPU6050 6-Axis IMU");
+                continue;
+            } else if (who == 0x71 || who == 0x73) {
+                addDetected(addr, "imu", "MPU9250", "USE_MPU9250_IMU", "MPU9250 9-Axis IMU (Acc+Gyr+Mag)");
+                continue;
+            } else if (who == 0x70) {
+                addDetected(addr, "imu", "MPU6500", "USE_MPU6050_IMU", "MPU6500 6-Axis IMU");
+                continue;
+            }
+
+            // Check ITG3200 (0x68)
+            uint8_t itg_who = readRegister8(addr, 0x00);
+            if (itg_who == 0x68) {
+                addDetected(addr, "imu", "GY85", "USE_GY85_IMU", "ITG3200 Gyroscope (GY85 component)");
+                continue;
+            }
+        }
+
+        // 3. Check BNO085 / BNO080 (0x4A or 0x4B)
+        if (addr == 0x4A || addr == 0x4B) {
+            addDetected(addr, "imu", "BNO085", "USE_BNO085_IMU", "BNO085/BNO080 9-DOF Robotic IMU");
+            continue;
+        }
+
+        // 4. Check BNO055 (0x28 or 0x29)
+        if (addr == 0x28 || addr == 0x29) {
+            uint8_t who = readRegister8(addr, 0x00);
+            if (who == 0xA0) {
+                addDetected(addr, "imu", "BNO055", "USE_BNO085_IMU", "BNO055 9-DOF Absolute Orientation IMU");
+                continue;
+            }
+        }
+
+        // 5. Check ADXL345 (0x53)
+        if (addr == 0x53) {
+            uint8_t who = readRegister8(addr, 0x00);
+            if (who == 0xE5) {
+                addDetected(addr, "imu", "GY85", "USE_GY85_IMU", "ADXL345 Accelerometer (GY85)");
+                continue;
+            }
+        }
+
+        // 6. Check Magnetometers: AK09918 (0x0C), AK8963 (0x0C), AK8975 (0x0C), QMC5883L (0x0D), HMC5883L (0x1E)
+        if (addr >= 0x0C && addr <= 0x0F) {
+            uint8_t wia2 = readRegister8(addr, 0x01);
+            uint8_t wia = readRegister8(addr, 0x00);
+            if (wia2 == 0x09 || addr == 0x0C) {
+                addDetected(addr, "mag", "AK09918", "USE_AK09918_MAG", "AK09918 3-Axis Precision Magnetometer");
+                continue;
+            } else if (wia == 0x48) {
+                addDetected(addr, "mag", "AK8963", "USE_AK8963_MAG", "AK8963/AK8975 3-Axis Magnetometer");
+                continue;
+            } else if (addr == 0x0D) {
+                addDetected(addr, "mag", "QMC5883L", "USE_QMC5883L_MAG", "QMC5883L 3-Axis Compass");
+                continue;
+            }
+        }
+
+        if (addr == 0x1E) {
+            uint8_t id_a = readRegister8(addr, 10);
+            uint8_t id_b = readRegister8(addr, 11);
+            if (id_a == 'H' && id_b == '4') {
+                addDetected(addr, "mag", "HMC5883L", "USE_HMC5883L_MAG", "HMC5883L 3-Axis Digital Compass");
+                continue;
+            }
+        }
+
+        // 7. Check Current / Power Monitors: INA219 (0x40..0x45, Waveshare GenDrv @ 0x42)
+        if (addr >= 0x40 && addr <= 0x45) {
+            addDetected(addr, "current", "INA219", "USE_INA219", "INA219 High-Side DC Current & Power Sensor");
+            continue;
+        }
+
+        // 8. Check BMP280 / BME280 (0x76 or 0x77)
+        if (addr == 0x76 || addr == 0x77) {
+            uint8_t id = readRegister8(addr, 0xD0);
+            if (id == 0x58 || id == 0x60) {
+                addDetected(addr, "env", "BMP280", "USE_BMP280", "BMP280/BME280 Environmental Barometer");
+                continue;
+            }
+        }
+    }
+
+    // Print Human-Readable Table
+    Serial.println("\n--- Identified Hardware Matrix ---");
+    const char* detected_imu = "NONE";
+    const char* detected_mag = "NONE";
+    const char* detected_curr = "NONE";
+
+    for (int i = 0; i < num_detected; i++) {
+        Serial.printf(" [%d] ADDR: 0x%02X | CATEGORY: %-8s | MODEL: %-10s | MACRO: %-18s | %s\n",
+            i + 1, detected[i].addr, detected[i].category, detected[i].model, detected[i].macro, detected[i].desc);
+        if (strcmp(detected[i].category, "imu") == 0 && strcmp(detected_imu, "NONE") == 0) detected_imu = detected[i].model;
+        if (strcmp(detected[i].category, "mag") == 0 && strcmp(detected_mag, "NONE") == 0) detected_mag = detected[i].model;
+        if (strcmp(detected[i].category, "current") == 0 && strcmp(detected_curr, "NONE") == 0) detected_curr = detected[i].model;
+    }
+
+    if (num_detected == 0) {
+        Serial.println("  (No known sensor signatures recognized)");
+    }
+
+    // Emit Machine-Readable JSON stream for Web UI
+    Serial.print("\n[I2C_JSON] {");
+    Serial.print("\"status\":\"ok\",");
+    Serial.printf("\"imu\":\"%s\",", detected_imu);
+    Serial.printf("\"mag\":\"%s\",", detected_mag);
+    Serial.printf("\"current\":\"%s\",", detected_curr);
+    Serial.print("\"devices\":[");
+    for (int i = 0; i < num_detected; i++) {
+        if (i > 0) Serial.print(",");
+        Serial.printf("{\"addr\":\"0x%02x\",\"category\":\"%s\",\"model\":\"%s\",\"macro\":\"%s\",\"desc\":\"%s\"}",
+            detected[i].addr, detected[i].category, detected[i].model, detected[i].macro, detected[i].desc);
+    }
+    Serial.println("]}");
+    Serial.println("=======================================================\n");
+}
+
+#if defined(I2C_SDA_OVERRIDE) && defined(I2C_SCL_OVERRIDE)
+  #define I2C_SCAN_SDA I2C_SDA_OVERRIDE
+  #define I2C_SCAN_SCL I2C_SCL_OVERRIDE
+#elif defined(SDA_PIN) && defined(SCL_PIN)
+  #define I2C_SCAN_SDA SDA_PIN
+  #define I2C_SCAN_SCL SCL_PIN
+#endif
+
+void setup() {
+    Serial.begin(BAUDRATE);
+#if defined(I2C_SDA_OVERRIDE) && defined(I2C_SCL_OVERRIDE)
+    // Explicit pins from the Web UI pinout — independent of the board config.
+  #if defined(ARDUINO_ARCH_RP2040) || defined(PICO) || defined(PICO2)
+    Wire.setSDA(I2C_SDA_OVERRIDE);
+    Wire.setSCL(I2C_SCL_OVERRIDE);
+    Wire.begin();
+  #else
+    Wire.begin(I2C_SDA_OVERRIDE, I2C_SCL_OVERRIDE);
+  #endif
+    Wire.setClock(400000);
+#elif defined(BOARD_INIT)
+    BOARD_INIT;
+    Wire.setClock(400000);
+#else
+    Wire.begin();
+    Wire.setClock(400000);
+#endif
+    delay(1500);
+    scanAndIdentify();
+}
+
+void loop() {
+    delay(5000);
+    scanAndIdentify();
+}

--- a/tools/robot_config_engine/.gitignore
+++ b/tools/robot_config_engine/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tools/robot_config_engine/README.md
+++ b/tools/robot_config_engine/README.md
@@ -1,0 +1,52 @@
+# Linorobot2 Robot Configuration Engine
+
+The **Robot Configuration Engine** is an automated hardware rule validation and code generation tool for Linorobot2. It translates high-level robot hardware specifications (JSON or Web UI) into production-ready C++ firmware headers, PlatformIO build environments, and ROS 2 URDF Xacro descriptions while guarding against electrical and microcontroller-specific hazards.
+
+---
+
+## 🌐 Interactive Web UI
+
+The Configuration Engine includes a **100% client-side, zero-dependency interactive Web UI** located in `tools/robot_config_engine/web/`. It can be opened directly in any modern web browser or hosted statically via GitHub Pages / MkDocs.
+
+- **Live Kinematics HUD**: Real-time calculation of max linear velocity (with 85% PID headroom), angular velocity, and ticks per meter.
+- **Hardware Safety Inspector**: Instant visual warnings for duplicate pin collisions, ESP32 input-only GPIOs, boot strapping pins, and RP2040 ADC bounds.
+- **Smart Auto-Assign**: One-click conflict-free pin allocation for Pico, Pico 2, ESP32, ESP32-S3, and Waveshare General Driver boards.
+- **Multi-Artifact Code Generator**: Real-time tabbed preview and one-click download for C++ config headers, PlatformIO snippets, URDF descriptions, wiring charts, and JSON specifications.
+
+### Launching the Web UI Locally
+```bash
+cd tools/robot_config_engine/web
+python3 -m http.server 8000
+# Open http://localhost:8000 in your browser
+```
+
+---
+
+## 🚀 CLI Features & Usage
+
+### 1. Validate Specification and Generate Code
+```bash
+python3 tools/robot_config_engine/generate_config.py examples/scout_pico2.json --out-dir ./output/
+```
+
+### 2. Preview in Terminal (No files written)
+```bash
+python3 tools/robot_config_engine/generate_config.py examples/scout_pico2.json
+```
+
+### 3. Run Unit Test Suite
+```bash
+python3 -m unittest tools/robot_config_engine/test_config_engine.py
+```
+
+---
+
+## 📁 File Structure
+
+- `web/`: 100% Client-side interactive Web UI (`index.html`, `style.css`, `app.js`).
+- `generate_config.py`: CLI entry point.
+- `validator.py`: Rule-based hardware and electrical validation engine.
+- `generator.py`: Template generator for C++, PlatformIO, and URDF Xacro.
+- `schema.json`: JSON schema definition for robot hardware specifications.
+- `test_config_engine.py`: Unit test suite covering valid specs and electrical error conditions.
+- `examples/`: Sample JSON specifications (`scout_pico2.json`, `mech_esp32.json`, `crawler_esp32s3.json`).

--- a/tools/robot_config_engine/docker/Dockerfile.builder
+++ b/tools/robot_config_engine/docker/Dockerfile.builder
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git build-essential udev curl pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+    platformio \
+    "cmake<4.0.0" \
+    catkin_pkg \
+    "empy==3.3.4" \
+    colcon-common-extensions \
+    lark
+
+WORKDIR /workspace

--- a/tools/robot_config_engine/examples/crawler_esp32s3.json
+++ b/tools/robot_config_engine/examples/crawler_esp32s3.json
@@ -1,0 +1,72 @@
+{
+  "robot_name": "crawler_esp32s3",
+  "kinematics": "SKID_STEER",
+  "mcu": "ESP32S3",
+  "transport": "SERIAL",
+  "geometry": {
+    "wheel_diameter": 0.085,
+    "track_width": 0.26,
+    "wheelbase": 0.22,
+    "weight": 4.2
+  },
+  "motors": {
+    "driver_type": "GENERIC_2_IN",
+    "max_rpm": 280,
+    "cpr": 1400,
+    "rated_torque": 2.0,
+    "rated_voltage": 12.0
+  },
+  "sensors": {
+    "imu": "MPU6050",
+    "mag": "NONE",
+    "battery_monitor": "ADC_DIVIDER",
+    "sonar": true,
+    "battery_nominal_voltage": 11.1,
+    "battery_capacity": 3.3,
+    "battery_min_voltage": 9.0,
+    "battery_max_voltage": 12.6,
+    "battery_dip": 0.98
+  },
+  "pins": {
+    "led": 48,
+    "motor1": {
+      "pwm": 1,
+      "in_a": 2,
+      "in_b": 4
+    },
+    "motor2": {
+      "pwm": 5,
+      "in_a": 6,
+      "in_b": 7
+    },
+    "motor3": {
+      "pwm": 8,
+      "in_a": 9,
+      "in_b": 10
+    },
+    "motor4": {
+      "pwm": 11,
+      "in_a": 12,
+      "in_b": 13
+    },
+    "encoders": {
+      "m1_a": 14,
+      "m1_b": 15,
+      "m2_a": 16,
+      "m2_b": 17,
+      "m3_a": 18,
+      "m3_b": 21,
+      "m4_a": 38,
+      "m4_b": 39
+    },
+    "i2c": {
+      "sda": 41,
+      "scl": 42
+    },
+    "battery_pin": 3,
+    "sonar": {
+      "trig": 47,
+      "echo": 40
+    }
+  }
+}

--- a/tools/robot_config_engine/examples/mech_esp32.json
+++ b/tools/robot_config_engine/examples/mech_esp32.json
@@ -1,0 +1,78 @@
+{
+  "robot_name": "mech_esp32",
+  "kinematics": "MECANUM",
+  "mcu": "ESP32",
+  "transport": "WIFI_UDP",
+  "wifi_settings": {
+    "ssid": "YOUR_WIFI_SSID",
+    "password": "YOUR_WIFI_PASSWORD",
+    "agent_ip": "192.168.1.100",
+    "agent_port": 8888
+  },
+  "geometry": {
+    "wheel_diameter": 0.08,
+    "track_width": 0.28,
+    "wheelbase": 0.24,
+    "weight": 5.0
+  },
+  "motors": {
+    "driver_type": "GENERIC_2_IN",
+    "max_rpm": 300,
+    "cpr": 1500,
+    "operating_voltage": 12.0,
+    "rated_torque": 2.5,
+    "rated_voltage": 12.0
+  },
+  "sensors": {
+    "imu": "BNO085",
+    "mag": "NONE",
+    "battery_monitor": "INA219",
+    "battery_nominal_voltage": 11.1,
+    "battery_capacity": 5.0,
+    "battery_min_voltage": 9.0,
+    "battery_max_voltage": 12.6,
+    "battery_dip": 0.98
+  },
+  "pins": {
+    "led": 2,
+    "motor1": {
+      "pwm": 13,
+      "in_a": 14,
+      "in_b": 27
+    },
+    "motor2": {
+      "pwm": 25,
+      "in_a": 26,
+      "in_b": 33
+    },
+    "motor3": {
+      "pwm": 18,
+      "in_a": 19,
+      "in_b": 23
+    },
+    "motor4": {
+      "pwm": 15,
+      "in_a": 16,
+      "in_b": 17
+    },
+    "encoders": {
+      "m1_a": 34,
+      "m1_b": 35,
+      "m2_a": 36,
+      "m2_b": 39,
+      "m3_a": 4,
+      "m3_b": 32,
+      "m4_a": 5,
+      "m4_b": 12
+    },
+    "i2c": {
+      "sda": 21,
+      "scl": 22
+    },
+    "battery_pin": 36,
+    "sonar": {
+      "trig": 0,
+      "echo": 0
+    }
+  }
+}

--- a/tools/robot_config_engine/examples/mech_pico2.json
+++ b/tools/robot_config_engine/examples/mech_pico2.json
@@ -1,0 +1,77 @@
+{
+  "robot_name": "mech_pico2",
+  "kinematics": "MECANUM",
+  "mcu": "PICO2",
+  "transport": "SERIAL",
+  "geometry": {
+    "wheel_diameter": 0.08,
+    "track_width": 0.26,
+    "wheelbase": 0.22,
+    "weight": 4.0
+  },
+  "motors": {
+    "driver_type": "GENERIC_2_IN",
+    "max_rpm": 330,
+    "cpr": 1440,
+    "operating_voltage": 12.0,
+    "rated_torque": 2.0,
+    "rated_voltage": 12.0,
+    "motor1_inv": false,
+    "motor2_inv": true,
+    "motor3_inv": false,
+    "motor4_inv": true
+  },
+  "sensors": {
+    "imu": "MPU6050",
+    "mag": "NONE",
+    "battery_monitor": "ADC_DIVIDER",
+    "battery_nominal_voltage": 11.1,
+    "battery_capacity": 3.0,
+    "battery_min_voltage": 9.0,
+    "battery_max_voltage": 12.6,
+    "battery_dip": 0.98,
+    "sonar": true
+  },
+  "pins": {
+    "led": 25,
+    "motor1": {
+      "pwm": 10,
+      "in_a": 11,
+      "in_b": 12
+    },
+    "motor2": {
+      "pwm": 13,
+      "in_a": 14,
+      "in_b": 15
+    },
+    "motor3": {
+      "pwm": 16,
+      "in_a": 17,
+      "in_b": 18
+    },
+    "motor4": {
+      "pwm": 19,
+      "in_a": 20,
+      "in_b": 21
+    },
+    "encoders": {
+      "m1_a": 2,
+      "m1_b": 3,
+      "m2_a": 4,
+      "m2_b": 5,
+      "m3_a": 6,
+      "m3_b": 7,
+      "m4_a": 8,
+      "m4_b": 9
+    },
+    "i2c": {
+      "sda": 0,
+      "scl": 1
+    },
+    "battery_pin": 26,
+    "sonar": {
+      "trig": 22,
+      "echo": 27
+    }
+  }
+}

--- a/tools/robot_config_engine/examples/scout_pico2.json
+++ b/tools/robot_config_engine/examples/scout_pico2.json
@@ -1,0 +1,62 @@
+{
+  "robot_name": "scout_pico2",
+  "kinematics": "DIFFERENTIAL_DRIVE",
+  "mcu": "PICO2",
+  "transport": "SERIAL",
+  "geometry": {
+    "wheel_diameter": 0.08,
+    "track_width": 0.22,
+    "weight": 3.5
+  },
+  "motors": {
+    "driver_type": "GENERIC_2_IN",
+    "max_rpm": 330,
+    "cpr": 1320,
+    "operating_voltage": 12.0,
+    "max_voltage": 12.0,
+    "pwm_frequency": 20000,
+    "motor1_inv": false,
+    "motor2_inv": true,
+    "rated_torque": 1.5,
+    "rated_voltage": 12.0
+  },
+  "sensors": {
+    "imu": "BNO085",
+    "mag": "NONE",
+    "battery_monitor": "ADC_DIVIDER",
+    "sonar": true,
+    "battery_nominal_voltage": 11.1,
+    "battery_capacity": 2.2,
+    "battery_min_voltage": 9.0,
+    "battery_max_voltage": 12.6,
+    "battery_dip": 0.98
+  },
+  "pins": {
+    "led": 25,
+    "motor1": {
+      "pwm": 14,
+      "in_a": 15,
+      "in_b": 13
+    },
+    "motor2": {
+      "pwm": 16,
+      "in_a": 17,
+      "in_b": 12
+    },
+    "encoders": {
+      "m1_a": 2,
+      "m1_b": 3,
+      "m2_a": 4,
+      "m2_b": 5
+    },
+    "i2c": {
+      "sda": 8,
+      "scl": 9
+    },
+    "battery_pin": 26,
+    "sonar": {
+      "trig": 18,
+      "echo": 19
+    }
+  }
+}

--- a/tools/robot_config_engine/examples/scout_pico2w.json
+++ b/tools/robot_config_engine/examples/scout_pico2w.json
@@ -1,0 +1,69 @@
+{
+  "robot_name": "scout_pico2w",
+  "kinematics": "DIFFERENTIAL_DRIVE",
+  "mcu": "PICO2W",
+  "transport": "SERIAL",
+  "wifi_telemetry": true,
+  "wifi_settings": {
+    "ssid": "YOUR_WIFI_SSID",
+    "password": "YOUR_WIFI_PASSWORD",
+    "agent_ip": "192.168.1.100",
+    "agent_port": 8888,
+    "syslog_server": "192.168.1.100"
+  },
+  "geometry": {
+    "wheel_diameter": 0.08,
+    "track_width": 0.22,
+    "weight": 3.5
+  },
+  "motors": {
+    "driver_type": "GENERIC_2_IN",
+    "max_rpm": 330,
+    "cpr": 1320,
+    "operating_voltage": 12.0,
+    "max_voltage": 12.0,
+    "rated_torque": 1.5,
+    "rated_voltage": 12.0,
+    "pwm_frequency": 20000,
+    "motor1_inv": false,
+    "motor2_inv": true
+  },
+  "sensors": {
+    "imu": "BNO085",
+    "mag": "NONE",
+    "battery_monitor": "ADC_DIVIDER",
+    "battery_capacity": 2.2,
+    "battery_nominal_voltage": 11.1,
+    "battery_min_voltage": 9.0,
+    "battery_max_voltage": 12.6,
+    "battery_dip": 0.98,
+    "sonar": true
+  },
+  "pins": {
+    "motor1": {
+      "pwm": 14,
+      "in_a": 15,
+      "in_b": 13
+    },
+    "motor2": {
+      "pwm": 16,
+      "in_a": 17,
+      "in_b": 12
+    },
+    "encoders": {
+      "m1_a": 2,
+      "m1_b": 3,
+      "m2_a": 4,
+      "m2_b": 5
+    },
+    "i2c": {
+      "sda": 8,
+      "scl": 9
+    },
+    "battery_pin": 26,
+    "sonar": {
+      "trig": 18,
+      "echo": 19
+    }
+  }
+}

--- a/tools/robot_config_engine/generate_config.py
+++ b/tools/robot_config_engine/generate_config.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Thomas Chou, Paul Bouchier, Linorobot contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CLI entry point for the Linorobot2 AI Robot Configuration Engine.
+Usage:
+    python3 generate_config.py spec.json --out-dir ./output/
+    python3 generate_config.py spec.json --merge --commit
+"""
+
+import os
+import sys
+import re
+import json
+import math
+import subprocess
+import argparse
+from validator import validate_robot_spec
+from generator import generate_config_header, generate_platformio_env, generate_urdf_xacro
+
+
+def merge_configuration(spec, repo_root, ros_distro="jazzy"):
+    robot_name = spec["robot_name"]
+    robot_name_upper = robot_name.upper()
+    header_code = generate_config_header(spec)
+    pio_code = generate_platformio_env(spec, ros_distro=ros_distro)
+    urdf_code = generate_urdf_xacro(spec)
+
+    print(f"\nMerging configuration for '{robot_name}' into repository root: {repo_root}")
+
+    # 1. Custom Header
+    custom_dir = os.path.join(repo_root, "config", "custom")
+    os.makedirs(custom_dir, exist_ok=True)
+    header_path = os.path.join(custom_dir, f"{robot_name}_config.h")
+    with open(header_path, "w") as f:
+        f.write(header_code)
+    print(f" ✅ Written header: {header_path}")
+
+    # 2. Register in config/config.h
+    config_h_path = os.path.join(repo_root, "config", "config.h")
+    if os.path.exists(config_h_path):
+        with open(config_h_path, "r") as f:
+            config_h_content = f.read()
+
+        macro_name = f"USE_{robot_name_upper}_CONFIG"
+        if macro_name not in config_h_content:
+            inclusion_block = f"#ifdef {macro_name}\n    #include \"custom/{robot_name}_config.h\"\n#endif\n\n"
+            barrier = "// add user configurations above this line"
+            if barrier in config_h_content:
+                config_h_content = config_h_content.replace(barrier, inclusion_block + barrier)
+            else:
+                config_h_content += "\n" + inclusion_block
+
+            with open(config_h_path, "w") as f:
+                f.write(config_h_content)
+            print(f" ✅ Registered '{macro_name}' in config/config.h")
+        else:
+            print(f" ℹ️  '{macro_name}' already registered in config/config.h")
+
+    # 3. PlatformIO environment injection into firmware/platformio.ini
+    pio_path = os.path.join(repo_root, "firmware", "platformio.ini")
+    env_header = f"[env:{robot_name}]"
+    if os.path.exists(pio_path):
+        with open(pio_path, "r") as f:
+            pio_content = f.read()
+        if env_header in pio_content:
+            pattern = re.escape(env_header) + r"[\s\S]*?(?=\n\[env:|\Z)"
+            pio_content = re.sub(pattern, pio_code.strip() + "\n", pio_content)
+            print(f" ✅ Updated '{env_header}' in {os.path.relpath(pio_path, repo_root)}")
+        else:
+            pio_content += f"\n{pio_code}\n"
+            print(f" ✅ Appended '{env_header}' to {os.path.relpath(pio_path, repo_root)}")
+        with open(pio_path, "w") as f:
+            f.write(pio_content)
+
+    # 4. URDF Generation
+    urdf_dir = os.path.join(repo_root, "urdf")
+    os.makedirs(urdf_dir, exist_ok=True)
+    urdf_path = os.path.join(urdf_dir, f"{robot_name}_properties.urdf.xacro")
+    with open(urdf_path, "w") as f:
+        f.write(urdf_code)
+    print(f" ✅ Written URDF: {urdf_path}")
+
+
+def commit_configuration(spec, repo_root, branch_name=None, commit_msg=None):
+    robot_name = spec["robot_name"]
+    branch = branch_name or f"config/{robot_name}"
+    msg = commit_msg or f"feat(config): add configuration for {robot_name}"
+
+    try:
+        subprocess.run(["git", "checkout", "-b", branch], cwd=repo_root, capture_output=True, check=False)
+        subprocess.run(["git", "checkout", branch], cwd=repo_root, capture_output=True, check=False)
+        subprocess.run(["git", "add", "config/", "firmware/platformio.ini", "urdf/"], cwd=repo_root, check=True)
+        res = subprocess.run(["git", "commit", "-m", msg], cwd=repo_root, capture_output=True, text=True)
+        if res.returncode == 0:
+            print(f"\n✅ Successfully committed configuration to Git branch '{branch}':\n   {msg}")
+        else:
+            print(f"\nℹ️  Git status: {res.stdout.strip() or res.stderr.strip()}")
+    except Exception as e:
+        print(f"\n⚠️  Git commit failed: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Linorobot2 Hardware Rule Validator & Code Generator")
+    parser.add_argument("spec_file", help="Path to input JSON specification file")
+    parser.add_argument("--out-dir", help="Output directory for generated files", default=None)
+    parser.add_argument("--ros-distro", help="Target ROS distribution (jazzy, lyrical, rolling, humble)", default="jazzy")
+    parser.add_argument("--merge", action="store_true", help="Merge generated header, platformio.ini, and URDF directly into codebase")
+    parser.add_argument("--commit", action="store_true", help="Automatically create Git commit with merged configuration")
+    parser.add_argument("--repo-root", help="Repository root path (defaults to auto-detected root)", default=None)
+    args = parser.parse_args()
+
+    if not os.path.exists(args.spec_file):
+        print(f"Error: Specification file '{args.spec_file}' not found.")
+        sys.exit(1)
+
+    with open(args.spec_file, "r") as f:
+        try:
+            spec = json.load(f)
+        except json.JSONDecodeError as e:
+            print(f"Error: Invalid JSON syntax in '{args.spec_file}': {e}")
+            sys.exit(1)
+
+    print(f"\n==========================================")
+    print(f" Validating: {spec.get('robot_name', 'Unknown Robot')}")
+    print(f"==========================================")
+
+    valid, errors, stats = validate_robot_spec(spec)
+
+    for err in errors:
+        prefix = "❌" if err.level == "ERROR" else "⚠️ "
+        print(f"{prefix} [{err.level}] {err.field}: {err.message}")
+
+    if not valid:
+        print("\n❌ Hardware validation FAILED. Fix errors before generating code.")
+        sys.exit(1)
+
+    print("\n✅ Hardware rule validation PASSED!")
+    print("\nKinematics & Performance Summary:")
+    print(f" - Wheel Circumference: {stats.get('wheel_circumference_m')} m")
+    print(f" - Max Linear Velocity (85% headroom): {stats.get('max_linear_speed_m_s')} m/s ({round(stats.get('max_linear_speed_m_s', 0)*3.6, 2)} km/h)")
+    if "max_angular_speed_rad_s" in stats:
+        print(f" - Max Angular Velocity: {stats.get('max_angular_speed_rad_s')} rad/s ({round(math.degrees(stats.get('max_angular_speed_rad_s', 0)), 1)} deg/s)")
+    print(f" - Ticks Per Meter: {stats.get('ticks_per_meter')} ticks/m")
+    if "max_accel_m_s2" in stats:
+        print(f" - Est. Max Acceleration: {stats.get('max_accel_m_s2')} m/s² (Total Thrust: {stats.get('total_thrust_n')} N)")
+
+    header_code = generate_config_header(spec)
+    pio_code = generate_platformio_env(spec, ros_distro=args.ros_distro)
+    urdf_code = generate_urdf_xacro(spec)
+
+    repo_root = args.repo_root or os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+    if args.merge:
+        merge_configuration(spec, repo_root, ros_distro=args.ros_distro)
+
+    if args.commit:
+        if not args.merge:
+            merge_configuration(spec, repo_root, ros_distro=args.ros_distro)
+        commit_configuration(spec, repo_root)
+
+    if args.out_dir:
+        os.makedirs(args.out_dir, exist_ok=True)
+        robot_name = spec["robot_name"]
+
+        header_path = os.path.join(args.out_dir, f"{robot_name}_config.h")
+        pio_path = os.path.join(args.out_dir, "platformio_section.ini")
+        urdf_path = os.path.join(args.out_dir, f"{robot_name}_properties.urdf.xacro")
+
+        with open(header_path, "w") as f:
+            f.write(header_code)
+        with open(pio_path, "w") as f:
+            f.write(pio_code)
+        with open(urdf_path, "w") as f:
+            f.write(urdf_code)
+
+        print(f"\nGenerated Artifacts in '{args.out_dir}':")
+        print(f" 1. C++ Header: {header_path}")
+        print(f" 2. PlatformIO Env: {pio_path}")
+        print(f" 3. URDF Description: {urdf_path}")
+    elif not args.merge and not args.commit:
+        print("\n--- C++ Header Preview ---")
+        print(header_code)
+        print("\n--- PlatformIO Environment Preview ---")
+        print(pio_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/robot_config_engine/generate_config.py
+++ b/tools/robot_config_engine/generate_config.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Thomas Chou, Paul Bouchier, Linorobot contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CLI entry point for the Linorobot2 AI Robot Configuration Engine.
+Usage:
+    python3 generate_config.py spec.json --out-dir ./output/
+    python3 generate_config.py spec.json --merge --commit
+"""
+
+import os
+import sys
+import re
+import json
+import math
+import subprocess
+import argparse
+from validator import validate_robot_spec
+from generator import generate_config_header, generate_platformio_env, generate_urdf_xacro
+
+
+def merge_configuration(spec, repo_root, ros_distro="jazzy"):
+    robot_name = spec["robot_name"]
+    robot_name_upper = robot_name.upper()
+    header_code = generate_config_header(spec)
+    pio_code = generate_platformio_env(spec, ros_distro=ros_distro)
+    urdf_code = generate_urdf_xacro(spec)
+
+    print(f"\nMerging configuration for '{robot_name}' into repository root: {repo_root}")
+
+    # 1. Custom Header
+    custom_dir = os.path.join(repo_root, "config", "custom")
+    os.makedirs(custom_dir, exist_ok=True)
+    header_path = os.path.join(custom_dir, f"{robot_name}_config.h")
+    with open(header_path, "w") as f:
+        f.write(header_code)
+    print(f" ✅ Written header: {header_path}")
+
+    # 2. Register in config/config.h
+    config_h_path = os.path.join(repo_root, "config", "config.h")
+    if os.path.exists(config_h_path):
+        with open(config_h_path, "r") as f:
+            config_h_content = f.read()
+
+        macro_name = f"USE_{robot_name_upper}_CONFIG"
+        if macro_name not in config_h_content:
+            inclusion_block = f"#ifdef {macro_name}\n    #include \"custom/{robot_name}_config.h\"\n#endif\n\n"
+            barrier = "// add user configurations above this line"
+            if barrier in config_h_content:
+                config_h_content = config_h_content.replace(barrier, inclusion_block + barrier)
+            else:
+                config_h_content += "\n" + inclusion_block
+
+            with open(config_h_path, "w") as f:
+                f.write(config_h_content)
+            print(f" ✅ Registered '{macro_name}' in config/config.h")
+        else:
+            print(f" ℹ️  '{macro_name}' already registered in config/config.h")
+
+    # 3. PlatformIO environment injection into firmware/platformio.ini
+    pio_path = os.path.join(repo_root, "firmware", "platformio.ini")
+    env_header = f"[env:{robot_name}]"
+    if os.path.exists(pio_path):
+        with open(pio_path, "r") as f:
+            pio_content = f.read()
+        if env_header in pio_content:
+            pattern = re.escape(env_header) + r"[\s\S]*?(?=\n\[env:|\Z)"
+            pio_content = re.sub(pattern, pio_code.strip() + "\n", pio_content)
+            print(f" ✅ Updated '{env_header}' in {os.path.relpath(pio_path, repo_root)}")
+        else:
+            pio_content += f"\n{pio_code}\n"
+            print(f" ✅ Appended '{env_header}' to {os.path.relpath(pio_path, repo_root)}")
+        with open(pio_path, "w") as f:
+            f.write(pio_content)
+
+    # 4. URDF Generation
+    urdf_dir = os.path.join(repo_root, "urdf")
+    os.makedirs(urdf_dir, exist_ok=True)
+    urdf_path = os.path.join(urdf_dir, f"{robot_name}_properties.urdf.xacro")
+    with open(urdf_path, "w") as f:
+        f.write(urdf_code)
+    print(f" ✅ Written URDF: {urdf_path}")
+
+
+def commit_configuration(spec, repo_root, branch_name=None, commit_msg=None):
+    robot_name = spec["robot_name"]
+    branch = branch_name or f"config/{robot_name}"
+    msg = commit_msg or f"feat(config): add configuration for {robot_name}"
+
+    try:
+        subprocess.run(["git", "checkout", "-b", branch], cwd=repo_root, capture_output=True, check=False)
+        subprocess.run(["git", "checkout", branch], cwd=repo_root, capture_output=True, check=False)
+        subprocess.run(["git", "add", "config/", "firmware/platformio.ini", "urdf/"], cwd=repo_root, check=True)
+        res = subprocess.run(["git", "commit", "-m", msg], cwd=repo_root, capture_output=True, text=True)
+        if res.returncode == 0:
+            print(f"\n✅ Successfully committed configuration to Git branch '{branch}':\n   {msg}")
+        else:
+            print(f"\nℹ️  Git status: {res.stdout.strip() or res.stderr.strip()}")
+    except Exception as e:
+        print(f"\n⚠️  Git commit failed: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Linorobot2 Hardware Rule Validator & Code Generator")
+    parser.add_argument("spec_file", help="Path to input JSON specification file")
+    parser.add_argument("--out-dir", help="Output directory for generated files", default=None)
+    parser.add_argument("--ros-distro", help="Target ROS distribution (jazzy, lyrical, rolling)", default="jazzy")
+    parser.add_argument("--merge", action="store_true", help="Merge generated header, platformio.ini, and URDF directly into codebase")
+    parser.add_argument("--commit", action="store_true", help="Automatically create Git commit with merged configuration")
+    parser.add_argument("--repo-root", help="Repository root path (defaults to auto-detected root)", default=None)
+    args = parser.parse_args()
+
+    if not os.path.exists(args.spec_file):
+        print(f"Error: Specification file '{args.spec_file}' not found.")
+        sys.exit(1)
+
+    with open(args.spec_file, "r") as f:
+        try:
+            spec = json.load(f)
+        except json.JSONDecodeError as e:
+            print(f"Error: Invalid JSON syntax in '{args.spec_file}': {e}")
+            sys.exit(1)
+
+    print(f"\n==========================================")
+    print(f" Validating: {spec.get('robot_name', 'Unknown Robot')}")
+    print(f"==========================================")
+
+    valid, errors, stats = validate_robot_spec(spec)
+
+    for err in errors:
+        prefix = "❌" if err.level == "ERROR" else "⚠️ "
+        print(f"{prefix} [{err.level}] {err.field}: {err.message}")
+
+    if not valid:
+        print("\n❌ Hardware validation FAILED. Fix errors before generating code.")
+        sys.exit(1)
+
+    print("\n✅ Hardware rule validation PASSED!")
+    print("\nKinematics & Performance Summary:")
+    print(f" - Wheel Circumference: {stats.get('wheel_circumference_m')} m")
+    print(f" - Max Linear Velocity (85% headroom): {stats.get('max_linear_speed_m_s')} m/s ({round(stats.get('max_linear_speed_m_s', 0)*3.6, 2)} km/h)")
+    if "max_angular_speed_rad_s" in stats:
+        print(f" - Max Angular Velocity: {stats.get('max_angular_speed_rad_s')} rad/s ({round(math.degrees(stats.get('max_angular_speed_rad_s', 0)), 1)} deg/s)")
+    print(f" - Ticks Per Meter: {stats.get('ticks_per_meter')} ticks/m")
+    if "max_accel_m_s2" in stats:
+        print(f" - Est. Max Acceleration: {stats.get('max_accel_m_s2')} m/s² (Total Thrust: {stats.get('total_thrust_n')} N)")
+
+    header_code = generate_config_header(spec)
+    pio_code = generate_platformio_env(spec, ros_distro=args.ros_distro)
+    urdf_code = generate_urdf_xacro(spec)
+
+    repo_root = args.repo_root or os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+    if args.merge:
+        merge_configuration(spec, repo_root, ros_distro=args.ros_distro)
+
+    if args.commit:
+        if not args.merge:
+            merge_configuration(spec, repo_root, ros_distro=args.ros_distro)
+        commit_configuration(spec, repo_root)
+
+    if args.out_dir:
+        os.makedirs(args.out_dir, exist_ok=True)
+        robot_name = spec["robot_name"]
+
+        header_path = os.path.join(args.out_dir, f"{robot_name}_config.h")
+        pio_path = os.path.join(args.out_dir, "platformio_section.ini")
+        urdf_path = os.path.join(args.out_dir, f"{robot_name}_properties.urdf.xacro")
+
+        with open(header_path, "w") as f:
+            f.write(header_code)
+        with open(pio_path, "w") as f:
+            f.write(pio_code)
+        with open(urdf_path, "w") as f:
+            f.write(urdf_code)
+
+        print(f"\nGenerated Artifacts in '{args.out_dir}':")
+        print(f" 1. C++ Header: {header_path}")
+        print(f" 2. PlatformIO Env: {pio_path}")
+        print(f" 3. URDF Description: {urdf_path}")
+    elif not args.merge and not args.commit:
+        print("\n--- C++ Header Preview ---")
+        print(header_code)
+        print("\n--- PlatformIO Environment Preview ---")
+        print(pio_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/robot_config_engine/generator.py
+++ b/tools/robot_config_engine/generator.py
@@ -145,10 +145,11 @@ def generate_config_header(spec: Dict[str, Any]) -> str:
     for i in range(1, 5):
         m = pins.get(f"motor{i}", {})
         if driver == "BTS7960":
-            # Real header format: MOTOR{i}_PWM = RPWM, IN_A = LPWM, IN_B = EN
-            lines.append(f"  #define MOTOR{i}_PWM {m.get('pwm_r', m.get('pwm', -1))} //DON'T TOUCH THIS! This is just a placeholder")
-            lines.append(f"  #define MOTOR{i}_IN_A {m.get('pwm_l', m.get('in_a', -1))}")
-            lines.append(f"  #define MOTOR{i}_IN_B {m.get('en', m.get('in_b', -1))}")
+            # BTS7960 uses two outputs only: IN_A = RPWM, IN_B = LPWM.
+            # MOTOR{i}_PWM is an unused arg in the driver class -> fixed placeholder.
+            lines.append(f"  #define MOTOR{i}_PWM -1 //DON'T TOUCH THIS! This is just a placeholder")
+            lines.append(f"  #define MOTOR{i}_IN_A {m.get('in_a', m.get('pwm_l', -1))}")
+            lines.append(f"  #define MOTOR{i}_IN_B {m.get('in_b', m.get('en', -1))}")
         elif driver == "GENERIC_2_IN":
             lines.append(f"  #define MOTOR{i}_PWM {m.get('pwm', -1)}")
             lines.append(f"  #define MOTOR{i}_IN_A {m.get('in_a', -1)}")
@@ -221,14 +222,6 @@ def generate_config_header(spec: Dict[str, Any]) -> str:
         if not have_imported_board_init:
             is_rp2 = "PICO" in mcu_name or "RP2" in mcu_name
             bi = ["#define BOARD_INIT { \\"]
-            if driver == "BTS7960":
-                n_active = 4 if kine != "DIFFERENTIAL_DRIVE" else 2
-                for i in range(1, n_active + 1):
-                    m = pins.get(f"motor{i}", {})
-                    pwm = m.get("pwm_r", m.get("pwm", -1))
-                    if pwm is not None and pwm >= 0:
-                        bi.append(f"    pinMode(MOTOR{i}_PWM, OUTPUT); \\")
-                        bi.append(f"    digitalWrite(MOTOR{i}_PWM, HIGH); \\")
             if is_rp2:
                 bi.append("    Wire.setSDA(SDA_PIN); \\")
                 bi.append("    Wire.setSCL(SCL_PIN); \\")

--- a/tools/robot_config_engine/generator.py
+++ b/tools/robot_config_engine/generator.py
@@ -195,11 +195,17 @@ def generate_config_header(spec: Dict[str, Any]) -> str:
     mb = tune.get("mag_bias")
     if isinstance(mb, (list, tuple)) and len(mb) == 3:
         lines.append(f"#define MAG_BIAS {{ {', '.join(_n(x) for x in mb)} }}")
-    for _macro, _key in (("ACCEL_COV", "accel_cov"), ("GYRO_COV", "gyro_cov"), ("ORI_COV", "ori_cov")):
+    # ACCEL/GYRO/ORI/MAG_COV are 3-vectors; POSE/TWIST_COV are 6-vectors — a
+    # scalar expands, a list is used as-is. All #ifndef-gated in firmware.
+    for _macro, _key, _len in (
+        ("ACCEL_COV", "accel_cov", 3), ("GYRO_COV", "gyro_cov", 3),
+        ("ORI_COV", "ori_cov", 3), ("MAG_COV", "mag_cov", 3),
+        ("POSE_COV", "pose_cov", 6), ("TWIST_COV", "twist_cov", 6),
+    ):
         _v = tune.get(_key)
-        if _v is None:
+        if _v is None or _v == "":
             continue
-        _t = list(_v) if isinstance(_v, (list, tuple)) else [_v, _v, _v]
+        _t = list(_v) if isinstance(_v, (list, tuple)) else [_v] * _len
         lines.append(f"#define {_macro} {{ {', '.join(_n(x) for x in _t)} }}")
 
     # I2C — BOARD_INIT is synthesised only when the user has actually defined
@@ -286,11 +292,24 @@ def generate_config_header(spec: Dict[str, Any]) -> str:
         lines.append('  #include "wifi_config.h"')
         lines.append('#endif')
     if use_wifi:
+        # The PlatformIO env pins board_microros_transport = wifi, so
+        # firmware.ino compiles set_microros_net_transports(AGENT_IP, AGENT_PORT)
+        # unconditionally — both macros must exist even before credentials are
+        # entered. Not secrets: emit #ifndef-guarded defaults, overridden by
+        # wifi_config.h once real values exist.
+        agent_ip = adv.get("agent_ip") or telemetry.get("agent_ip") or "192.168.1.100"
         lines.append("#define USE_WIFI")
-        lines.append(f"#define AGENT_PORT {telemetry.get('agent_port', 8888)}")
+        lines.append("#ifndef AGENT_IP")
+        lines.append(f"  #define AGENT_IP {_ipv4_c(agent_ip)}")
+        lines.append("#endif")
+        lines.append("#ifndef AGENT_PORT")
+        lines.append(f"  #define AGENT_PORT {telemetry.get('agent_port', 8888)}")
+        lines.append("#endif")
     if use_wifi and telemetry.get("use_syslog", False):
         lines.append("#define USE_SYSLOG")
         lines.append(f"#define SYSLOG_PORT {adv.get('syslog_port', 514)}")
+        if adv.get("wifi_monitor"):
+            lines.append(f"#define WIFI_MONITOR {adv['wifi_monitor']} // min. period to send WiFi RSSI to syslog")
     if use_wifi and telemetry.get("use_arduino_ota", False):
         lines.append("#define USE_ARDUINO_OTA")
         if adv.get("ota_hostname"):

--- a/tools/robot_config_engine/generator.py
+++ b/tools/robot_config_engine/generator.py
@@ -1,0 +1,523 @@
+# Copyright (c) 2026 Thomas Chou, Paul Bouchier, Linorobot contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from typing import Dict, Any
+
+
+def _n(v) -> str:
+    """Format a number the way the hand-written headers do: whole values as
+    plain ints (12, not 12.0), fractional values without trailing zeros."""
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return str(v)
+    if f == int(f):
+        return str(int(f))
+    return repr(f).rstrip("0").rstrip(".")
+
+
+def _ipv4_c(ip: str) -> str:
+    parts = [p.strip() for p in str(ip).split(".")]
+    if len(parts) == 4 and all(p.isdigit() for p in parts):
+        return "{ " + ", ".join(parts) + " }"
+    return "{ 192, 168, 1, 100 }"
+
+
+def generate_config_header(spec: Dict[str, Any]) -> str:
+    """
+    Generate a Linorobot2 C++ configuration header from a spec dict.
+    Pin assignments are emitted in the same macro format used by the
+    original hand-written config headers so that round-trip
+    parse → generate → re-parse is lossless.
+    """
+    name     = spec.get("robot_name", "custom_robot").upper()
+    kine     = spec.get("kinematics", "DIFFERENTIAL_DRIVE")
+    geom     = spec.get("geometry", {})
+    motors   = spec.get("motors", {})
+    sensors  = spec.get("sensors", {})
+    pins     = spec.get("pins", {})
+    telemetry = spec.get("telemetry", {})
+    driver   = motors.get("driver_type", "BTS7960")
+
+    # ── Header guard & kinematics ────────────────────────────────────
+    lines = [
+        "// Copyright (c) 2026 Thomas Chou, Paul Bouchier, Linorobot contributors",
+        f"// Auto-generated configuration for {spec.get('robot_name', 'custom_robot')}",
+        f"#ifndef {name}_CONFIG_H",
+        f"#define {name}_CONFIG_H",
+        "",
+        f"#define LINO_BASE {kine}",
+        "",
+        "// Robot Physical Geometry",
+        f"#define WHEEL_DIAMETER {_n(geom.get('wheel_diameter', 0.065))}",
+        f"#define LR_WHEELS_DISTANCE {_n(geom.get('track_width', 0.20))}",
+    ]
+    # FR_WHEELS_DISTANCE only matters for 4-wheel bases
+    if "wheelbase" in geom and kine != "DIFFERENTIAL_DRIVE":
+        lines.append(f"#define FR_WHEELS_DISTANCE {_n(geom['wheelbase'])}")
+    if geom.get("weight") is not None:
+        lines.append(f"#define ROBOT_WEIGHT {_n(geom['weight'])}")
+
+    # ── Motor driver & characteristics ───────────────────────────────
+    lines.extend([
+        "",
+        "// Motor Driver & Characteristics",
+        f"#define USE_{driver}_MOTOR_DRIVER",
+        f"#define MOTOR_MAX_RPM {motors.get('max_rpm', 300)}",
+        f"#define MAX_RPM_RATIO 0.85",
+        f"#define MOTOR_OPERATING_VOLTAGE {_n(motors.get('operating_voltage', 12.0))}",
+        f"#define MOTOR_POWER_MAX_VOLTAGE {_n(motors.get('max_voltage', 12.0))}",
+        f"#define MOTOR_POWER_MEASURED_VOLTAGE {_n(motors.get('measured_voltage', motors.get('max_voltage', 12.0)))}",
+        "",
+        f"#define PWM_BITS {motors.get('pwm_bits', 10)}",
+        f"#define PWM_FREQUENCY {motors.get('pwm_frequency', 20000)}",
+        f"#define PWM_MAX pow(2, PWM_BITS) - 1",
+        f"#define PWM_MIN -PWM_MAX",
+        "",
+        f"#define COUNTS_PER_REV1 {motors.get('cpr', 1320)}",
+        f"#define COUNTS_PER_REV2 {motors.get('cpr', 1320)}",
+        f"#define COUNTS_PER_REV3 {motors.get('cpr', 1320)}",
+        f"#define COUNTS_PER_REV4 {motors.get('cpr', 1320)}",
+        "",
+        "// INVERT MOTOR DIRECTIONS",
+        f"#define MOTOR1_INV {str(motors.get('motor1_inv', False)).lower()}",
+        f"#define MOTOR2_INV {str(motors.get('motor2_inv', True)).lower()}",
+        f"#define MOTOR3_INV {str(motors.get('motor3_inv', False)).lower()}",
+        f"#define MOTOR4_INV {str(motors.get('motor4_inv', True)).lower()}",
+        "",
+        "// INVERT ENCODER COUNTS",
+        f"#define MOTOR1_ENCODER_INV {str(pins.get('encoders', {}).get('m1_inv', False)).lower()}",
+        f"#define MOTOR2_ENCODER_INV {str(pins.get('encoders', {}).get('m2_inv', False)).lower()}",
+        f"#define MOTOR3_ENCODER_INV {str(pins.get('encoders', {}).get('m3_inv', False)).lower()}",
+        f"#define MOTOR4_ENCODER_INV {str(pins.get('encoders', {}).get('m4_inv', False)).lower()}",
+        "",
+        "// Velocity PID Tuning Constants",
+        f"#define K_P {_n(spec.get('pid', {}).get('kp', 0.6))}",
+        f"#define K_I {_n(spec.get('pid', {}).get('ki', 0.8))}",
+        f"#define K_D {_n(spec.get('pid', {}).get('kd', 0.5))}",
+        "",
+        "// Pin Assignments",
+    ])
+
+    # ── LED pin ──────────────────────────────────────────────────────
+    mcu_name = spec.get("mcu", "").upper()
+    led_pin = pins.get("led")
+    if led_pin is None:
+        if mcu_name in ["PICOW", "PICO2W"]:
+            led_pin = "LED_BUILTIN"
+        elif "PICO" in mcu_name:
+            led_pin = 25
+        elif "GENDRV" in mcu_name or "ESP32" in mcu_name:
+            led_pin = "LED_BUILTIN"
+        else:
+            led_pin = 13
+    lines.append(f"#define LED_PIN {led_pin}")
+
+    # ── Encoder pins (all 4 motors, always) ──────────────────────────
+    # These are unconditional #defines (not inside #ifdef blocks)
+    enc = pins.get("encoders", {})
+    lines.append("")
+    lines.append("// ENCODER PINS")
+    for i in range(1, 5):
+        a = enc.get(f"m{i}_a", -1)
+        b = enc.get(f"m{i}_b", -1)
+        lines.append(f"#define MOTOR{i}_ENCODER_A {a}")
+        lines.append(f"#define MOTOR{i}_ENCODER_B {b}")
+
+    # ── Motor driver pins inside #ifdef block ─────────────────────────
+    # Emit in exactly the same format as the hand-written headers:
+    # one #ifdef USE_*_MOTOR_DRIVER block containing all 4 motors.
+    lines.append("")
+    lines.append(f"// MOTOR PINS")
+    lines.append(f"#ifdef {_driver_macro(driver)}")
+    for i in range(1, 5):
+        m = pins.get(f"motor{i}", {})
+        if driver == "BTS7960":
+            # Real header format: MOTOR{i}_PWM = RPWM, IN_A = LPWM, IN_B = EN
+            lines.append(f"  #define MOTOR{i}_PWM {m.get('pwm_r', m.get('pwm', -1))} //DON'T TOUCH THIS! This is just a placeholder")
+            lines.append(f"  #define MOTOR{i}_IN_A {m.get('pwm_l', m.get('in_a', -1))}")
+            lines.append(f"  #define MOTOR{i}_IN_B {m.get('en', m.get('in_b', -1))}")
+        elif driver == "GENERIC_2_IN":
+            lines.append(f"  #define MOTOR{i}_PWM {m.get('pwm', -1)}")
+            lines.append(f"  #define MOTOR{i}_IN_A {m.get('in_a', -1)}")
+            lines.append(f"  #define MOTOR{i}_IN_B {m.get('in_b', -1)}")
+        elif driver == "GENERIC_1_IN":
+            lines.append(f"  #define MOTOR{i}_PWM {m.get('pwm', -1)}")
+            lines.append(f"  #define MOTOR{i}_IN_A {m.get('dir', m.get('in_a', -1))}")
+            lines.append(f"  #define MOTOR{i}_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder")
+        elif driver == "ESC":
+            lines.append(f"  #define MOTOR{i}_PWM {m.get('pwm', -1)}")
+            lines.append(f"  #define MOTOR{i}_IN_A -1 //DON'T TOUCH THIS! This is just a placeholder")
+            lines.append(f"  #define MOTOR{i}_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder")
+    lines.append(f"  #define PWM_MAX pow(2, PWM_BITS) - 1")
+    lines.append(f"  #define PWM_MIN -PWM_MAX")
+    lines.append(f"#endif")
+
+    # ── Servo for Ackermann ───────────────────────────────────────────
+    if kine == "ACKERMANN":
+        servo_pin = pins.get("servo", 21)
+        lines.append(f"#define STEERING_SERVO_PIN {servo_pin}")
+
+    # ── Sensor configuration ──────────────────────────────────────────
+    lines.extend(["", "// Sensor Configuration"])
+
+    imu = sensors.get("imu_type") or sensors.get("imu", "USE_FAKE_IMU")
+    if imu and imu not in ["NONE", "USE_FAKE_IMU", "FAKE"]:
+        macro = imu if imu.startswith("USE_") else f"USE_{imu}_IMU"
+        lines.append(f"#define {macro}")
+    else:
+        lines.append("// #define USE_FAKE_IMU")
+
+    mag = sensors.get("mag_type") or sensors.get("mag", "USE_FAKE_MAG")
+    if mag and mag not in ["NONE", "USE_FAKE_MAG", "FAKE"]:
+        macro = mag if mag.startswith("USE_") else f"USE_{mag}_MAG"
+        lines.append(f"#define {macro}")
+    else:
+        lines.append("// #define USE_FAKE_MAG")
+
+    # IMU / magnetometer tuning. MAG_BIAS is #ifdef-gated in firmware.ino;
+    # ACCEL_COV / GYRO_COV / ORI_COV are #ifndef-gated in imu_interface.h
+    # (blank == firmware default of 0.00001).
+    tune = spec.get("imu_tuning", {})
+    mb = tune.get("mag_bias")
+    if isinstance(mb, (list, tuple)) and len(mb) == 3:
+        lines.append(f"#define MAG_BIAS {{ {', '.join(_n(x) for x in mb)} }}")
+    for _macro, _key in (("ACCEL_COV", "accel_cov"), ("GYRO_COV", "gyro_cov"), ("ORI_COV", "ori_cov")):
+        _v = tune.get(_key)
+        if _v is None:
+            continue
+        _t = list(_v) if isinstance(_v, (list, tuple)) else [_v, _v, _v]
+        lines.append(f"#define {_macro} {{ {', '.join(_n(x) for x in _t)} }}")
+
+    # I2C — BOARD_INIT is synthesised only when the user has actually defined
+    # I2C pins (SDA_PIN / SCL_PIN >= 0). A bare module leaves them unset: no
+    # SDA_PIN/SCL_PIN and no BOARD_INIT, so firmware.ino's default Wire.begin()
+    # path applies.
+    _i2c_pins = pins.get("i2c", {})
+    i2c_sda = sensors.get("i2c_sda", _i2c_pins.get("sda", -1))
+    i2c_scl = sensors.get("i2c_scl", _i2c_pins.get("scl", -1))
+    i2c_sda = -1 if i2c_sda is None else i2c_sda
+    i2c_scl = -1 if i2c_scl is None else i2c_scl
+    have_imported_board_init = any(d.get("name") == "BOARD_INIT" for d in spec.get("raw_defines", []))
+    if i2c_sda >= 0 and i2c_scl >= 0:
+        lines.append(f"#define SDA_PIN {i2c_sda}")
+        lines.append(f"#define SCL_PIN {i2c_scl}")
+        # SDA_PIN/SCL_PIN are only consulted through BOARD_INIT
+        # (firmware.ino: `#ifdef BOARD_INIT ... #else Wire.begin(); #endif`).
+        # An imported header's own BOARD_INIT is kept verbatim by the
+        # passthrough below; only synthesise one when the import lacked it.
+        if not have_imported_board_init:
+            is_rp2 = "PICO" in mcu_name or "RP2" in mcu_name
+            bi = ["#define BOARD_INIT { \\"]
+            if driver == "BTS7960":
+                n_active = 4 if kine != "DIFFERENTIAL_DRIVE" else 2
+                for i in range(1, n_active + 1):
+                    m = pins.get(f"motor{i}", {})
+                    pwm = m.get("pwm_r", m.get("pwm", -1))
+                    if pwm is not None and pwm >= 0:
+                        bi.append(f"    pinMode(MOTOR{i}_PWM, OUTPUT); \\")
+                        bi.append(f"    digitalWrite(MOTOR{i}_PWM, HIGH); \\")
+            if is_rp2:
+                bi.append("    Wire.setSDA(SDA_PIN); \\")
+                bi.append("    Wire.setSCL(SCL_PIN); \\")
+                bi.append("    Wire.begin(); \\")
+            else:
+                bi.append("    Wire.begin(SDA_PIN, SCL_PIN); \\")
+            bi.append("    Wire.setClock(400000); \\")
+            bi.append("}")
+            lines.extend(bi)
+
+    # Battery
+    if sensors.get("use_ina219", False):
+        lines.append("#define USE_INA219")
+    else:
+        bat_pin = pins.get("battery_pin", sensors.get("battery_pin", -1))
+        if bat_pin is not None and bat_pin >= 0:
+            lines.append(f"#define BATTERY_PIN {bat_pin}")
+            r1 = sensors.get("battery_r1", sensors.get("battery_divider_r1", 30000.0))
+            r2 = sensors.get("battery_r2", sensors.get("battery_divider_r2", 7500.0))
+            # firmware/lib/battery/battery.cpp: `return BATTERY_ADJUST(reading);`
+            # (no #ifndef fallback) — an ADC battery config MUST define it.
+            if not any(d.get("name") == "BATTERY_ADJUST" for d in spec.get("raw_defines", [])):
+                # express the divider as kΩ the way the hand-written headers do
+                r1k, r2k = _n(float(r1) / 1000.0), _n(float(r2) / 1000.0)
+                if "PICO" in mcu_name or "RP2" in mcu_name:
+                    lines.append(f"#define BATTERY_ADJUST(v) ((v) * (3.3 / 4096 * ({r1k} + {r2k}) / {r2k}))")
+                else:  # ESP32 family: analogReadMilliVolts() returns millivolts
+                    lines.append(f"#define BATTERY_ADJUST(v) ((v) * (({r1k} + {r2k}) / {r2k}) / 1000.0)")
+
+    for macro, keys in [
+        ("BATTERY_CAP", ("battery_cap", "battery_capacity")),
+        ("BATTERY_MIN", ("battery_min", "battery_min_voltage")),
+        ("BATTERY_MAX", ("battery_max", "battery_max_voltage")),
+        ("BATTERY_DIP", ("battery_dip",)),
+    ]:
+        val = next((sensors[k] for k in keys if sensors.get(k) is not None), None)
+        if val is not None:
+            lines.append(f"#define {macro} {_n(val)}")
+
+    # Sonar
+    sonar_trig = sensors.get("sonar_trig", -1)
+    sonar_echo = sensors.get("sonar_echo", -1)
+    if sonar_trig >= 0 and sonar_echo >= 0:
+        lines.append(f"#define TRIG_PIN {sonar_trig}")
+        lines.append(f"#define ECHO_PIN {sonar_echo}")
+
+    # ── Telemetry ─────────────────────────────────────────────────────
+    baudrate = telemetry.get("baudrate") or spec.get("baudrate", 921600)
+    lines.extend(["", "// Telemetry & micro-ROS Communication",
+                  f"#define BAUDRATE {baudrate}"])
+
+    adv = spec.get("advanced", {})
+
+    use_wifi = telemetry.get("use_wifi", False) or ("WIFI" in str(telemetry.get("transport", "")).upper())
+    if (use_wifi or telemetry.get("use_syslog", False)
+            or telemetry.get("use_arduino_ota", False) or telemetry.get("use_lidar_udp", False)):
+        # Secrets (WIFI_AP_LIST, AGENT_IP, SYSLOG_SERVER, LIDAR_SERVER,
+        # OTA_PASSWORD) live ONLY in the git-ignored config/custom/wifi_config.h;
+        # this tracked header keeps the non-secret feature flags and pulls the
+        # rest in via __has_include (see generate_wifi_config()).
+        lines.append('#if __has_include("wifi_config.h")')
+        lines.append('  #include "wifi_config.h"')
+        lines.append('#endif')
+    if use_wifi:
+        lines.append("#define USE_WIFI")
+        lines.append(f"#define AGENT_PORT {telemetry.get('agent_port', 8888)}")
+    if use_wifi and telemetry.get("use_syslog", False):
+        lines.append("#define USE_SYSLOG")
+        lines.append(f"#define SYSLOG_PORT {adv.get('syslog_port', 514)}")
+    if use_wifi and telemetry.get("use_arduino_ota", False):
+        lines.append("#define USE_ARDUINO_OTA")
+        if adv.get("ota_hostname"):
+            lines.append(f'#define OTA_HOSTNAME "{adv["ota_hostname"]}"')
+    if use_wifi and telemetry.get("use_lidar_udp", False):
+        lines.append("#define USE_LIDAR_UDP")
+        lines.append(f"#define LIDAR_PORT {adv.get('lidar_port', 8889)}")
+        if adv.get("lidar_baudrate") is not None:
+            lines.append(f"#define LIDAR_BAUDRATE {adv['lidar_baudrate']}")
+        if adv.get("lidar_rxd") is not None:
+            lines.append(f"#define LIDAR_RXD {adv['lidar_rxd']}")
+        if adv.get("lidar_serial") is not None:
+            lines.append(f"#define LIDAR_SERIAL {adv['lidar_serial']}")
+    if telemetry.get("use_dual_core", False):
+        lines.append("#define USE_DUAL_CORE")
+    if adv.get("use_short_brake"):
+        lines.append("#define USE_SHORT_BRAKE")
+    if adv.get("node_name"):
+        lines.append(f'#define NODE_NAME "{adv["node_name"]}"')
+    if adv.get("topic_prefix"):
+        _tp = str(adv["topic_prefix"])
+        if not _tp.endswith("/"):
+            _tp += "/"
+        lines.append(f'#define TOPIC_PREFIX "{_tp}"')
+    if adv.get("device_hostname"):
+        lines.append(f'#define DEVICE_HOSTNAME "{adv["device_hostname"]}"')
+    if adv.get("app_name"):
+        lines.append(f'#define APP_NAME "{adv["app_name"]}"')
+
+    # ── Verbatim passthrough of anything the import carried that we did
+    #    not otherwise model, so parse → generate never silently drops a
+    #    macro (covariances, RCCHECK, board hooks, …).
+    _blob = "\n".join(lines)
+    # names the generator produced, commented forms (// #define X) included
+    emitted = set(re.findall(r'^[ \t]*(?://\s*)?#define[ \t]+([A-Za-z_]\w*)', _blob, re.M))
+    # structural macro families the generator always owns from the modeled spec
+    _owned_re = re.compile(r'^(MOTOR\d|COUNTS_PER_REV\d?$'
+                            r'|MOTOR_(MAX_RPM|OPERATING_VOLTAGE|POWER_MAX_VOLTAGE|POWER_MEASURED_VOLTAGE)$'
+                            r'|MAX_RPM_RATIO$|PWM_(BITS|FREQUENCY|MAX|MIN)$|K_[PID]$|LINO_BASE$'
+                            r'|WHEEL_DIAMETER$|LR_WHEELS_DISTANCE$|FR_WHEELS_DISTANCE$|ROBOT_WEIGHT$'
+                            r'|LED_PIN$|BAUDRATE$|SDA_PIN$|SCL_PIN$|TRIG_PIN$|ECHO_PIN$)')
+    def _keep(nm):
+        return (nm and nm not in emitted
+                and not nm.startswith("USE_")   # every USE_* feature flag is a modeled decision
+                and not _owned_re.match(nm))
+    extras = [d for d in spec.get("raw_defines", []) if _keep(d.get("name"))]
+    if extras:
+        lines.append("")
+        lines.append("// Preserved from the imported configuration")
+        for d in extras:
+            lines.append(d["text"])
+
+    lines.extend(["", f"#endif // {name}_CONFIG_H", ""])
+    return "\n".join(lines)
+
+
+def _driver_macro(driver: str) -> str:
+    return {
+        "BTS7960":    "USE_BTS7960_MOTOR_DRIVER",
+        "GENERIC_2_IN": "USE_GENERIC_2_IN_MOTOR_DRIVER",
+        "GENERIC_1_IN": "USE_GENERIC_1_IN_MOTOR_DRIVER",
+        "ESC":        "USE_ESC_MOTOR_DRIVER",
+    }.get(driver, "USE_GENERIC_2_IN_MOTOR_DRIVER")
+
+
+def generate_platformio_env(spec: Dict[str, Any], ros_distro: str = "jazzy") -> str:
+    """A `[env:<robot>]` block for firmware/platformio.ini, mirroring the Web
+    UI's generatePlatformioEnv(). Inherits micro-ROS distro etc. from the
+    file-level [env]; ros_distro is accepted for CLI compatibility and only
+    emitted when it is not the default."""
+    name = spec.get("robot_name", "my_robot")
+    mcu = str(spec.get("mcu", "PICO2")).upper()
+    cfg_macro = f"USE_{name.upper()}_CONFIG"
+
+    transport = str(spec.get("transport")
+                    or spec.get("telemetry", {}).get("transport") or "")
+    is_wifi = bool(re.search(r"WIFI|UDP", transport, re.I))
+    wifi_transport_line = "board_microros_transport = wifi\n" if is_wifi else ""
+    wifi_flag = "\n    -D USE_STAY_CONNECTED" if is_wifi else ""
+    distro_line = ""
+    if ros_distro and ros_distro not in ("jazzy", "${sysenv.ROS_DISTRO}"):
+        distro_line = f"board_microros_distro = {ros_distro}\n"
+
+    adv = spec.get("advanced", {})
+    ota_ip = adv.get("ota_ip") if adv.get("ota_enable") and adv.get("ota_ip") else ""
+
+    if mcu in ("PICO", "PICO2", "PICOW", "PICO2W"):
+        board = {"PICO": "rpipico", "PICO2": "rpipico2",
+                 "PICOW": "rpipicow", "PICO2W": "rpipico2w"}.get(mcu, "rpipico")
+        pico_macro = f"    -D {mcu}\n" if mcu in ("PICOW", "PICO2W") else ""
+        return (
+            f"[env:{name}]\n"
+            "platform = https://github.com/maxgerhardt/platform-raspberrypi.git\n"
+            f"board = {board}\n"
+            "monitor_port = /dev/ttyACM0\n"
+            "upload_port = /dev/ttyACM0\n"
+            "upload_protocol = picotool\n"
+            "board_microros_user_meta = atomic.meta\n"
+            f"{distro_line}{wifi_transport_line}lib_deps =\n"
+            "    ${env.lib_deps}\n"
+            "    https://github.com/gbr1/rp2040-encoder-library.git\n"
+            "build_flags =\n"
+            "    -I ../config\n"
+            "    -D PICO\n"
+            f"{pico_macro}    -D {cfg_macro}{wifi_flag}\n"
+        )
+
+    if mcu in ("ESP32", "GENDRV"):
+        if ota_ip:
+            upl = (f"monitor_port = /dev/ttyUSB0\nupload_port = {ota_ip}\n"
+                   "upload_protocol = espota")
+        else:
+            upl = ("monitor_port = /dev/ttyUSB0\nupload_port = /dev/ttyUSB0\n"
+                   "upload_protocol = esptool")
+        return (
+            f"[env:{name}]\n"
+            "platform = espressif32\n"
+            "board = nodemcu-32s\n"
+            "board_build.f_flash = 80000000L\n"
+            "board_build.flash_mode = qio\n"
+            "board_build.partitions = min_spiffs.csv\n"
+            "monitor_speed = 921600\n"
+            f"{upl}\n"
+            f"{distro_line}{wifi_transport_line}lib_deps =\n"
+            "    ${env.lib_deps}\n"
+            "    madhephaestus/ESP32Servo\n"
+            "    madhephaestus/ESP32Encoder\n"
+            "build_flags =\n"
+            "    -I ../config\n"
+            "    -D __PGMSPACE_H_\n"
+            f"    -D {cfg_macro}{wifi_flag}\n"
+        )
+
+    if mcu in ("ESP32S3", "ESP32S2"):
+        board = "esp32-s3-devkitc-1" if mcu == "ESP32S3" else "esp32-s2-saola-1"
+        is_bridge = str(spec.get("serial_interface", "CDC")) == "BRIDGE"
+        port = "/dev/ttyUSB0" if is_bridge else "/dev/ttyACM0"
+        cdc_flag = "" if is_bridge else "\n    -D ARDUINO_USB_CDC_ON_BOOT"
+        flash_lines = ("board_build.f_flash = 80000000L\nboard_build.flash_mode = qio\n"
+                       if mcu == "ESP32S3" else "")
+        return (
+            f"[env:{name}]\n"
+            "platform = espressif32\n"
+            f"board = {board}\n"
+            f"{flash_lines}"
+            "monitor_speed = 921600\n"
+            f"monitor_port = {port}\n"
+            f"upload_port = {port}\n"
+            "upload_protocol = esptool\n"
+            f"{distro_line}{wifi_transport_line}lib_deps =\n"
+            "    ${env.lib_deps}\n"
+            "    madhephaestus/ESP32Servo\n"
+            "    madhephaestus/ESP32Encoder\n"
+            "build_flags =\n"
+            f"    -I ../config{cdc_flag}\n"
+            "    -D __PGMSPACE_H_\n"
+            f"    -D {cfg_macro}{wifi_flag}\n"
+        )
+
+    return ""
+
+
+def generate_wifi_config(spec: Dict[str, Any]) -> str:
+    """Contents of the git-ignored config/custom/wifi_config.h — WiFi credentials
+    and host IPs only. Returns "" when the spec has no real WiFi SSID.
+    Mirrors the Web UI's generateWifiConfig()."""
+    wifi = spec.get("wifi_settings", {}) or {}
+    adv = spec.get("advanced", {}) or {}
+    tele = spec.get("telemetry", {}) or {}
+    ssid = str(wifi.get("ssid", "")).strip()
+    if not ssid or ssid == "YOUR_WIFI_SSID":
+        return ""
+    transport = str(spec.get("transport", "") or tele.get("transport", "")).upper()
+    is_wifi_transport = "WIFI" in transport or "UDP" in transport
+    if not (is_wifi_transport or tele.get("use_syslog") or tele.get("use_arduino_ota")
+            or tele.get("use_lidar_udp") or spec.get("enable_ota_syslog")):
+        return ""
+    password = wifi.get("password", "") or ""
+    agent_ip = adv.get("agent_ip") or wifi.get("agent_ip") or "192.168.1.100"
+    out = [
+        "// config/custom/wifi_config.h  --  generated by the Robot Configuration Engine",
+        "// GIT-IGNORED: your WiFi credentials and host IPs are never committed.",
+        "// Delete this file to let the studio regenerate it, or edit it by hand.",
+        "",
+        f'#define WIFI_AP_LIST {{ {{ "{ssid}", "{password}" }}, {{ NULL, NULL }} }}',
+    ]
+    if is_wifi_transport:
+        out.append(f"#define AGENT_IP {_ipv4_c(agent_ip)}")
+    out.append(f"#define SYSLOG_SERVER {_ipv4_c(adv.get('syslog_ip') or agent_ip)}")
+    if tele.get("use_lidar_udp"):
+        out.append(f"#define LIDAR_SERVER {_ipv4_c(adv.get('lidar_ip') or agent_ip)}")
+    if adv.get("ota_password"):
+        out.append(f'#define OTA_PASSWORD "{adv["ota_password"]}"')
+    out.append("")
+    return "\n".join(out)
+
+
+def generate_urdf_xacro(spec: Dict[str, Any]) -> str:
+    """URDF xacro property block, mirroring the Web UI's generateUrdfXacro()."""
+    geom = spec.get("geometry", {})
+    wheel_d = geom.get("wheel_diameter", 0.08)
+    wheel_r = wheel_d / 2.0
+    track_w = geom.get("track_width", 0.22)
+    wheel_pos_y = track_w / 2.0
+    return (
+        '<?xml version="1.0"?>\n'
+        '<robot xmlns:xacro="http://ros.org/wiki/xacro">\n'
+        f'  <xacro:property name="wheel_radius" value="{wheel_r:.4f}" />\n'
+        '  <xacro:property name="wheel_width" value="0.026" />\n'
+        '  <xacro:property name="wheel_pos_x" value="0.0" />\n'
+        f'  <xacro:property name="wheel_pos_y" value="{wheel_pos_y:.4f}" />\n'
+        '  <xacro:property name="wheel_pos_z" value="-0.010" />\n'
+        '  <xacro:property name="wheel_mass" value="0.05" />\n'
+        f'  <xacro:property name="base_length" value="{track_w * 1.2:.3f}" />\n'
+        f'  <xacro:property name="base_width" value="{track_w * 0.9:.3f}" />\n'
+        '  <xacro:property name="base_height" value="0.070" />\n'
+        '  <xacro:property name="base_mass" value="1.2" />\n'
+        '\n'
+        '  <xacro:property name="laser_pose">\n'
+        '    <origin xyz="0.05 0 0.08" rpy="0 0 0"/>\n'
+        '  </xacro:property>\n'
+        '</robot>\n'
+    )

--- a/tools/robot_config_engine/generator.py
+++ b/tools/robot_config_engine/generator.py
@@ -197,12 +197,43 @@ def generate_config_header(spec: Dict[str, Any]) -> str:
         lines.append(f"#define MAG_BIAS {{ {', '.join(_n(x) for x in mb)} }}")
     # ACCEL/GYRO/ORI/MAG_COV are 3-vectors; POSE/TWIST_COV are 6-vectors — a
     # scalar expands, a list is used as-is. All #ifndef-gated in firmware.
+    # When a known sensor is enabled and the spec left a covariance blank, fall
+    # back to a datasheet-derived default (variance ≈ (noise_density·√100 Hz)²)
+    # so the header ships realistic values instead of the firmware's 1e-5.
+    _imu_key = (sensors.get("imu") or str(sensors.get("imu_type") or "")
+                ).replace("USE_", "").replace("_IMU", "").upper()
+    _mag_key = (sensors.get("mag") or str(sensors.get("mag_type") or "")
+                ).replace("USE_", "").replace("_MAG", "").upper()
+    _env_key = str(sensors.get("env") or sensors.get("env_type") or "").upper()
+    _imu_cov = {
+        "BNO085": {"accel_cov": 2.2e-4, "gyro_cov": 1.5e-6, "ori_cov": 4e-3},
+        "LSM6DSOX": {"accel_cov": 4.7e-5, "gyro_cov": 4.4e-7},
+        "ICM20948": {"accel_cov": 5.1e-4, "gyro_cov": 6.9e-6},
+        "QMI8658": {"accel_cov": 8e-5, "gyro_cov": 2e-6},
+        "MPU9250": {"accel_cov": 9e-4, "gyro_cov": 3e-6},
+        "MPU9150": {"accel_cov": 1.5e-3, "gyro_cov": 3e-6},
+        "MPU6050": {"accel_cov": 1.5e-3, "gyro_cov": 3e-6},
+        "GY85": {"accel_cov": 1.8e-3, "gyro_cov": 4.4e-5},
+    }.get(_imu_key, {})
+    _mag_cov = {"AK09918": 2.3e-14, "ICM20948": 2.3e-14, "QMC5883L": 4e-14,
+                "HMC5883L": 4e-14, "AK8963": 9e-14, "AK8975": 9e-14}.get(_mag_key)
+    # pressure Pa² (σ≈1.7 Pa), temperature °C² (±0.5°C accuracy), humidity (0..1)² (±3% RH)
+    _env_cov = {"BMP280": [3, 0.25, 0], "BME280": [3, 0.25, 9e-4]}.get(_env_key)
+    _cov_defaults = dict(_imu_cov)
+    if _mag_cov is not None:
+        _cov_defaults["mag_cov"] = _mag_cov
+    if _env_cov is not None:
+        _cov_defaults["env_cov"] = _env_cov
+
     for _macro, _key, _len in (
         ("ACCEL_COV", "accel_cov", 3), ("GYRO_COV", "gyro_cov", 3),
         ("ORI_COV", "ori_cov", 3), ("MAG_COV", "mag_cov", 3),
         ("POSE_COV", "pose_cov", 6), ("TWIST_COV", "twist_cov", 6),
+        ("ENV_COV", "env_cov", 3),   # BMP280 pressure/temperature/humidity .variance
     ):
         _v = tune.get(_key)
+        if _v is None or _v == "":
+            _v = _cov_defaults.get(_key)
         if _v is None or _v == "":
             continue
         _t = list(_v) if isinstance(_v, (list, tuple)) else [_v] * _len
@@ -273,6 +304,17 @@ def generate_config_header(spec: Dict[str, Any]) -> str:
     if sonar_trig >= 0 and sonar_echo >= 0:
         lines.append(f"#define TRIG_PIN {sonar_trig}")
         lines.append(f"#define ECHO_PIN {sonar_echo}")
+
+    # Environmental barometer (BMP280 / BME280). BMP280 & BME280 share the
+    # macro; the driver reads the chip id at runtime and only publishes
+    # /humidity for a BME280.
+    env = sensors.get("env") or sensors.get("env_type")
+    if (env and str(env).upper() not in ("NONE", "FAKE")) or sensors.get("use_bmp280"):
+        lines.append("#define USE_BMP280")
+        _bmp_addr = sensors.get("bmp280_addr")
+        if _bmp_addr not in (None, ""):
+            _a = _bmp_addr if isinstance(_bmp_addr, str) else hex(_bmp_addr)
+            lines.append(f"#define BMP280_ADDR {_a}")
 
     # ── Telemetry ─────────────────────────────────────────────────────
     baudrate = telemetry.get("baudrate") or spec.get("baudrate", 921600)

--- a/tools/robot_config_engine/generator.py
+++ b/tools/robot_config_engine/generator.py
@@ -1,0 +1,760 @@
+# Copyright (c) 2026 Thomas Chou, Paul Bouchier, Linorobot contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from typing import Dict, Any
+
+
+def _n(v) -> str:
+    """Format a number the way the hand-written headers do: whole values as
+    plain ints (12, not 12.0), fractional values without trailing zeros."""
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return str(v)
+    if f == int(f):
+        return str(int(f))
+    return repr(f).rstrip("0").rstrip(".")
+
+
+def _format_adc_lut(lut) -> str:
+    """`const int16_t ADC_LUT[4096] = { ... };`, 16 values/row — matches the
+    web UI's formatAdcLutArray() so a browser-generated and a server-generated
+    header are byte-identical."""
+    vals = [int(round(float(x))) for x in (lut or [])]
+    if not vals:
+        return "const int16_t ADC_LUT[4096] = { /* insert adc_calibrate data here */ };"
+    rows = []
+    for i in range(0, len(vals), 16):
+        chunk = vals[i:i + 16]
+        row = "    " + ", ".join(str(v) for v in chunk)
+        if i + 16 < len(vals):
+            row += ","
+        rows.append(row)
+    return "const int16_t ADC_LUT[4096] = {\n" + "\n".join(rows) + "\n};"
+
+
+def _ipv4_c(ip: str) -> str:
+    parts = [p.strip() for p in str(ip).split(".")]
+    if len(parts) == 4 and all(p.isdigit() for p in parts):
+        return "{ " + ", ".join(parts) + " }"
+    return "{ 192, 168, 1, 100 }"
+
+
+def generate_config_header(spec: Dict[str, Any]) -> str:
+    """
+    Generate a Linorobot2 C++ configuration header from a spec dict.
+    Pin assignments are emitted in the same macro format used by the
+    original hand-written config headers so that round-trip
+    parse → generate → re-parse is lossless.
+    """
+    name     = spec.get("robot_name", "custom_robot").upper()
+    kine     = spec.get("kinematics", "DIFFERENTIAL_DRIVE")
+    geom     = spec.get("geometry", {})
+    motors   = spec.get("motors", {})
+    sensors  = spec.get("sensors", {})
+    pins     = spec.get("pins", {})
+    telemetry = spec.get("telemetry", {})
+    driver   = motors.get("driver_type", "BTS7960")
+
+    # ── Header guard & kinematics ────────────────────────────────────
+    lines = [
+        "// Copyright (c) 2026 Thomas Chou, Paul Bouchier, Linorobot contributors",
+        f"// Auto-generated configuration for {spec.get('robot_name', 'custom_robot')}",
+        f"#ifndef {name}_CONFIG_H",
+        f"#define {name}_CONFIG_H",
+        "",
+        f"#define LINO_BASE {kine}",
+        "",
+        "// Robot Physical Geometry",
+        f"#define WHEEL_DIAMETER {_n(geom.get('wheel_diameter', 0.065))}",
+        f"#define LR_WHEELS_DISTANCE {_n(geom.get('track_width', 0.20))}",
+    ]
+    # FR_WHEELS_DISTANCE only matters for 4-wheel bases
+    if "wheelbase" in geom and kine != "DIFFERENTIAL_DRIVE":
+        lines.append(f"#define FR_WHEELS_DISTANCE {_n(geom['wheelbase'])}")
+    if geom.get("weight") is not None:
+        lines.append(f"#define ROBOT_WEIGHT {_n(geom['weight'])}")
+
+    # ── Motor driver & characteristics ───────────────────────────────
+    # Simulation mode (Fake Wheel and/or Fake LD19)
+    sim = spec.get("simulation") or {}
+    if sim.get("fake_wheel") or sim.get("fake_ld19"):
+        # A simulated config looks entirely normal from the outside and the
+        # board reports plausible topics, so flashing one to a real robot ends
+        # with a machine that sits still while /odom insists it is driving.
+        # Say so where it cannot be missed.
+        lines.extend([
+            "",
+            "// ===========================================================================",
+            "// SIMULATION MODE IS ENABLED -- THIS IS NOT A REAL ROBOT CONFIG",
+            "// Comment out the USE_FAKE_* defines below before flashing a robot whose",
+            "// motors, encoders or LiDAR are actually wired, or they will be ignored.",
+            "// ===========================================================================",
+        ])
+    if sim.get("fake_wheel"):
+        lines.extend([
+            "",
+            "// Simulated drivetrain -- no motors or encoders need to be attached",
+            "#define USE_FAKE_WHEEL",
+        ])
+        if sim.get("robot_mass") is not None:
+            lines.append(f"#define FAKE_ROBOT_MASS {sim['robot_mass']:.2f} // kg")
+        if sim.get("wheel_noise_rpm") is not None:
+            lines.append(f"#define FAKE_WHEEL_NOISE_RPM {sim['wheel_noise_rpm']:.2f} // +/- peak encoder noise")
+
+    # The emulated scan leaves the board either over the LiDAR UART pin or over
+    # WiFi UDP. With neither, there is nowhere for it to go, so the emulator is
+    # not enabled at all: turning it on would burn the loop building packets and
+    # writing them into an unconnected pad, while the board reported success and
+    # no scan ever reached ROS. The pin is unset by default because on a stock
+    # board nothing is wired to it -- wire it, set the pin, and this switches on.
+    lidar_rxd = pins.get("lidar_rxd")
+    if lidar_rxd is None:
+        lidar_rxd = (spec.get("advanced") or {}).get("lidar_rxd")
+    # A negative pin is "not wired", not a pin number.
+    lidar_pin_wired = lidar_rxd is not None and int(lidar_rxd) >= 0
+    lidar_over_udp = bool((spec.get("telemetry") or {}).get("use_lidar_udp"))
+    ld19_routed = lidar_pin_wired or lidar_over_udp
+
+    if sim.get("fake_ld19") and not ld19_routed:
+        lines.extend([
+            "",
+            "// Fake LD19 requested but NOT enabled: no LiDAR UART pin is wired",
+            "// and LiDAR-over-UDP is off, so the simulated scan would have no",
+            "// route out. Any route over the serial pin needs a physical wire:",
+            "// fake LD19 transmits the scan on it, and a real LD19 forwarded",
+            "// over UDP must be wired into it, since UDP only carries what the",
+            "// board receives. Fake LD19 over WiFi UDP needs no wire at all.",
+            "// Wire IO4 (gendrv) and set the pin, or turn on LiDAR over UDP.",
+        ])
+
+    if sim.get("fake_ld19") and ld19_routed:
+        lines.extend([
+            "",
+            "// Simulated LD19 LiDAR -- raycasts 2D room + obstacle wall to LIDAR_RXD",
+            "#define USE_FAKE_LD19",
+        ])
+        if lidar_pin_wired:
+            lines.append(f"#define LIDAR_RXD {int(lidar_rxd)}")
+        if sim.get("lidar_baudrate") is not None:
+            lines.append(f"#define LIDAR_BAUDRATE {int(sim['lidar_baudrate'])}")
+        if sim.get("map_width") is not None:
+            lines.append(f"#define FAKE_MAP_WIDTH {sim['map_width']:.1f}f // room width (m)")
+        if sim.get("map_height") is not None:
+            lines.append(f"#define FAKE_MAP_HEIGHT {sim['map_height']:.1f}f // room height (m)")
+        if sim.get("wall_obstacle") is not None:
+            wall_val = 1 if sim["wall_obstacle"] else 0
+            lines.append(f"#define FAKE_WALL_OBSTACLE {wall_val}")
+        if sim.get("wall_x1") is not None:
+            lines.append(f"#define FAKE_WALL_X1 {sim['wall_x1']:.2f}f")
+        if sim.get("wall_y1") is not None:
+            lines.append(f"#define FAKE_WALL_Y1 {sim['wall_y1']:.2f}f")
+        if sim.get("wall_x2") is not None:
+            lines.append(f"#define FAKE_WALL_X2 {sim['wall_x2']:.2f}f")
+        if sim.get("wall_y2") is not None:
+            lines.append(f"#define FAKE_WALL_Y2 {sim['wall_y2']:.2f}f")
+        # Defaults on: the range comes from the same raycast as the scan, so it
+        # needs no pins, and a simulated robot driven into a wall should get the
+        # same protection a real one would have.
+        if sim.get("fake_sonar", True):
+            lines.extend([
+                "",
+                "// Simulated forward sonar -- nearest return in a cone of the same",
+                "// raycast that feeds the scan. No pins, no wiring.",
+                "#define USE_FAKE_SONAR",
+                "// Firmware-side hazard stop: blocks forward motion inside",
+                "// SAFETY_STOP_RANGE and publishes the state on /safety_stop.",
+                "// Reverse stays available so the robot can back out.",
+                "#define USE_SAFETY_STOP",
+            ])
+
+    lines.extend([
+        "",
+        "// Motor Driver & Characteristics",
+        f"#define USE_{driver}_MOTOR_DRIVER",
+        f"#define MOTOR_MAX_RPM {motors.get('max_rpm', 300)}",
+        f"#define MAX_RPM_RATIO 0.85",
+        f"#define MOTOR_OPERATING_VOLTAGE {_n(motors.get('operating_voltage', 12.0))}",
+        f"#define MOTOR_POWER_MAX_VOLTAGE {_n(motors.get('max_voltage', 12.0))}",
+        f"#define MOTOR_POWER_MEASURED_VOLTAGE {_n(motors.get('measured_voltage', motors.get('max_voltage', 12.0)))}",
+        "",
+        f"#define PWM_BITS {motors.get('pwm_bits', 10)}",
+        f"#define PWM_FREQUENCY {motors.get('pwm_frequency', 20000)}",
+        f"#define PWM_MAX pow(2, PWM_BITS) - 1",
+        f"#define PWM_MIN -PWM_MAX",
+        "",
+        f"#define COUNTS_PER_REV1 {motors.get('cpr', 1320)}",
+        f"#define COUNTS_PER_REV2 {motors.get('cpr', 1320)}",
+        f"#define COUNTS_PER_REV3 {motors.get('cpr', 1320)}",
+        f"#define COUNTS_PER_REV4 {motors.get('cpr', 1320)}",
+        "",
+        "// INVERT MOTOR DIRECTIONS",
+        f"#define MOTOR1_INV {str(motors.get('motor1_inv', False)).lower()}",
+        f"#define MOTOR2_INV {str(motors.get('motor2_inv', True)).lower()}",
+        f"#define MOTOR3_INV {str(motors.get('motor3_inv', False)).lower()}",
+        f"#define MOTOR4_INV {str(motors.get('motor4_inv', True)).lower()}",
+        "",
+        "// INVERT ENCODER COUNTS",
+        f"#define MOTOR1_ENCODER_INV {str(pins.get('encoders', {}).get('m1_inv', False)).lower()}",
+        f"#define MOTOR2_ENCODER_INV {str(pins.get('encoders', {}).get('m2_inv', False)).lower()}",
+        f"#define MOTOR3_ENCODER_INV {str(pins.get('encoders', {}).get('m3_inv', False)).lower()}",
+        f"#define MOTOR4_ENCODER_INV {str(pins.get('encoders', {}).get('m4_inv', False)).lower()}",
+        "",
+        "// Velocity PID Tuning Constants",
+        f"#define K_P {_n(spec.get('pid', {}).get('kp', 0.6))}",
+        f"#define K_I {_n(spec.get('pid', {}).get('ki', 0.8))}",
+        f"#define K_D {_n(spec.get('pid', {}).get('kd', 0.5))}",
+        "",
+        "// Pin Assignments",
+    ])
+
+    # ── LED pin ──────────────────────────────────────────────────────
+    mcu_name = spec.get("mcu", "").upper()
+    led_pin = pins.get("led")
+    if led_pin is None:
+        if mcu_name in ["PICOW", "PICO2W"]:
+            led_pin = "LED_BUILTIN"
+        elif "PICO" in mcu_name:
+            led_pin = 25
+        elif "GENDRV" in mcu_name or "ESP32" in mcu_name:
+            led_pin = "LED_BUILTIN"
+        else:
+            led_pin = 13
+    lines.append(f"#define LED_PIN {led_pin}")
+
+    # ── Encoder pins (all 4 motors, always) ──────────────────────────
+    # These are unconditional #defines (not inside #ifdef blocks)
+    enc = pins.get("encoders", {})
+    lines.append("")
+    lines.append("// ENCODER PINS")
+    for i in range(1, 5):
+        a = enc.get(f"m{i}_a", -1)
+        b = enc.get(f"m{i}_b", -1)
+        lines.append(f"#define MOTOR{i}_ENCODER_A {a}")
+        lines.append(f"#define MOTOR{i}_ENCODER_B {b}")
+
+    # ── Motor driver pins inside #ifdef block ─────────────────────────
+    # Emit in exactly the same format as the hand-written headers:
+    # one #ifdef USE_*_MOTOR_DRIVER block containing all 4 motors.
+    lines.append("")
+    lines.append(f"// MOTOR PINS")
+    lines.append(f"#ifdef {_driver_macro(driver)}")
+    for i in range(1, 5):
+        m = pins.get(f"motor{i}", {})
+        if driver == "BTS7960":
+            # BTS7960 uses two outputs only: IN_A = RPWM, IN_B = LPWM.
+            # MOTOR{i}_PWM is an unused arg in the driver class -> fixed placeholder.
+            lines.append(f"  #define MOTOR{i}_PWM -1 //DON'T TOUCH THIS! This is just a placeholder")
+            lines.append(f"  #define MOTOR{i}_IN_A {m.get('in_a', m.get('pwm_l', -1))}")
+            lines.append(f"  #define MOTOR{i}_IN_B {m.get('in_b', m.get('en', -1))}")
+        elif driver == "GENERIC_2_IN":
+            lines.append(f"  #define MOTOR{i}_PWM {m.get('pwm', -1)}")
+            lines.append(f"  #define MOTOR{i}_IN_A {m.get('in_a', -1)}")
+            lines.append(f"  #define MOTOR{i}_IN_B {m.get('in_b', -1)}")
+        elif driver == "GENERIC_1_IN":
+            lines.append(f"  #define MOTOR{i}_PWM {m.get('pwm', -1)}")
+            lines.append(f"  #define MOTOR{i}_IN_A {m.get('dir', m.get('in_a', -1))}")
+            lines.append(f"  #define MOTOR{i}_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder")
+        elif driver == "ESC":
+            lines.append(f"  #define MOTOR{i}_PWM {m.get('pwm', -1)}")
+            lines.append(f"  #define MOTOR{i}_IN_A -1 //DON'T TOUCH THIS! This is just a placeholder")
+            lines.append(f"  #define MOTOR{i}_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder")
+    lines.append(f"  #define PWM_MAX pow(2, PWM_BITS) - 1")
+    lines.append(f"  #define PWM_MIN -PWM_MAX")
+    lines.append(f"#endif")
+
+    # ── Servo for Ackermann ───────────────────────────────────────────
+    if kine == "ACKERMANN":
+        servo_pin = pins.get("servo", 21)
+        lines.append(f"#define STEERING_SERVO_PIN {servo_pin}")
+
+    # ── Sensor configuration ──────────────────────────────────────────
+    lines.extend(["", "// Sensor Configuration"])
+
+    # Form-shape (sensors.imu, short name e.g. "QMI8658") checked before
+    # parser-shape (sensors.imu_type, full macro): parser.py's default spec
+    # always sets imu_type (even "USE_FAKE_IMU" as a placeholder), so an
+    # overlay that only sets imu — every web-UI form does — would otherwise
+    # always lose to a stale/default imu_type already in the base spec on
+    # any merge (same key-mismatch class as battery/sonar/INA219 above).
+    imu = sensors.get("imu") or sensors.get("imu_type", "USE_FAKE_IMU")
+    if imu and imu not in ["NONE", "USE_FAKE_IMU", "FAKE"]:
+        macro = imu if imu.startswith("USE_") else f"USE_{imu}_IMU"
+        lines.append(f"#define {macro}")
+    else:
+        lines.append("// #define USE_FAKE_IMU")
+
+    mag = sensors.get("mag") or sensors.get("mag_type", "USE_FAKE_MAG")   # see imu comment above
+    if mag and mag not in ["NONE", "USE_FAKE_MAG", "FAKE"]:
+        macro = mag if mag.startswith("USE_") else f"USE_{mag}_MAG"
+        lines.append(f"#define {macro}")
+    else:
+        lines.append("// #define USE_FAKE_MAG")
+
+    # IMU / magnetometer tuning. MAG_BIAS is #ifdef-gated in firmware.ino;
+    # ACCEL_COV / GYRO_COV / ORI_COV are #ifndef-gated in imu_interface.h
+    # (blank == firmware default of 0.00001).
+    tune = spec.get("imu_tuning", {})
+    mb = tune.get("mag_bias")
+    if isinstance(mb, (list, tuple)) and len(mb) == 3:
+        lines.append(f"#define MAG_BIAS {{ {', '.join(_n(x) for x in mb)} }}")
+    # ACCEL/GYRO/ORI/MAG_COV are 3-vectors; POSE/TWIST_COV are 6-vectors — a
+    # scalar expands, a list is used as-is. All #ifndef-gated in firmware.
+    # When a known sensor is enabled and the spec left a covariance blank, fall
+    # back to a datasheet-derived default (variance ≈ (noise_density·√100 Hz)²)
+    # so the header ships realistic values instead of the firmware's 1e-5.
+    _imu_key = (sensors.get("imu") or str(sensors.get("imu_type") or "")
+                ).replace("USE_", "").replace("_IMU", "").upper()
+    _mag_key = (sensors.get("mag") or str(sensors.get("mag_type") or "")
+                ).replace("USE_", "").replace("_MAG", "").upper()
+    _env_key = str(sensors.get("env") or sensors.get("env_type") or "").upper()
+    _imu_cov = {
+        "BNO085": {"accel_cov": 2.2e-4, "gyro_cov": 1.5e-6, "ori_cov": 4e-3},
+        "LSM6DSOX": {"accel_cov": 4.7e-5, "gyro_cov": 4.4e-7},
+        "ICM20948": {"accel_cov": 5.1e-4, "gyro_cov": 6.9e-6},
+        "QMI8658": {"accel_cov": 8e-5, "gyro_cov": 2e-6},
+        "MPU9250": {"accel_cov": 9e-4, "gyro_cov": 3e-6},
+        "MPU9150": {"accel_cov": 1.5e-3, "gyro_cov": 3e-6},
+        "MPU6050": {"accel_cov": 1.5e-3, "gyro_cov": 3e-6},
+        "GY85": {"accel_cov": 1.8e-3, "gyro_cov": 4.4e-5},
+    }.get(_imu_key, {})
+    _mag_cov = {"AK09918": 2.3e-14, "ICM20948": 2.3e-14, "QMC5883L": 4e-14,
+                "HMC5883L": 4e-14, "AK8963": 9e-14, "AK8975": 9e-14}.get(_mag_key)
+    # pressure Pa² (σ≈1.7 Pa), temperature °C² (±0.5°C accuracy), humidity (0..1)² (±3% RH)
+    _env_cov = {"BMP280": [3, 0.25, 0], "BME280": [3, 0.25, 9e-4]}.get(_env_key)
+    _cov_defaults = dict(_imu_cov)
+    if _mag_cov is not None:
+        _cov_defaults["mag_cov"] = _mag_cov
+    if _env_cov is not None:
+        _cov_defaults["env_cov"] = _env_cov
+
+    for _macro, _key, _len in (
+        ("ACCEL_COV", "accel_cov", 3), ("GYRO_COV", "gyro_cov", 3),
+        ("ORI_COV", "ori_cov", 3), ("MAG_COV", "mag_cov", 3),
+        ("POSE_COV", "pose_cov", 6), ("TWIST_COV", "twist_cov", 6),
+        ("ENV_COV", "env_cov", 3),   # BMP280 pressure/temperature/humidity .variance
+    ):
+        _v = tune.get(_key)
+        if _v is None or _v == "":
+            _v = _cov_defaults.get(_key)
+        if _v is None or _v == "":
+            continue
+        _t = list(_v) if isinstance(_v, (list, tuple)) else [_v] * _len
+        lines.append(f"#define {_macro} {{ {', '.join(_n(x) for x in _t)} }}")
+
+    # I2C — BOARD_INIT is synthesised only when the user has actually defined
+    # I2C pins (SDA_PIN / SCL_PIN >= 0). A bare module leaves them unset: no
+    # SDA_PIN/SCL_PIN and no BOARD_INIT, so firmware.ino's default Wire.begin()
+    # path applies.
+    # pins.i2c (form-shape) checked before sensors.i2c_sda/scl (parser-shape):
+    # the web-UI form always writes pins.i2c, never sensors.i2c_sda/scl, so
+    # the parser-shape key from an existing base spec would otherwise always
+    # win on merge (same key-mismatch class as imu/mag above).
+    _i2c_pins = pins.get("i2c", {})
+    i2c_sda = _i2c_pins.get("sda")
+    i2c_scl = _i2c_pins.get("scl")
+    i2c_sda = sensors.get("i2c_sda", -1) if i2c_sda is None else i2c_sda
+    i2c_scl = sensors.get("i2c_scl", -1) if i2c_scl is None else i2c_scl
+    have_imported_board_init = any(d.get("name") == "BOARD_INIT" for d in spec.get("raw_defines", []))
+    if i2c_sda >= 0 and i2c_scl >= 0:
+        lines.append(f"#define SDA_PIN {i2c_sda}")
+        lines.append(f"#define SCL_PIN {i2c_scl}")
+        # SDA_PIN/SCL_PIN are only consulted through BOARD_INIT
+        # (firmware.ino: `#ifdef BOARD_INIT ... #else Wire.begin(); #endif`).
+        # An imported header's own BOARD_INIT is kept verbatim by the
+        # passthrough below; only synthesise one when the import lacked it.
+        if not have_imported_board_init:
+            is_rp2 = "PICO" in mcu_name or "RP2" in mcu_name
+            bi = ["#define BOARD_INIT { \\"]
+            if is_rp2:
+                bi.append("    Wire.setSDA(SDA_PIN); \\")
+                bi.append("    Wire.setSCL(SCL_PIN); \\")
+                bi.append("    Wire.begin(); \\")
+            else:
+                bi.append("    Wire.begin(SDA_PIN, SCL_PIN); \\")
+            bi.append("    Wire.setClock(400000); \\")
+            bi.append("}")
+            lines.extend(bi)
+
+    # Battery. Same key-name split as everywhere else in this block: the
+    # web-UI form (readSpecFromForm()) only ever sets battery_monitor to the
+    # string "INA219"/"ADC_DIVIDER"/"NONE"; only a spec parsed from an
+    # existing header also carries the legacy boolean use_ina219 parser.py
+    # emits. Checking use_ina219 alone meant a brand-new robot (nothing to
+    # merge with, so the raw form overlay reaches generate_config_header()
+    # untouched) silently got NO #define USE_INA219 at all, even with i2c
+    # auto-detect having correctly set battery_monitor="INA219" in the form.
+    if sensors.get("battery_monitor") == "INA219" or sensors.get("use_ina219", False):
+        lines.append("#define USE_INA219")
+    else:
+        bat_pin = pins.get("battery_pin", sensors.get("battery_pin", -1))
+        if bat_pin is not None and bat_pin >= 0:
+            lines.append(f"#define BATTERY_PIN {bat_pin}")
+            # DAC output pin for the adc_calibrate sweep. Only the classic ESP32,
+            # the ESP32-S2 and the ESP32-based Waveshare General Driver carry a
+            # hardware DAC; everything else (ESP32-S3/C3, RP2040/RP2350, Teensy)
+            # has none, so no DAC_PIN is emitted there.
+            _dac_pin = pins.get("dac_pin", sensors.get("dac_pin"))
+            _mcu_has_dac = mcu_name in ("ESP32", "ESP32S2", "GENDRV")
+            if _mcu_has_dac and _dac_pin is not None and int(_dac_pin) >= 0:
+                lines.append(f"#define DAC_PIN {int(_dac_pin)}")
+            r1 = sensors.get("battery_r1", sensors.get("battery_divider_r1", 30000.0))
+            r2 = sensors.get("battery_r2", sensors.get("battery_divider_r2", 7500.0))
+            # firmware/lib/battery/battery.cpp: `return BATTERY_ADJUST(reading);`
+            # (no #ifndef fallback) — an ADC battery config MUST define it.
+            adc_lut = sensors.get("adc_lut")
+            r1k, r2k = _n(float(r1) / 1000.0), _n(float(r2) / 1000.0)
+            if adc_lut:
+                # A real calibration (adc_lut present) is always fresh, explicit
+                # user intent — "I just ran Run Hardware Calibration" — so it
+                # wins unconditionally, even over a BATTERY_ADJUST this same
+                # generator wrote into an earlier version of this file (which
+                # a re-parse can't tell apart from a hand customization, so it
+                # would otherwise sit in raw_defines and block a rewrite here
+                # forever). The line below still ends up in `emitted` further
+                # down, so the stale raw_defines copy is skipped, not doubled.
+                lines.append("#define USE_ADC_LUT")
+                lines.append(_format_adc_lut(adc_lut))
+                lines.append(f"#define BATTERY_ADJUST(v) (ADC_LUT[v] * (3.3 / 4096 * ({r1k} + {r2k}) / {r2k}))")
+            elif not any(d.get("name") == "BATTERY_ADJUST" for d in spec.get("raw_defines", [])):
+                # firmware/lib/battery/battery.cpp: `return BATTERY_ADJUST(reading);`
+                # (no #ifndef fallback) — an ADC battery config MUST define it.
+                if "PICO" in mcu_name or "RP2" in mcu_name:
+                    lines.append(f"#define BATTERY_ADJUST(v) ((v) * (3.3 / 4096 * ({r1k} + {r2k}) / {r2k}))")
+                else:  # ESP32 family: analogReadMilliVolts() returns millivolts
+                    lines.append(f"#define BATTERY_ADJUST(v) ((v) * (({r1k} + {r2k}) / {r2k}) / 1000.0)")
+
+    for macro, keys in [
+        ("BATTERY_CAP", ("battery_cap", "battery_capacity")),
+        ("BATTERY_MIN", ("battery_min", "battery_min_voltage")),
+        ("BATTERY_MAX", ("battery_max", "battery_max_voltage")),
+        ("BATTERY_DIP", ("battery_dip",)),
+    ]:
+        val = next((sensors[k] for k in keys if sensors.get(k) is not None), None)
+        if val is not None:
+            lines.append(f"#define {macro} {_n(val)}")
+
+    # Sonar. firmware.ino/range.cpp actually gate on TRIG_PIN/ECHO_PIN alone —
+    # USE_SONAR isn't read anywhere — but app.js's generateCppHeader() (the
+    # client-side preview) emits it as a documentation marker next to them,
+    # matching USE_INA219/USE_BMP280/etc.; kept in parity here so a
+    # server-merged header (search-and-merge writes) and the browser preview
+    # aren't cosmetically different, and so re-parsing what we ourselves wrote
+    # is unambiguous either way.
+    # Sonar pins live in two places depending on who built the spec: the
+    # web-UI form (readSpecFromForm()) only ever writes pins.sonar.trig/echo;
+    # a spec parsed from an existing header (or a hand-built overlay like a
+    # test fixture) may instead carry the flat sensors.sonar_trig/echo
+    # parser.py also emits. A deep-merge can leave a stale -1 sitting in
+    # whichever location the overlay didn't touch, so -1 ("no pin", the
+    # sentinel used everywhere in this spec) is treated as absent rather
+    # than a real value — whichever location holds a real pin wins;
+    # pins.sonar (the current, form-shape location) is the tiebreaker.
+    def _valid_pin(v):
+        return v if isinstance(v, (int, float)) and v >= 0 else None
+    _sonar_pins = pins.get("sonar") or {}
+    sonar_trig = _valid_pin(_sonar_pins.get("trig"))
+    if sonar_trig is None: sonar_trig = _valid_pin(sensors.get("sonar_trig"))
+    sonar_echo = _valid_pin(_sonar_pins.get("echo"))
+    if sonar_echo is None: sonar_echo = _valid_pin(sensors.get("sonar_echo"))
+    if sonar_trig is None: sonar_trig = -1
+    if sonar_echo is None: sonar_echo = -1
+    if sonar_trig >= 0 and sonar_echo >= 0:
+        lines.append("#define USE_SONAR")
+        lines.append(f"#define TRIG_PIN {sonar_trig}")
+        lines.append(f"#define ECHO_PIN {sonar_echo}")
+
+    # Environmental barometer (BMP280 / BME280). BMP280 & BME280 share the
+    # macro; the driver reads the chip id at runtime and only publishes
+    # /humidity for a BME280.
+    env = sensors.get("env") or sensors.get("env_type")
+    if (env and str(env).upper() not in ("NONE", "FAKE")) or sensors.get("use_bmp280"):
+        lines.append("#define USE_BMP280")
+        _bmp_addr = sensors.get("bmp280_addr")
+        if _bmp_addr not in (None, ""):
+            _a = _bmp_addr if isinstance(_bmp_addr, str) else hex(_bmp_addr)
+            lines.append(f"#define BMP280_ADDR {_a}")
+
+    # ── Telemetry ─────────────────────────────────────────────────────
+    baudrate = telemetry.get("baudrate") or spec.get("baudrate", 921600)
+    lines.extend(["", "// Telemetry & micro-ROS Communication",
+                  f"#define BAUDRATE {baudrate}"])
+
+    adv = spec.get("advanced", {})
+
+    use_wifi = telemetry.get("use_wifi", False) or ("WIFI" in str(telemetry.get("transport", "")).upper())
+    if (use_wifi or telemetry.get("use_syslog", False)
+            or telemetry.get("use_arduino_ota", False) or telemetry.get("use_lidar_udp", False)):
+        # Secrets (WIFI_AP_LIST, AGENT_IP, SYSLOG_SERVER, LIDAR_SERVER,
+        # OTA_PASSWORD) live ONLY in the git-ignored config/custom/wifi_config.h;
+        # this tracked header keeps the non-secret feature flags and pulls the
+        # rest in via __has_include (see generate_wifi_config()).
+        lines.append('#if __has_include("wifi_config.h")')
+        lines.append('  #include "wifi_config.h"')
+        lines.append('#endif')
+    if use_wifi:
+        # The PlatformIO env pins board_microros_transport = wifi, so
+        # firmware.ino compiles set_microros_net_transports(AGENT_IP, AGENT_PORT)
+        # unconditionally — both macros must exist even before credentials are
+        # entered. Not secrets: emit #ifndef-guarded defaults, overridden by
+        # wifi_config.h once real values exist.
+        agent_ip = adv.get("agent_ip") or telemetry.get("agent_ip") or "192.168.1.100"
+        lines.append("#define USE_WIFI")
+        lines.append("#ifndef AGENT_IP")
+        lines.append(f"  #define AGENT_IP {_ipv4_c(agent_ip)}")
+        lines.append("#endif")
+        lines.append("#ifndef AGENT_PORT")
+        lines.append(f"  #define AGENT_PORT {telemetry.get('agent_port', 8888)}")
+        lines.append("#endif")
+    if use_wifi and telemetry.get("use_syslog", False):
+        lines.append("#define USE_SYSLOG")
+        lines.append(f"#define SYSLOG_PORT {adv.get('syslog_port', 514)}")
+        if adv.get("wifi_monitor"):
+            lines.append(f"#define WIFI_MONITOR {adv['wifi_monitor']} // min. period to send WiFi RSSI to syslog")
+    if use_wifi and telemetry.get("use_arduino_ota", False):
+        lines.append("#define USE_ARDUINO_OTA")
+        if adv.get("ota_hostname"):
+            lines.append(f'#define OTA_HOSTNAME "{adv["ota_hostname"]}"')
+    if use_wifi and telemetry.get("use_lidar_udp", False):
+        lines.append("#define USE_LIDAR_UDP")
+        lines.append(f"#define LIDAR_PORT {adv.get('lidar_port', 8889)}")
+        if adv.get("lidar_baudrate") is not None:
+            lines.append(f"#define LIDAR_BAUDRATE {adv['lidar_baudrate']}")
+        if adv.get("lidar_rxd") is not None:
+            lines.append(f"#define LIDAR_RXD {adv['lidar_rxd']}")
+        if adv.get("lidar_serial") is not None:
+            lines.append(f"#define LIDAR_SERIAL {adv['lidar_serial']}")
+    # Simulation and the dual-core control task do not mix: the fake LiDAR
+    # touches the simulated pose and its UART from the loop while the control
+    # task drives the same pose from the other core with no lock between them,
+    # and the board crash-loops. Simulation wins -- it is the point of the
+    # config -- so the second core is left alone.
+    sim_cfg = spec.get("simulation") or {}
+    simulating = bool(sim_cfg.get("fake_wheel") or sim_cfg.get("fake_ld19"))
+    if telemetry.get("use_dual_core", False) and not simulating:
+        lines.append("#define USE_DUAL_CORE")
+    if adv.get("use_short_brake"):
+        lines.append("#define USE_SHORT_BRAKE")
+    if adv.get("node_name"):
+        lines.append(f'#define NODE_NAME "{adv["node_name"]}"')
+    if adv.get("topic_prefix"):
+        _tp = str(adv["topic_prefix"])
+        if not _tp.endswith("/"):
+            _tp += "/"
+        lines.append(f'#define TOPIC_PREFIX "{_tp}"')
+    if adv.get("device_hostname"):
+        lines.append(f'#define DEVICE_HOSTNAME "{adv["device_hostname"]}"')
+    if adv.get("app_name"):
+        lines.append(f'#define APP_NAME "{adv["app_name"]}"')
+
+    # ── Verbatim passthrough of anything the import carried that we did
+    #    not otherwise model, so parse → generate never silently drops a
+    #    macro (covariances, RCCHECK, board hooks, …).
+    _blob = "\n".join(lines)
+    # names the generator produced, commented forms (// #define X) included
+    emitted = set(re.findall(r'^[ \t]*(?://\s*)?#define[ \t]+([A-Za-z_]\w*)', _blob, re.M))
+    # structural macro families the generator always owns from the modeled spec
+    _owned_re = re.compile(r'^(MOTOR\d|COUNTS_PER_REV\d?$'
+                            r'|MOTOR_(MAX_RPM|OPERATING_VOLTAGE|POWER_MAX_VOLTAGE|POWER_MEASURED_VOLTAGE)$'
+                            r'|MAX_RPM_RATIO$|PWM_(BITS|FREQUENCY|MAX|MIN)$|K_[PID]$|LINO_BASE$'
+                            r'|WHEEL_DIAMETER$|LR_WHEELS_DISTANCE$|FR_WHEELS_DISTANCE$|ROBOT_WEIGHT$'
+                            r'|LED_PIN$|BAUDRATE$|SDA_PIN$|SCL_PIN$|TRIG_PIN$|ECHO_PIN$|DAC_PIN$)')
+    def _keep(nm):
+        return (nm and nm not in emitted
+                and not nm.startswith("USE_")   # every USE_* feature flag is a modeled decision
+                and not _owned_re.match(nm))
+    extras = [d for d in spec.get("raw_defines", []) if _keep(d.get("name"))]
+    if extras:
+        lines.append("")
+        lines.append("// Preserved from the imported configuration")
+        for d in extras:
+            lines.append(d["text"])
+
+    lines.extend(["", f"#endif // {name}_CONFIG_H", ""])
+    return "\n".join(lines)
+
+
+def _driver_macro(driver: str) -> str:
+    return {
+        "BTS7960":    "USE_BTS7960_MOTOR_DRIVER",
+        "GENERIC_2_IN": "USE_GENERIC_2_IN_MOTOR_DRIVER",
+        "GENERIC_1_IN": "USE_GENERIC_1_IN_MOTOR_DRIVER",
+        "ESC":        "USE_ESC_MOTOR_DRIVER",
+    }.get(driver, "USE_GENERIC_2_IN_MOTOR_DRIVER")
+
+
+def generate_platformio_env(spec: Dict[str, Any], ros_distro: str = "jazzy") -> str:
+    """A `[env:<robot>]` block for firmware/platformio.ini, mirroring the Web
+    UI's generatePlatformioEnv(). Inherits micro-ROS distro etc. from the
+    file-level [env]; ros_distro is accepted for CLI compatibility and only
+    emitted when it is not the default."""
+    name = spec.get("robot_name", "my_robot")
+    mcu = str(spec.get("mcu", "PICO2")).upper()
+    cfg_macro = f"USE_{name.upper()}_CONFIG"
+
+    transport = str(spec.get("transport")
+                    or spec.get("telemetry", {}).get("transport") or "")
+    is_wifi = bool(re.search(r"WIFI|UDP", transport, re.I))
+    wifi_transport_line = "board_microros_transport = wifi\n" if is_wifi else ""
+    wifi_flag = "\n    -D USE_STAY_CONNECTED" if is_wifi else ""
+    distro_line = ""
+    if ros_distro and ros_distro not in ("jazzy", "${sysenv.ROS_DISTRO}"):
+        distro_line = f"board_microros_distro = {ros_distro}\n"
+
+    adv = spec.get("advanced", {})
+    ota_ip = adv.get("ota_ip") if adv.get("ota_enable") and adv.get("ota_ip") else ""
+
+    if mcu in ("PICO", "PICO2", "PICOW", "PICO2W"):
+        board = {"PICO": "rpipico", "PICO2": "rpipico2",
+                 "PICOW": "rpipicow", "PICO2W": "rpipico2w"}.get(mcu, "rpipico")
+        pico_macro = f"    -D {mcu}\n" if mcu in ("PICOW", "PICO2W") else ""
+        return (
+            f"[env:{name}]\n"
+            "platform = https://github.com/maxgerhardt/platform-raspberrypi.git\n"
+            f"board = {board}\n"
+            "monitor_port = /dev/ttyACM0\n"
+            "upload_port = /dev/ttyACM0\n"
+            "upload_protocol = picotool\n"
+            "board_microros_user_meta = atomic.meta\n"
+            f"{distro_line}{wifi_transport_line}lib_deps =\n"
+            "    ${env.lib_deps}\n"
+            "    https://github.com/gbr1/rp2040-encoder-library.git\n"
+            "build_flags =\n"
+            "    -I ../config\n"
+            "    -D PICO\n"
+            f"{pico_macro}    -D {cfg_macro}{wifi_flag}\n"
+        )
+
+    # monitor_speed must match the BAUDRATE the firmware is built with, or
+    # `pio device monitor` shows garbage on a board configured for anything
+    # other than 921600 (the GenDrv reference designs run at 1.5 Mbaud).
+    monitor_baud = (spec.get("telemetry") or {}).get("baudrate") or spec.get("baudrate", 921600)
+
+    if mcu in ("ESP32", "GENDRV"):
+        if ota_ip:
+            upl = (f"monitor_port = /dev/ttyUSB0\nupload_port = {ota_ip}\n"
+                   "upload_protocol = espota")
+        else:
+            upl = ("monitor_port = /dev/ttyUSB0\nupload_port = /dev/ttyUSB0\n"
+                   "upload_protocol = esptool")
+        return (
+            f"[env:{name}]\n"
+            "platform = espressif32\n"
+            "board = nodemcu-32s\n"
+            "board_build.f_flash = 80000000L\n"
+            "board_build.flash_mode = qio\n"
+            "board_build.partitions = min_spiffs.csv\n"
+            f"monitor_speed = {monitor_baud}\n"
+            f"{upl}\n"
+            f"{distro_line}{wifi_transport_line}lib_deps =\n"
+            "    ${env.lib_deps}\n"
+            "    madhephaestus/ESP32Servo\n"
+            "    madhephaestus/ESP32Encoder\n"
+            "build_flags =\n"
+            "    -I ../config\n"
+            "    -D __PGMSPACE_H_\n"
+            f"    -D {cfg_macro}{wifi_flag}\n"
+        )
+
+    if mcu in ("ESP32S3", "ESP32S2"):
+        board = "esp32-s3-devkitc-1" if mcu == "ESP32S3" else "esp32-s2-saola-1"
+        is_bridge = str(spec.get("serial_interface", "CDC")) == "BRIDGE"
+        port = "/dev/ttyUSB0" if is_bridge else "/dev/ttyACM0"
+        cdc_flag = "" if is_bridge else "\n    -D ARDUINO_USB_CDC_ON_BOOT"
+        flash_lines = ("board_build.f_flash = 80000000L\nboard_build.flash_mode = qio\n"
+                       if mcu == "ESP32S3" else "")
+        return (
+            f"[env:{name}]\n"
+            "platform = espressif32\n"
+            f"board = {board}\n"
+            f"{flash_lines}"
+            f"monitor_speed = {monitor_baud}\n"
+            f"monitor_port = {port}\n"
+            f"upload_port = {port}\n"
+            "upload_protocol = esptool\n"
+            f"{distro_line}{wifi_transport_line}lib_deps =\n"
+            "    ${env.lib_deps}\n"
+            "    madhephaestus/ESP32Servo\n"
+            "    madhephaestus/ESP32Encoder\n"
+            "build_flags =\n"
+            f"    -I ../config{cdc_flag}\n"
+            "    -D __PGMSPACE_H_\n"
+            f"    -D {cfg_macro}{wifi_flag}\n"
+        )
+
+    return ""
+
+
+def generate_wifi_config(spec: Dict[str, Any]) -> str:
+    """Contents of the git-ignored config/custom/wifi_config.h — WiFi credentials
+    and host IPs only. Returns "" when the spec has no real WiFi SSID.
+    Mirrors the Web UI's generateWifiConfig()."""
+    wifi = spec.get("wifi_settings", {}) or {}
+    adv = spec.get("advanced", {}) or {}
+    tele = spec.get("telemetry", {}) or {}
+    ssid = str(wifi.get("ssid", "")).strip()
+    if not ssid or ssid == "YOUR_WIFI_SSID":
+        return ""
+    transport = str(spec.get("transport", "") or tele.get("transport", "")).upper()
+    is_wifi_transport = "WIFI" in transport or "UDP" in transport
+    if not (is_wifi_transport or tele.get("use_syslog") or tele.get("use_arduino_ota")
+            or tele.get("use_lidar_udp") or spec.get("enable_ota_syslog")):
+        return ""
+    password = wifi.get("password", "") or ""
+    agent_ip = adv.get("agent_ip") or wifi.get("agent_ip") or "192.168.1.100"
+    out = [
+        "// config/custom/wifi_config.h  --  generated by the Robot Configuration Engine",
+        "// GIT-IGNORED: your WiFi credentials and host IPs are never committed.",
+        "// Delete this file to let the studio regenerate it, or edit it by hand.",
+        "",
+        f'#define WIFI_AP_LIST {{ {{ "{ssid}", "{password}" }}, {{ NULL, NULL }} }}',
+    ]
+    if is_wifi_transport:
+        out.append(f"#define AGENT_IP {_ipv4_c(agent_ip)}")
+    out.append(f"#define SYSLOG_SERVER {_ipv4_c(adv.get('syslog_ip') or agent_ip)}")
+    if tele.get("use_lidar_udp"):
+        out.append(f"#define LIDAR_SERVER {_ipv4_c(adv.get('lidar_ip') or agent_ip)}")
+    if adv.get("ota_password"):
+        out.append(f'#define OTA_PASSWORD "{adv["ota_password"]}"')
+    out.append("")
+    return "\n".join(out)
+
+
+def generate_urdf_xacro(spec: Dict[str, Any]) -> str:
+    """URDF xacro property block, mirroring the Web UI's generateUrdfXacro()."""
+    geom = spec.get("geometry", {})
+    wheel_d = geom.get("wheel_diameter", 0.08)
+    wheel_r = wheel_d / 2.0
+    track_w = geom.get("track_width", 0.22)
+    wheel_pos_y = track_w / 2.0
+    return (
+        '<?xml version="1.0"?>\n'
+        '<robot xmlns:xacro="http://ros.org/wiki/xacro">\n'
+        f'  <xacro:property name="wheel_radius" value="{wheel_r:.4f}" />\n'
+        '  <xacro:property name="wheel_width" value="0.026" />\n'
+        '  <xacro:property name="wheel_pos_x" value="0.0" />\n'
+        f'  <xacro:property name="wheel_pos_y" value="{wheel_pos_y:.4f}" />\n'
+        '  <xacro:property name="wheel_pos_z" value="-0.010" />\n'
+        '  <xacro:property name="wheel_mass" value="0.05" />\n'
+        f'  <xacro:property name="base_length" value="{track_w * 1.2:.3f}" />\n'
+        f'  <xacro:property name="base_width" value="{track_w * 0.9:.3f}" />\n'
+        '  <xacro:property name="base_height" value="0.070" />\n'
+        '  <xacro:property name="base_mass" value="1.2" />\n'
+        '\n'
+        '  <xacro:property name="laser_pose">\n'
+        '    <origin xyz="0.05 0 0.08" rpy="0 0 0"/>\n'
+        '  </xacro:property>\n'
+        '</robot>\n'
+    )

--- a/tools/robot_config_engine/parser.py
+++ b/tools/robot_config_engine/parser.py
@@ -61,12 +61,27 @@ def _define_num(text: str, macro: str):
 
 def _define_triple(text: str, macro: str):
     """Extract `#define MACRO { a, b, c }` as a list of 3 numbers, or None."""
+    return _define_vec(text, macro, 3)
+
+
+_COV_NUM = r'[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?'
+
+
+def _define_vec(text: str, macro: str, n: int):
+    """Extract `#define MACRO { v1, ..., vn }` as a list of n numbers, or None.
+    Accepts decimals and scientific notation (e.g. 1e-12)."""
     m = re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\s*\{{\s*'
-                  r'(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\}',
+                  + r'\s*,\s*'.join([f'({_COV_NUM})'] * n) + r'\s*\}',
                   text, re.MULTILINE)
     if not m:
         return None
-    return [float(x) if "." in x else int(x) for x in m.groups()]
+    out = []
+    for x in m.groups():
+        try:
+            out.append(int(x))
+        except ValueError:
+            out.append(float(x))
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -295,10 +310,15 @@ def parse_header_to_spec(content: str) -> Dict[str, Any]:
     _mb = _define_triple(content, "MAG_BIAS")
     if _mb is not None:
         tuning["mag_bias"] = _mb
-    for _k, _m in (("accel_cov", "ACCEL_COV"), ("gyro_cov", "GYRO_COV"), ("ori_cov", "ORI_COV")):
-        _t = _define_triple(content, _m)
+    for _k, _m in (("accel_cov", "ACCEL_COV"), ("gyro_cov", "GYRO_COV"),
+                   ("ori_cov", "ORI_COV"), ("mag_cov", "MAG_COV")):
+        _t = _define_vec(content, _m, 3)
         if _t is not None:
             tuning[_k] = _t[0] if _t[0] == _t[1] == _t[2] else _t
+    for _k, _m in (("pose_cov", "POSE_COV"), ("twist_cov", "TWIST_COV")):
+        _t = _define_vec(content, _m, 6)
+        if _t is not None:
+            tuning[_k] = _t[0] if len(set(_t)) == 1 else _t
     if tuning:
         spec["imu_tuning"] = tuning
 
@@ -481,6 +501,7 @@ def parse_header_to_spec(content: str) -> Dict[str, Any]:
     for key, fn, macro in [
         ("syslog_ip",     _ipv4, "SYSLOG_SERVER"),
         ("syslog_port",   _num,  "SYSLOG_PORT"),
+        ("wifi_monitor",  _num,  "WIFI_MONITOR"),
         ("lidar_ip",      _ipv4, "LIDAR_SERVER"),
         ("lidar_port",    _num,  "LIDAR_PORT"),
         ("lidar_baudrate", _num, "LIDAR_BAUDRATE"),
@@ -515,7 +536,7 @@ def parse_header_to_spec(content: str) -> Dict[str, Any]:
     # the generator re-emits them from the spec, so keep them out of the
     # verbatim passthrough or they would double-emit / ignore a UI clear.
     modeled = {"K_P", "K_I", "K_D", "MAG_BIAS", "ACCEL_COV", "GYRO_COV",
-               "ORI_COV", "TOPIC_PREFIX"}
+               "ORI_COV", "MAG_COV", "POSE_COV", "TWIST_COV", "TOPIC_PREFIX"}
     src_lines = content.split("\n")
     raw_defines: List[Dict[str, str]] = []
     stack: List[str] = []

--- a/tools/robot_config_engine/parser.py
+++ b/tools/robot_config_engine/parser.py
@@ -246,6 +246,8 @@ def parse_header_to_spec(content: str) -> Dict[str, Any]:
         ("USE_MPU9150_IMU", "USE_MPU9150_IMU"),
         ("USE_MPU9250_IMU", "USE_MPU9250_IMU"),
         ("USE_QMI8658_IMU", "USE_QMI8658_IMU"),
+        ("USE_LSM6DSOX_IMU", "USE_LSM6DSOX_IMU"),
+        ("USE_ICM20948_IMU", "USE_ICM20948_IMU"),
         ("USE_BNO085_IMU", "USE_BNO085_IMU"),
     ]
     for macro, name in imu_map:
@@ -259,6 +261,7 @@ def parse_header_to_spec(content: str) -> Dict[str, Any]:
         ("USE_AK8963_MAG", "USE_AK8963_MAG"),
         ("USE_AK8975_MAG", "USE_AK8975_MAG"),
         ("USE_AK09918_MAG", "USE_AK09918_MAG"),
+        ("USE_ICM20948_MAG", "USE_ICM20948_MAG"),
         ("USE_QMC5883L_MAG", "USE_QMC5883L_MAG"),
     ]
     for macro, name in mag_map:
@@ -288,6 +291,14 @@ def parse_header_to_spec(content: str) -> Dict[str, Any]:
         spec["sensors"]["battery_pin"] = int(bat.group(1))
     if _define_bool(content, "USE_INA219"):
         spec["sensors"]["use_ina219"] = True
+
+    # Environmental barometer (BMP280 / BME280)
+    if _define_bool(content, "USE_BMP280"):
+        spec["sensors"]["use_bmp280"] = True
+        spec["sensors"]["env_type"] = "BMP280"
+        _ba = re.search(r'^[ \t]*#define\s+BMP280_ADDR\s+(0x[0-9A-Fa-f]+|\d+)', content, re.MULTILINE)
+        if _ba:
+            spec["sensors"]["bmp280_addr"] = _ba.group(1)
 
     for _bk, _bm in [("battery_dip", "BATTERY_DIP"), ("battery_min", "BATTERY_MIN"),
                      ("battery_max", "BATTERY_MAX"), ("battery_cap", "BATTERY_CAP")]:
@@ -319,6 +330,9 @@ def parse_header_to_spec(content: str) -> Dict[str, Any]:
         _t = _define_vec(content, _m, 6)
         if _t is not None:
             tuning[_k] = _t[0] if len(set(_t)) == 1 else _t
+    _ec = _define_vec(content, "ENV_COV", 3)
+    if _ec is not None:
+        tuning["env_cov"] = _ec[0] if _ec[0] == _ec[1] == _ec[2] else _ec
     if tuning:
         spec["imu_tuning"] = tuning
 
@@ -536,7 +550,8 @@ def parse_header_to_spec(content: str) -> Dict[str, Any]:
     # the generator re-emits them from the spec, so keep them out of the
     # verbatim passthrough or they would double-emit / ignore a UI clear.
     modeled = {"K_P", "K_I", "K_D", "MAG_BIAS", "ACCEL_COV", "GYRO_COV",
-               "ORI_COV", "MAG_COV", "POSE_COV", "TWIST_COV", "TOPIC_PREFIX"}
+               "ORI_COV", "MAG_COV", "POSE_COV", "TWIST_COV", "ENV_COV",
+               "TOPIC_PREFIX", "USE_BMP280", "BMP280_ADDR"}
     src_lines = content.split("\n")
     raw_defines: List[Dict[str, str]] = []
     stack: List[str] = []

--- a/tools/robot_config_engine/parser.py
+++ b/tools/robot_config_engine/parser.py
@@ -417,17 +417,17 @@ def parse_header_to_spec(content: str) -> Dict[str, Any]:
         mk   = f"motor{i}"
 
         if driver == "BTS7960":
-            # Waveshare GenDrv convention: PWM = pwm_r (RPWM),
-            # IN_A = pwm_l (LPWM), IN_B = en (enable/bridge)
+            # BTS7960 uses two outputs only: MOTORx_IN_A = RPWM, MOTORx_IN_B = LPWM.
+            # MOTORx_PWM is an unused placeholder in the header / driver class.
             spec["pins"][mk] = {
-                "pwm_r": pwm,
-                "pwm_l": in_a,
-                "en":    in_b,
-                # keep generic keys for compatibility
-                "pwm":  pwm,
                 "in_a": in_a,
                 "in_b": in_b,
-                "dir":  -1,
+                "pwm":  pwm,
+                # legacy keys kept for older importers
+                "pwm_l": in_a,
+                "en":    in_b,
+                "pwm_r": -1,
+                "dir":   -1,
             }
         elif driver == "GENERIC_1_IN":
             spec["pins"][mk] = {

--- a/tools/robot_config_engine/parser.py
+++ b/tools/robot_config_engine/parser.py
@@ -1,0 +1,614 @@
+# Copyright (c) 2026 Thomas Chou, Paul Bouchier, Linorobot contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import json
+from typing import Dict, Any, Tuple, List
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ifdef_block(content: str, macro: str) -> str:
+    """Return text inside the first #ifdef <macro> ... #endif block (non-nested)."""
+    pattern = rf'#ifdef\s+{re.escape(macro)}\s*\n(.*?)(?:\n[ \t]*#endif\b|\Z)'
+    m = re.search(pattern, content, re.DOTALL)
+    return m.group(1) if m else ""
+
+
+def _define_int(text: str, macro: str, default: int = -1) -> int:
+    """Extract integer value of an uncommented #define macro."""
+    m = re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\s+(-?\d+)', text, re.MULTILINE)
+    return int(m.group(1)) if m else default
+
+
+def _define_bool(text: str, macro: str) -> bool:
+    """Return True if an uncommented #define for macro exists."""
+    return bool(re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\b', text, re.MULTILINE))
+
+
+def _define_float(text: str, macro: str, default: float = 0.0) -> float:
+    m = re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\s+([\d.]+)', text, re.MULTILINE)
+    return float(m.group(1)) if m else default
+
+
+def _define_truthy(text: str, macro: str) -> bool:
+    """Return True if #define MACRO is 'true' (case-insensitive)."""
+    m = re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\s+(true|false)\b', text, re.MULTILINE | re.IGNORECASE)
+    return m.group(1).lower() == "true" if m else False
+
+
+def _define_num(text: str, macro: str):
+    """Extract a signed int/float #define value, or None if absent."""
+    m = re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\s+(-?\d+(?:\.\d+)?)', text, re.MULTILINE)
+    if not m:
+        return None
+    v = m.group(1)
+    return float(v) if "." in v else int(v)
+
+
+def _define_triple(text: str, macro: str):
+    """Extract `#define MACRO { a, b, c }` as a list of 3 numbers, or None."""
+    m = re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\s*\{{\s*'
+                  r'(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\}',
+                  text, re.MULTILINE)
+    if not m:
+        return None
+    return [float(x) if "." in x else int(x) for x in m.groups()]
+
+
+# ---------------------------------------------------------------------------
+# Main parser
+# ---------------------------------------------------------------------------
+
+def parse_header_to_spec(content: str) -> Dict[str, Any]:
+    """
+    Parses a Linorobot2 C++ configuration header file into a structured
+    dictionary spec including full pin assignments.
+    """
+    spec: Dict[str, Any] = {
+        "robot_name": "custom_robot",
+        "mcu": "PICO2",
+        "kinematics": "DIFFERENTIAL_DRIVE",
+        "geometry": {
+            "wheel_diameter": 0.065,
+            "track_width": 0.20,
+            "wheelbase": 0.15,
+            "weight": 2.5
+        },
+        "motors": {
+            "driver_type": "BTS7960",
+            "max_rpm": 300,
+            "operating_voltage": 12.0,
+            "max_voltage": 12.0,
+            "measured_voltage": 12.0,
+            "pwm_bits": 10,
+            "pwm_frequency": 20000,
+            "cpr": 1320,
+            "motor1_inv": False,
+            "motor2_inv": True,
+            "motor3_inv": False,
+            "motor4_inv": True
+        },
+        "sensors": {
+            "imu_type": "USE_FAKE_IMU",
+            "mag_type": "USE_FAKE_MAG",
+            "battery_pin": -1,
+            "battery_divider_r1": 10000,
+            "battery_divider_r2": 1000,
+            "battery_dip": None,
+            "battery_min": None,
+            "battery_max": None,
+            "battery_cap": None,
+            "use_ina219": False,
+            "sonar_trig": -1,
+            "sonar_echo": -1,
+            "i2c_sda": -1,
+            "i2c_scl": -1
+        },
+        "telemetry": {
+            "baudrate": 921600,
+            "transport": "SERIAL",
+            "agent_port": 8888,
+            "use_wifi": False,
+            "use_syslog": False,
+            "use_arduino_ota": False,
+            "use_lidar_udp": False,
+            "use_dual_core": False
+        },
+        "pins": {
+            "led": 13,
+            "encoders": {
+                "m1_a": 0, "m1_b": 0,
+                "m2_a": 0, "m2_b": 0,
+                "m3_a": -1, "m3_b": -1,
+                "m4_a": -1, "m4_b": -1,
+                "m1_inv": False, "m2_inv": False,
+                "m3_inv": False, "m4_inv": False
+            },
+            "motor1": {"pwm": -1, "in_a": -1, "in_b": -1, "pwm_r": -1, "pwm_l": -1, "en": -1, "dir": -1},
+            "motor2": {"pwm": -1, "in_a": -1, "in_b": -1, "pwm_r": -1, "pwm_l": -1, "en": -1, "dir": -1},
+            "motor3": {"pwm": -1, "in_a": -1, "in_b": -1, "pwm_r": -1, "pwm_l": -1, "en": -1, "dir": -1},
+            "motor4": {"pwm": -1, "in_a": -1, "in_b": -1, "pwm_r": -1, "pwm_l": -1, "en": -1, "dir": -1},
+            "i2c": {"sda": -1, "scl": -1},
+            "battery_pin": -1,
+            "sonar": {"trig": -1, "echo": -1}
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Robot Name from header guard
+    # ------------------------------------------------------------------
+    guard_match = re.search(r'#ifndef\s+([A-Za-z0-9_]+)_CONFIG_H', content)
+    if guard_match:
+        spec["robot_name"] = guard_match.group(1).lower()
+
+    # ------------------------------------------------------------------
+    # Kinematics
+    # ------------------------------------------------------------------
+    k_match = re.search(r'^[ \t]*#define\s+LINO_BASE\s+([A-Za-z0-9_]+)', content, re.MULTILINE)
+    if k_match:
+        spec["kinematics"] = k_match.group(1).strip()
+
+    # ------------------------------------------------------------------
+    # Geometry
+    # ------------------------------------------------------------------
+    wd = re.search(r'^[ \t]*#define\s+WHEEL_DIAMETER\s+([\d.]+)', content, re.MULTILINE)
+    if wd:
+        spec["geometry"]["wheel_diameter"] = float(wd.group(1))
+    tw = re.search(r'^[ \t]*#define\s+LR_WHEELS_DISTANCE\s+([\d.]+)', content, re.MULTILINE)
+    if tw:
+        spec["geometry"]["track_width"] = float(tw.group(1))
+    wb = re.search(r'^[ \t]*#define\s+FR_WHEELS_DISTANCE\s+([\d.]+)', content, re.MULTILINE)
+    if wb:
+        spec["geometry"]["wheelbase"] = float(wb.group(1))
+    wt = re.search(r'^[ \t]*#define\s+ROBOT_WEIGHT\s+([\d.]+)', content, re.MULTILINE)
+    if wt:
+        spec["geometry"]["weight"] = float(wt.group(1))
+
+    # ------------------------------------------------------------------
+    # Motor Driver
+    # ------------------------------------------------------------------
+    if _define_bool(content, "USE_BTS7960_MOTOR_DRIVER"):
+        spec["motors"]["driver_type"] = "BTS7960"
+    elif _define_bool(content, "USE_GENERIC_1_IN_MOTOR_DRIVER"):
+        spec["motors"]["driver_type"] = "GENERIC_1_IN"
+    elif _define_bool(content, "USE_GENERIC_2_IN_MOTOR_DRIVER"):
+        spec["motors"]["driver_type"] = "GENERIC_2_IN"
+    elif _define_bool(content, "USE_ESC_MOTOR_DRIVER"):
+        spec["motors"]["driver_type"] = "ESC"
+
+    # ------------------------------------------------------------------
+    # Motor Parameters
+    # ------------------------------------------------------------------
+    m = re.search(r'^[ \t]*#define\s+MOTOR_MAX_RPM\s+(\d+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["max_rpm"] = int(m.group(1))
+    m = re.search(r'^[ \t]*#define\s+MOTOR_OPERATING_VOLTAGE\s+([\d.]+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["operating_voltage"] = float(m.group(1))
+    m = re.search(r'^[ \t]*#define\s+MOTOR_POWER_MAX_VOLTAGE\s+([\d.]+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["max_voltage"] = float(m.group(1))
+    m = re.search(r'^[ \t]*#define\s+MOTOR_POWER_MEASURED_VOLTAGE\s+([\d.]+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["measured_voltage"] = float(m.group(1))
+    m = re.search(r'^[ \t]*#define\s+COUNTS_PER_REV1\s+(\d+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["cpr"] = int(m.group(1))
+    m = re.search(r'^[ \t]*#define\s+PWM_BITS\s+(\d+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["pwm_bits"] = int(m.group(1))
+    m = re.search(r'^[ \t]*#define\s+PWM_FREQUENCY\s+(\d+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["pwm_frequency"] = int(m.group(1))
+
+    # Motor direction invert flags
+    for i in range(1, 5):
+        inv = re.search(rf'^[ \t]*#define\s+MOTOR{i}_INV\s+(true|false)', content, re.MULTILINE | re.IGNORECASE)
+        if inv:
+            spec["motors"][f"motor{i}_inv"] = (inv.group(1).lower() == "true")
+
+    # ------------------------------------------------------------------
+    # IMU / Mag selection
+    # ------------------------------------------------------------------
+    imu_map = [
+        ("USE_FAKE_IMU", "USE_FAKE_IMU"),
+        ("USE_GY85_IMU", "USE_GY85_IMU"),
+        ("USE_MPU6050_IMU", "USE_MPU6050_IMU"),
+        ("USE_MPU9150_IMU", "USE_MPU9150_IMU"),
+        ("USE_MPU9250_IMU", "USE_MPU9250_IMU"),
+        ("USE_QMI8658_IMU", "USE_QMI8658_IMU"),
+        ("USE_BNO085_IMU", "USE_BNO085_IMU"),
+    ]
+    for macro, name in imu_map:
+        if _define_bool(content, macro):
+            spec["sensors"]["imu_type"] = name
+            break
+
+    mag_map = [
+        ("USE_FAKE_MAG", "USE_FAKE_MAG"),
+        ("USE_HMC5883L_MAG", "USE_HMC5883L_MAG"),
+        ("USE_AK8963_MAG", "USE_AK8963_MAG"),
+        ("USE_AK8975_MAG", "USE_AK8975_MAG"),
+        ("USE_AK09918_MAG", "USE_AK09918_MAG"),
+        ("USE_QMC5883L_MAG", "USE_QMC5883L_MAG"),
+    ]
+    for macro, name in mag_map:
+        if _define_bool(content, macro):
+            spec["sensors"]["mag_type"] = name
+            break
+
+    # ------------------------------------------------------------------
+    # Sensors: Sonar, I2C, Battery
+    # ------------------------------------------------------------------
+    trig = re.search(r'^[ \t]*#define\s+TRIG_PIN\s+(\d+)', content, re.MULTILINE)
+    echo = re.search(r'^[ \t]*#define\s+ECHO_PIN\s+(\d+)', content, re.MULTILINE)
+    if trig:
+        spec["sensors"]["sonar_trig"] = int(trig.group(1))
+    if echo:
+        spec["sensors"]["sonar_echo"] = int(echo.group(1))
+
+    sda = re.search(r'^[ \t]*#define\s+SDA_PIN\s+(\d+)', content, re.MULTILINE)
+    scl = re.search(r'^[ \t]*#define\s+SCL_PIN\s+(\d+)', content, re.MULTILINE)
+    if sda:
+        spec["sensors"]["i2c_sda"] = int(sda.group(1))
+    if scl:
+        spec["sensors"]["i2c_scl"] = int(scl.group(1))
+
+    bat = re.search(r'^[ \t]*#define\s+BATTERY_PIN\s+(\d+)', content, re.MULTILINE)
+    if bat:
+        spec["sensors"]["battery_pin"] = int(bat.group(1))
+    if _define_bool(content, "USE_INA219"):
+        spec["sensors"]["use_ina219"] = True
+
+    for _bk, _bm in [("battery_dip", "BATTERY_DIP"), ("battery_min", "BATTERY_MIN"),
+                     ("battery_max", "BATTERY_MAX"), ("battery_cap", "BATTERY_CAP")]:
+        _bmm = re.search(rf'^[ \t]*#define\s+{_bm}\s+([\d.]+)', content, re.MULTILINE)
+        if _bmm:
+            spec["sensors"][_bk] = float(_bmm.group(1))
+
+    # ------------------------------------------------------------------
+    # Velocity PID constants + IMU / magnetometer tuning
+    # ------------------------------------------------------------------
+    pid = {}
+    for _k, _m in (("kp", "K_P"), ("ki", "K_I"), ("kd", "K_D")):
+        _v = _define_num(content, _m)
+        if _v is not None:
+            pid[_k] = _v
+    if pid:
+        spec["pid"] = pid
+
+    tuning: Dict[str, Any] = {}
+    _mb = _define_triple(content, "MAG_BIAS")
+    if _mb is not None:
+        tuning["mag_bias"] = _mb
+    for _k, _m in (("accel_cov", "ACCEL_COV"), ("gyro_cov", "GYRO_COV"), ("ori_cov", "ORI_COV")):
+        _t = _define_triple(content, _m)
+        if _t is not None:
+            tuning[_k] = _t[0] if _t[0] == _t[1] == _t[2] else _t
+    if tuning:
+        spec["imu_tuning"] = tuning
+
+    # ------------------------------------------------------------------
+    # Telemetry / Transport
+    # ------------------------------------------------------------------
+    baud = re.search(r'^[ \t]*#define\s+BAUDRATE\s+(\d+)', content, re.MULTILINE)
+    if baud:
+        spec["telemetry"]["baudrate"] = int(baud.group(1))
+
+    if _define_bool(content, "USE_WIFI"):
+        spec["telemetry"]["use_wifi"] = True
+        spec["telemetry"]["transport"] = "WIFI_UDP"
+    _wifi_on = spec["telemetry"]["use_wifi"]
+    if _wifi_on and _define_bool(content, "USE_SYSLOG"):
+        spec["telemetry"]["use_syslog"] = True
+    if _wifi_on and _define_bool(content, "USE_ARDUINO_OTA"):
+        spec["telemetry"]["use_arduino_ota"] = True
+    if _define_bool(content, "USE_LIDAR_UDP"):
+        spec["telemetry"]["use_lidar_udp"] = True
+    if _define_bool(content, "USE_DUAL_CORE"):
+        spec["telemetry"]["use_dual_core"] = True
+
+    # ------------------------------------------------------------------
+    # MCU Family detection — the header-guard name is authoritative
+    # (a mere comment mentioning "ESP32" must not flip a pico_config.h).
+    # ------------------------------------------------------------------
+    guard = (guard_match.group(1).upper() if guard_match else "")
+    cu = content.upper()
+
+    def _mcu_from(text):
+        if "ESP32_S3" in text or "ESP32S3" in text:
+            return "ESP32S3"
+        if "ESP32_S2" in text or "ESP32S2" in text:
+            return "ESP32S2"
+        if "GENDRV" in text or "WAVESHARE" in text:
+            return "GENDRV"
+        if "ESP32" in text:
+            return "ESP32"
+        if "PICO2W" in text:
+            return "PICO2W"
+        if "PICO2" in text or "RP2350" in text:
+            return "PICO2"
+        if "PICOW" in text:
+            return "PICOW"
+        if "PICO" in text or "RP2040" in text:
+            return "PICO"
+        return None
+
+    spec["mcu"] = _mcu_from(guard) or _mcu_from(cu) or spec["mcu"]
+
+    # ------------------------------------------------------------------
+    # Pins: LED
+    # ------------------------------------------------------------------
+    led = re.search(r'^[ \t]*#define\s+LED_PIN\s+(\S+)', content, re.MULTILINE)
+    if led:
+        raw = led.group(1).strip()
+        # Integer pin number (allowing -1 = "no connection / no addressable
+        # LED" — see firmware ledInit/ledWrite helpers). Anything else is
+        # treated as a symbolic alias (e.g. LED_BUILTIN).
+        if re.fullmatch(r'-?\d+', raw):
+            spec["pins"]["led"] = int(raw)
+        else:
+            spec["pins"]["led"] = raw  # e.g. LED_BUILTIN
+
+    # ------------------------------------------------------------------
+    # Pins: Encoder A/B (these are outside any #ifdef block)
+    # ------------------------------------------------------------------
+    enc = spec["pins"]["encoders"]
+    for i, key_a, key_b in [
+        (1, "m1_a", "m1_b"),
+        (2, "m2_a", "m2_b"),
+        (3, "m3_a", "m3_b"),
+        (4, "m4_a", "m4_b"),
+    ]:
+        a = re.search(rf'^[ \t]*#define\s+MOTOR{i}_ENCODER_A\s+(-?\d+)', content, re.MULTILINE)
+        b = re.search(rf'^[ \t]*#define\s+MOTOR{i}_ENCODER_B\s+(-?\d+)', content, re.MULTILINE)
+        if a:
+            enc[key_a] = int(a.group(1))
+        if b:
+            enc[key_b] = int(b.group(1))
+
+    # ------------------------------------------------------------------
+    # Pins: Encoder invert flags
+    # ------------------------------------------------------------------
+    for i, key in [(1, "m1_inv"), (2, "m2_inv"), (3, "m3_inv"), (4, "m4_inv")]:
+        inv = re.search(
+            rf'^[ \t]*#define\s+MOTOR{i}_ENCODER_INV\s+(true|false)',
+            content, re.MULTILINE | re.IGNORECASE
+        )
+        if inv:
+            enc[key] = (inv.group(1).lower() == "true")
+
+    # ------------------------------------------------------------------
+    # Pins: Motor driver pins — parse the active #ifdef block
+    # ------------------------------------------------------------------
+    driver = spec["motors"]["driver_type"]
+
+    driver_macro_map = {
+        "BTS7960":    "USE_BTS7960_MOTOR_DRIVER",
+        "GENERIC_2_IN": "USE_GENERIC_2_IN_MOTOR_DRIVER",
+        "GENERIC_1_IN": "USE_GENERIC_1_IN_MOTOR_DRIVER",
+        "ESC":        "USE_ESC_MOTOR_DRIVER",
+    }
+    block_macro = driver_macro_map.get(driver, "USE_GENERIC_2_IN_MOTOR_DRIVER")
+    drv_block = _ifdef_block(content, block_macro)
+
+    # If the block is empty (possible when the main file uses a flat structure
+    # without #ifdef guards), fall back to the whole content
+    search_in = drv_block if drv_block.strip() else content
+
+    for i in range(1, 5):
+        pwm  = _define_int(search_in, f"MOTOR{i}_PWM")
+        in_a = _define_int(search_in, f"MOTOR{i}_IN_A")
+        in_b = _define_int(search_in, f"MOTOR{i}_IN_B")
+        mk   = f"motor{i}"
+
+        if driver == "BTS7960":
+            # Waveshare GenDrv convention: PWM = pwm_r (RPWM),
+            # IN_A = pwm_l (LPWM), IN_B = en (enable/bridge)
+            spec["pins"][mk] = {
+                "pwm_r": pwm,
+                "pwm_l": in_a,
+                "en":    in_b,
+                # keep generic keys for compatibility
+                "pwm":  pwm,
+                "in_a": in_a,
+                "in_b": in_b,
+                "dir":  -1,
+            }
+        elif driver == "GENERIC_1_IN":
+            spec["pins"][mk] = {
+                "pwm":   pwm,
+                "dir":   in_a,
+                "in_a":  in_a,
+                "in_b":  -1,
+                "pwm_r": -1, "pwm_l": -1, "en": -1,
+            }
+        elif driver == "ESC":
+            spec["pins"][mk] = {
+                "pwm":   pwm,
+                "in_a":  -1, "in_b": -1, "dir": -1,
+                "pwm_r": -1, "pwm_l": -1, "en":  -1,
+            }
+        else:  # GENERIC_2_IN (default)
+            spec["pins"][mk] = {
+                "pwm":   pwm,
+                "in_a":  in_a,
+                "in_b":  in_b,
+                "dir":   -1,
+                "pwm_r": -1, "pwm_l": -1, "en": -1,
+            }
+
+    # ------------------------------------------------------------------
+    # Pins: I2C, Battery, Sonar — mirror into pins sub-section
+    # ------------------------------------------------------------------
+    spec["pins"]["i2c"]["sda"] = spec["sensors"]["i2c_sda"]
+    spec["pins"]["i2c"]["scl"] = spec["sensors"]["i2c_scl"]
+    spec["pins"]["battery_pin"] = spec["sensors"]["battery_pin"]
+    spec["pins"]["sonar"]["trig"] = spec["sensors"]["sonar_trig"]
+    spec["pins"]["sonar"]["echo"] = spec["sensors"]["sonar_echo"]
+
+    # ------------------------------------------------------------------
+    # Modeled advanced telemetry values (editable in the Web UI, so they
+    # must round-trip through the spec, not the verbatim passthrough).
+    # ------------------------------------------------------------------
+    adv = spec.setdefault("advanced", {})
+
+    def _ipv4(macro: str):
+        mm = re.search(rf'^[ \t]*#define\s+{macro}\s*\{{\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\}}',
+                       content, re.MULTILINE)
+        return ".".join(mm.groups()) if mm else None
+    def _num(macro: str):
+        mm = re.search(rf'^[ \t]*#define\s+{macro}\s+(\d+)', content, re.MULTILINE)
+        return int(mm.group(1)) if mm else None
+    def _str(macro: str):
+        mm = re.search(rf'^[ \t]*#define\s+{macro}\s+"([^"]*)"', content, re.MULTILINE)
+        return mm.group(1) if mm else None
+
+    for key, fn, macro in [
+        ("syslog_ip",     _ipv4, "SYSLOG_SERVER"),
+        ("syslog_port",   _num,  "SYSLOG_PORT"),
+        ("lidar_ip",      _ipv4, "LIDAR_SERVER"),
+        ("lidar_port",    _num,  "LIDAR_PORT"),
+        ("lidar_baudrate", _num, "LIDAR_BAUDRATE"),
+        ("lidar_rxd",     _num,  "LIDAR_RXD"),
+        ("lidar_serial",  _num,  "LIDAR_SERIAL"),
+        ("agent_ip",      _ipv4, "AGENT_IP"),
+        ("ota_hostname",  _str,  "OTA_HOSTNAME"),
+        ("ota_password",  _str,  "OTA_PASSWORD"),
+        ("topic_prefix",  _str,  "TOPIC_PREFIX"),
+    ]:
+        v = fn(macro)
+        if v is not None:
+            adv[key] = v
+    if _define_bool(content, "USE_SHORT_BRAKE"):
+        adv["use_short_brake"] = True
+
+    # ------------------------------------------------------------------
+    # Verbatim passthrough of every other uncommented #define, so an
+    # imported header round-trips without silently dropping anything
+    # (covariances, RCCHECK, board hooks, LIDAR_* the UI does not model…).
+    # The generator re-emits these only if it did not already produce a
+    # #define of the same name.
+    # ------------------------------------------------------------------
+    # A #define is "unconditional" if every preprocessor guard enclosing it is
+    # benign — the header guard, an `#if __has_include(...)` wifi_config probe,
+    # or `#ifndef BAUDRATE`. Anything guarded by a feature macro we model
+    # (USE_WIFI, USE_SYSLOG, USE_*_MOTOR_DRIVER, USE_LIDAR_UDP, …) is logic we
+    # regenerate ourselves and must NOT hoist to the top level.
+    guard_name = f"{spec['robot_name'].upper()}_CONFIG_H"
+    benign = {guard_name, "BAUDRATE"}
+    # Macros now captured into the structured spec above (editable in the UI);
+    # the generator re-emits them from the spec, so keep them out of the
+    # verbatim passthrough or they would double-emit / ignore a UI clear.
+    modeled = {"K_P", "K_I", "K_D", "MAG_BIAS", "ACCEL_COV", "GYRO_COV",
+               "ORI_COV", "TOPIC_PREFIX"}
+    src_lines = content.split("\n")
+    raw_defines: List[Dict[str, str]] = []
+    stack: List[str] = []
+    i = 0
+    while i < len(src_lines):
+        ln = src_lines[i]
+        bare = ln.strip()
+        mif = re.match(r'#if(n?def)?\b(.*)', bare)
+        if mif:
+            rest = mif.group(2)
+            if "__has_include" in rest:
+                stack.append("__has_include")
+            else:
+                tok = re.search(r'([A-Za-z_]\w*)', rest)
+                stack.append(tok.group(1) if tok else "?")
+        elif bare.startswith("#endif"):
+            if stack:
+                stack.pop()
+        elif re.match(r'^[ \t]*#define[ \t]', ln) and all(
+                g in benign or g == "__has_include" for g in stack):
+            nm = re.match(r'^[ \t]*#define[ \t]+([A-Za-z_]\w*)', ln)
+            block = [ln]
+            while block[-1].rstrip().endswith("\\") and i + 1 < len(src_lines):
+                i += 1
+                block.append(src_lines[i])
+            if nm and nm.group(1) not in modeled:
+                raw_defines.append({"name": nm.group(1), "text": "\n".join(block).rstrip()})
+        i += 1
+    spec["raw_defines"] = raw_defines
+
+    return spec
+
+
+def merge_wifi_config(spec: Dict[str, Any], wifi_content: str) -> Dict[str, Any]:
+    """Fold the git-ignored config/custom/wifi_config.h into a parsed spec so
+    the Web UI form shows the real SSID / password / host IPs. Mutates & returns
+    `spec`. Safe to call with an empty string (no-op)."""
+    if not wifi_content:
+        return spec
+    ap = re.search(r'#define\s+WIFI_AP_LIST\s*\{\s*\{\s*"([^"]*)"\s*,\s*"([^"]*)"',
+                   wifi_content)
+    ssid_m = re.search(r'#define\s+WIFI_SSID\s+"([^"]*)"', wifi_content)
+    pw_m = re.search(r'#define\s+WIFI_PASSWORD\s+"([^"]*)"', wifi_content)
+    ssid = ap.group(1) if ap else (ssid_m.group(1) if ssid_m else "")
+    password = ap.group(2) if ap else (pw_m.group(1) if pw_m else "")
+    if not ssid:
+        return spec
+
+    def _ip(macro):
+        mm = re.search(rf'#define\s+{macro}\s*\{{\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\}}',
+                       wifi_content)
+        return ".".join(mm.groups()) if mm else None
+
+    ws = spec.setdefault("wifi_settings", {})
+    ws["ssid"] = ssid
+    ws["password"] = password
+    adv = spec.setdefault("advanced", {})
+    agent_ip = _ip("AGENT_IP")
+    if agent_ip:
+        adv["agent_ip"] = agent_ip
+        ws["agent_ip"] = agent_ip
+    syslog_ip = _ip("SYSLOG_SERVER")
+    if syslog_ip:
+        adv["syslog_ip"] = syslog_ip
+    lidar_ip = _ip("LIDAR_SERVER")
+    if lidar_ip:
+        adv["lidar_ip"] = lidar_ip
+    ota_pw = re.search(r'#define\s+OTA_PASSWORD\s+"([^"]*)"', wifi_content)
+    if ota_pw:
+        adv["ota_password"] = ota_pw.group(1)
+    # Present a real SSID -> the studio should show the WiFi block.
+    spec["enable_ota_syslog"] = True
+    return spec
+
+
+def merge_configurations(base_spec: Dict[str, Any], override_spec: Dict[str, Any]) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """
+    Deep-merges an override specification into an existing base specification.
+    Returns (merged_spec, list_of_changes).
+    """
+    merged = json.loads(json.dumps(base_spec))  # Deep copy
+    changes = []
+
+    def deep_merge(target, source, prefix=""):
+        for k, v in source.items():
+            field_name = f"{prefix}.{k}" if prefix else k
+            if isinstance(v, dict) and k in target and isinstance(target[k], dict):
+                deep_merge(target[k], v, field_name)
+            else:
+                old_val = target.get(k)
+                if old_val != v:
+                    changes.append({"field": field_name, "old": old_val, "new": v})
+                    target[k] = v
+
+    deep_merge(merged, override_spec)
+    return merged, changes

--- a/tools/robot_config_engine/parser.py
+++ b/tools/robot_config_engine/parser.py
@@ -1,0 +1,766 @@
+# Copyright (c) 2026 Thomas Chou, Paul Bouchier, Linorobot contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import json
+from typing import Dict, Any, Tuple, List
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ifdef_block(content: str, macro: str) -> str:
+    """Return text inside the first #ifdef <macro> ... #endif block (non-nested)."""
+    pattern = rf'#ifdef\s+{re.escape(macro)}\s*\n(.*?)(?:\n[ \t]*#endif\b|\Z)'
+    m = re.search(pattern, content, re.DOTALL)
+    return m.group(1) if m else ""
+
+
+def _define_int(text: str, macro: str, default: int = -1) -> int:
+    """Extract integer value of an uncommented #define macro."""
+    m = re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\s+(-?\d+)', text, re.MULTILINE)
+    return int(m.group(1)) if m else default
+
+
+def _define_bool(text: str, macro: str) -> bool:
+    """Return True if an uncommented #define for macro exists."""
+    return bool(re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\b', text, re.MULTILINE))
+
+
+def _define_float(text: str, macro: str, default: float = 0.0) -> float:
+    m = re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\s+([\d.]+)', text, re.MULTILINE)
+    return float(m.group(1)) if m else default
+
+
+def _define_truthy(text: str, macro: str) -> bool:
+    """Return True if #define MACRO is 'true' (case-insensitive)."""
+    m = re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\s+(true|false)\b', text, re.MULTILINE | re.IGNORECASE)
+    return m.group(1).lower() == "true" if m else False
+
+
+def _define_num(text: str, macro: str):
+    """Extract a signed int/float #define value, or None if absent."""
+    m = re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\s+(-?\d+(?:\.\d+)?)', text, re.MULTILINE)
+    if not m:
+        return None
+    v = m.group(1)
+    return float(v) if "." in v else int(v)
+
+
+def _define_triple(text: str, macro: str):
+    """Extract `#define MACRO { a, b, c }` as a list of 3 numbers, or None."""
+    return _define_vec(text, macro, 3)
+
+
+_COV_NUM = r'[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?'
+
+
+def _define_vec(text: str, macro: str, n: int):
+    """Extract `#define MACRO { v1, ..., vn }` as a list of n numbers, or None.
+    Accepts decimals and scientific notation (e.g. 1e-12)."""
+    m = re.search(rf'^[ \t]*#define\s+{re.escape(macro)}\s*\{{\s*'
+                  + r'\s*,\s*'.join([f'({_COV_NUM})'] * n) + r'\s*\}',
+                  text, re.MULTILINE)
+    if not m:
+        return None
+    out = []
+    for x in m.groups():
+        try:
+            out.append(int(x))
+        except ValueError:
+            out.append(float(x))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Main parser
+# ---------------------------------------------------------------------------
+
+def parse_header_to_spec(content: str) -> Dict[str, Any]:
+    """
+    Parses a Linorobot2 C++ configuration header file into a structured
+    dictionary spec including full pin assignments.
+    """
+    spec: Dict[str, Any] = {
+        "robot_name": "custom_robot",
+        "mcu": "PICO2",
+        "kinematics": "DIFFERENTIAL_DRIVE",
+        "geometry": {
+            "wheel_diameter": 0.065,
+            "track_width": 0.20,
+            "wheelbase": 0.15,
+            "weight": 2.5
+        },
+        "motors": {
+            "driver_type": "BTS7960",
+            "max_rpm": 300,
+            "operating_voltage": 12.0,
+            "max_voltage": 12.0,
+            "measured_voltage": 12.0,
+            "pwm_bits": 10,
+            "pwm_frequency": 20000,
+            "cpr": 1320,
+            "motor1_inv": False,
+            "motor2_inv": True,
+            "motor3_inv": False,
+            "motor4_inv": True
+        },
+        "sensors": {
+            "imu_type": "USE_FAKE_IMU",
+            "mag_type": "USE_FAKE_MAG",
+            "battery_pin": -1,
+            # Same key names generator.py's web-UI/overlay spec shape uses
+            # (battery_r1/r2, battery_*_voltage, battery_capacity) — a base
+            # spec parsed from disk and an overlay from the form MUST agree
+            # on field names, or merge_configurations()'s deep-merge creates
+            # a second, differently-named copy instead of overwriting the
+            # one that's actually read, and the overlay's value is silently
+            # ignored. Defaults match generator.py's own fallbacks so an
+            # untouched field behaves the same whether the spec came from a
+            # freshly parsed header or a fresh form.
+            "battery_r1": 30000.0,
+            "battery_r2": 7500.0,
+            "battery_dip": None,
+            "battery_min_voltage": None,
+            "battery_max_voltage": None,
+            "battery_capacity": None,
+            "use_ina219": False,
+            "sonar_trig": -1,
+            "sonar_echo": -1,
+            "i2c_sda": -1,
+            "i2c_scl": -1
+        },
+        "telemetry": {
+            "baudrate": 921600,
+            "transport": "SERIAL",
+            "agent_port": 8888,
+            "use_wifi": False,
+            "use_syslog": False,
+            "use_arduino_ota": False,
+            "use_lidar_udp": False,
+            "use_dual_core": False
+        },
+        "pins": {
+            "led": 13,
+            "encoders": {
+                "m1_a": 0, "m1_b": 0,
+                "m2_a": 0, "m2_b": 0,
+                "m3_a": -1, "m3_b": -1,
+                "m4_a": -1, "m4_b": -1,
+                "m1_inv": False, "m2_inv": False,
+                "m3_inv": False, "m4_inv": False
+            },
+            "motor1": {"pwm": -1, "in_a": -1, "in_b": -1, "pwm_r": -1, "pwm_l": -1, "en": -1, "dir": -1},
+            "motor2": {"pwm": -1, "in_a": -1, "in_b": -1, "pwm_r": -1, "pwm_l": -1, "en": -1, "dir": -1},
+            "motor3": {"pwm": -1, "in_a": -1, "in_b": -1, "pwm_r": -1, "pwm_l": -1, "en": -1, "dir": -1},
+            "motor4": {"pwm": -1, "in_a": -1, "in_b": -1, "pwm_r": -1, "pwm_l": -1, "en": -1, "dir": -1},
+            "i2c": {"sda": -1, "scl": -1},
+            "battery_pin": -1,
+            "sonar": {"trig": -1, "echo": -1}
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Robot Name from header guard
+    # ------------------------------------------------------------------
+    guard_match = re.search(r'#ifndef\s+([A-Za-z0-9_]+)_CONFIG_H', content)
+    if guard_match:
+        spec["robot_name"] = guard_match.group(1).lower()
+
+    # ------------------------------------------------------------------
+    # Kinematics
+    # ------------------------------------------------------------------
+    k_match = re.search(r'^[ \t]*#define\s+LINO_BASE\s+([A-Za-z0-9_]+)', content, re.MULTILINE)
+    if k_match:
+        spec["kinematics"] = k_match.group(1).strip()
+
+    # ------------------------------------------------------------------
+    # Geometry
+    # ------------------------------------------------------------------
+    wd = re.search(r'^[ \t]*#define\s+WHEEL_DIAMETER\s+([\d.]+)', content, re.MULTILINE)
+    if wd:
+        spec["geometry"]["wheel_diameter"] = float(wd.group(1))
+    tw = re.search(r'^[ \t]*#define\s+LR_WHEELS_DISTANCE\s+([\d.]+)', content, re.MULTILINE)
+    if tw:
+        spec["geometry"]["track_width"] = float(tw.group(1))
+    wb = re.search(r'^[ \t]*#define\s+FR_WHEELS_DISTANCE\s+([\d.]+)', content, re.MULTILINE)
+    if wb:
+        spec["geometry"]["wheelbase"] = float(wb.group(1))
+    wt = re.search(r'^[ \t]*#define\s+ROBOT_WEIGHT\s+([\d.]+)', content, re.MULTILINE)
+    if wt:
+        spec["geometry"]["weight"] = float(wt.group(1))
+
+    # ------------------------------------------------------------------
+    # Simulation Mode (Fake Wheel & Fake LD19)
+    # ------------------------------------------------------------------
+    if re.search(r'^[ 	]*#define\s+USE_FAKE_WHEEL', content, re.MULTILINE):
+        spec.setdefault("simulation", {})["fake_wheel"] = True
+        m = re.search(r'^[ 	]*#define\s+FAKE_ROBOT_MASS\s+([\d.]+)', content, re.MULTILINE)
+        if m:
+            spec["simulation"]["robot_mass"] = float(m.group(1))
+        m = re.search(r'^[ 	]*#define\s+FAKE_WHEEL_NOISE_RPM\s+([\d.]+)', content, re.MULTILINE)
+        if m:
+            spec["simulation"]["wheel_noise_rpm"] = float(m.group(1))
+
+    if re.search(r'^[ 	]*#define\s+USE_FAKE_LD19', content, re.MULTILINE):
+        spec.setdefault("simulation", {})["fake_ld19"] = True
+        m = re.search(r'^[ 	]*#define\s+FAKE_MAP_WIDTH\s+([\d.]+)', content, re.MULTILINE)
+        if m:
+            spec["simulation"]["map_width"] = float(m.group(1))
+        m = re.search(r'^[ 	]*#define\s+FAKE_MAP_HEIGHT\s+([\d.]+)', content, re.MULTILINE)
+        if m:
+            spec["simulation"]["map_height"] = float(m.group(1))
+        m = re.search(r'^[ 	]*#define\s+FAKE_WALL_OBSTACLE\s+(\d+)', content, re.MULTILINE)
+        if m:
+            spec["simulation"]["wall_obstacle"] = bool(int(m.group(1)))
+        m = re.search(r'^[ 	]*#define\s+FAKE_WALL_X1\s+([-\d.]+)', content, re.MULTILINE)
+        if m:
+            spec["simulation"]["wall_x1"] = float(m.group(1))
+        m = re.search(r'^[ 	]*#define\s+FAKE_WALL_Y1\s+([-\d.]+)', content, re.MULTILINE)
+        if m:
+            spec["simulation"]["wall_y1"] = float(m.group(1))
+        m = re.search(r'^[ 	]*#define\s+FAKE_WALL_X2\s+([-\d.]+)', content, re.MULTILINE)
+        if m:
+            spec["simulation"]["wall_x2"] = float(m.group(1))
+        m = re.search(r'^[ 	]*#define\s+FAKE_WALL_Y2\s+([-\d.]+)', content, re.MULTILINE)
+        if m:
+            spec["simulation"]["wall_y2"] = float(m.group(1))
+
+    # ------------------------------------------------------------------
+    # Motor Driver
+    # ------------------------------------------------------------------
+    if _define_bool(content, "USE_BTS7960_MOTOR_DRIVER"):
+        spec["motors"]["driver_type"] = "BTS7960"
+    elif _define_bool(content, "USE_GENERIC_1_IN_MOTOR_DRIVER"):
+        spec["motors"]["driver_type"] = "GENERIC_1_IN"
+    elif _define_bool(content, "USE_GENERIC_2_IN_MOTOR_DRIVER"):
+        spec["motors"]["driver_type"] = "GENERIC_2_IN"
+    elif _define_bool(content, "USE_ESC_MOTOR_DRIVER"):
+        spec["motors"]["driver_type"] = "ESC"
+
+    # ------------------------------------------------------------------
+    # Motor Parameters
+    # ------------------------------------------------------------------
+    m = re.search(r'^[ \t]*#define\s+MOTOR_MAX_RPM\s+(\d+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["max_rpm"] = int(m.group(1))
+    m = re.search(r'^[ \t]*#define\s+MOTOR_OPERATING_VOLTAGE\s+([\d.]+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["operating_voltage"] = float(m.group(1))
+    m = re.search(r'^[ \t]*#define\s+MOTOR_POWER_MAX_VOLTAGE\s+([\d.]+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["max_voltage"] = float(m.group(1))
+    m = re.search(r'^[ \t]*#define\s+MOTOR_POWER_MEASURED_VOLTAGE\s+([\d.]+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["measured_voltage"] = float(m.group(1))
+    m = re.search(r'^[ \t]*#define\s+COUNTS_PER_REV1\s+(\d+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["cpr"] = int(m.group(1))
+    m = re.search(r'^[ \t]*#define\s+PWM_BITS\s+(\d+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["pwm_bits"] = int(m.group(1))
+    m = re.search(r'^[ \t]*#define\s+PWM_FREQUENCY\s+(\d+)', content, re.MULTILINE)
+    if m:
+        spec["motors"]["pwm_frequency"] = int(m.group(1))
+
+    # Motor direction invert flags
+    for i in range(1, 5):
+        inv = re.search(rf'^[ \t]*#define\s+MOTOR{i}_INV\s+(true|false)', content, re.MULTILINE | re.IGNORECASE)
+        if inv:
+            spec["motors"][f"motor{i}_inv"] = (inv.group(1).lower() == "true")
+
+    # ------------------------------------------------------------------
+    # IMU / Mag selection
+    # ------------------------------------------------------------------
+    imu_map = [
+        ("USE_FAKE_IMU", "USE_FAKE_IMU"),
+        ("USE_GY85_IMU", "USE_GY85_IMU"),
+        ("USE_MPU6050_IMU", "USE_MPU6050_IMU"),
+        ("USE_MPU9150_IMU", "USE_MPU9150_IMU"),
+        ("USE_MPU9250_IMU", "USE_MPU9250_IMU"),
+        ("USE_QMI8658_IMU", "USE_QMI8658_IMU"),
+        ("USE_LSM6DSOX_IMU", "USE_LSM6DSOX_IMU"),
+        ("USE_ICM20948_IMU", "USE_ICM20948_IMU"),
+        ("USE_BNO085_IMU", "USE_BNO085_IMU"),
+    ]
+    for macro, name in imu_map:
+        if _define_bool(content, macro):
+            spec["sensors"]["imu_type"] = name
+            # Also the form-shape short name (generator.py checks this
+            # first — see its comment): "USE_QMI8658_IMU" -> "QMI8658",
+            # "USE_FAKE_IMU" -> "FAKE", matching the <option value=...> the
+            # web-UI dropdown uses, so a later merge treats imu/imu_type as
+            # the same field instead of two differently-named copies.
+            spec["sensors"]["imu"] = name.replace("USE_", "").replace("_IMU", "")
+            break
+
+    mag_map = [
+        ("USE_FAKE_MAG", "USE_FAKE_MAG"),
+        ("USE_HMC5883L_MAG", "USE_HMC5883L_MAG"),
+        ("USE_AK8963_MAG", "USE_AK8963_MAG"),
+        ("USE_AK8975_MAG", "USE_AK8975_MAG"),
+        ("USE_AK09918_MAG", "USE_AK09918_MAG"),
+        ("USE_ICM20948_MAG", "USE_ICM20948_MAG"),
+        ("USE_QMC5883L_MAG", "USE_QMC5883L_MAG"),
+    ]
+    for macro, name in mag_map:
+        if _define_bool(content, macro):
+            spec["sensors"]["mag_type"] = name
+            spec["sensors"]["mag"] = name.replace("USE_", "").replace("_MAG", "")
+            break
+
+    # ------------------------------------------------------------------
+    # Sensors: Sonar, I2C, Battery
+    # ------------------------------------------------------------------
+    trig = re.search(r'^[ \t]*#define\s+TRIG_PIN\s+(\d+)', content, re.MULTILINE)
+    echo = re.search(r'^[ \t]*#define\s+ECHO_PIN\s+(\d+)', content, re.MULTILINE)
+    if trig:
+        spec["sensors"]["sonar_trig"] = int(trig.group(1))
+    if echo:
+        spec["sensors"]["sonar_echo"] = int(echo.group(1))
+
+    sda = re.search(r'^[ \t]*#define\s+SDA_PIN\s+(\d+)', content, re.MULTILINE)
+    scl = re.search(r'^[ \t]*#define\s+SCL_PIN\s+(\d+)', content, re.MULTILINE)
+    if sda:
+        spec["sensors"]["i2c_sda"] = int(sda.group(1))
+    if scl:
+        spec["sensors"]["i2c_scl"] = int(scl.group(1))
+
+    bat = re.search(r'^[ \t]*#define\s+BATTERY_PIN\s+(\d+)', content, re.MULTILINE)
+    if bat:
+        spec["sensors"]["battery_pin"] = int(bat.group(1))
+    dacp = re.search(r'^[ \t]*#define\s+DAC_PIN\s+(\d+)', content, re.MULTILINE)
+    if dacp:
+        spec["sensors"]["dac_pin"] = int(dacp.group(1))
+    # adc_calibrate-derived 12-bit lookup table (not a #define — a plain const
+    # array — so it needs its own round-trip; otherwise a parse->merge->
+    # regenerate cycle would silently drop a previously calibrated LUT).
+    lut_m = re.search(r'const\s+int16_t\s+ADC_LUT\s*\[\s*4096\s*\]\s*=\s*\{(.*?)\}\s*;', content, re.DOTALL)
+    if lut_m:
+        lut_vals = [int(v) for v in re.findall(r'-?\d+', lut_m.group(1))]
+        if lut_vals:
+            spec["sensors"]["adc_lut"] = lut_vals
+    if _define_bool(content, "USE_INA219"):
+        spec["sensors"]["use_ina219"] = True
+        # Also set the form-shape key (see generator.py's comment on this):
+        # otherwise an overlay's battery_monitor="ADC_DIVIDER"/"NONE" can't
+        # actually override a parsed use_ina219=True (deep-merge only
+        # overwrites a key the overlay itself sets), and the reverse — this
+        # value never reaching a brand-new, un-merged spec — is the bug that
+        # prompted this comment in the first place.
+        spec["sensors"]["battery_monitor"] = "INA219"
+
+    # Environmental barometer (BMP280 / BME280)
+    if _define_bool(content, "USE_BMP280"):
+        spec["sensors"]["use_bmp280"] = True
+        spec["sensors"]["env_type"] = "BMP280"
+        _ba = re.search(r'^[ \t]*#define\s+BMP280_ADDR\s+(0x[0-9A-Fa-f]+|\d+)', content, re.MULTILINE)
+        if _ba:
+            spec["sensors"]["bmp280_addr"] = _ba.group(1)
+
+    for _bk, _bm in [("battery_dip", "BATTERY_DIP"), ("battery_min_voltage", "BATTERY_MIN"),
+                     ("battery_max_voltage", "BATTERY_MAX"), ("battery_capacity", "BATTERY_CAP")]:
+        _bmm = re.search(rf'^[ \t]*#define\s+{_bm}\s+([\d.]+)', content, re.MULTILINE)
+        if _bmm:
+            spec["sensors"][_bk] = float(_bmm.group(1))
+
+    # ------------------------------------------------------------------
+    # Velocity PID constants + IMU / magnetometer tuning
+    # ------------------------------------------------------------------
+    pid = {}
+    for _k, _m in (("kp", "K_P"), ("ki", "K_I"), ("kd", "K_D")):
+        _v = _define_num(content, _m)
+        if _v is not None:
+            pid[_k] = _v
+    if pid:
+        spec["pid"] = pid
+
+    tuning: Dict[str, Any] = {}
+    _mb = _define_triple(content, "MAG_BIAS")
+    if _mb is not None:
+        tuning["mag_bias"] = _mb
+    for _k, _m in (("accel_cov", "ACCEL_COV"), ("gyro_cov", "GYRO_COV"),
+                   ("ori_cov", "ORI_COV"), ("mag_cov", "MAG_COV")):
+        _t = _define_vec(content, _m, 3)
+        if _t is not None:
+            tuning[_k] = _t[0] if _t[0] == _t[1] == _t[2] else _t
+    for _k, _m in (("pose_cov", "POSE_COV"), ("twist_cov", "TWIST_COV")):
+        _t = _define_vec(content, _m, 6)
+        if _t is not None:
+            tuning[_k] = _t[0] if len(set(_t)) == 1 else _t
+    _ec = _define_vec(content, "ENV_COV", 3)
+    if _ec is not None:
+        tuning["env_cov"] = _ec[0] if _ec[0] == _ec[1] == _ec[2] else _ec
+    if tuning:
+        spec["imu_tuning"] = tuning
+
+    # ------------------------------------------------------------------
+    # Telemetry / Transport
+    # ------------------------------------------------------------------
+    baud = re.search(r'^[ \t]*#define\s+BAUDRATE\s+(\d+)', content, re.MULTILINE)
+    if baud:
+        spec["telemetry"]["baudrate"] = int(baud.group(1))
+
+    if _define_bool(content, "USE_WIFI"):
+        spec["telemetry"]["use_wifi"] = True
+        spec["telemetry"]["transport"] = "WIFI_UDP"
+    _wifi_on = spec["telemetry"]["use_wifi"]
+    if _wifi_on and _define_bool(content, "USE_SYSLOG"):
+        spec["telemetry"]["use_syslog"] = True
+    if _wifi_on and _define_bool(content, "USE_ARDUINO_OTA"):
+        spec["telemetry"]["use_arduino_ota"] = True
+    if _define_bool(content, "USE_LIDAR_UDP"):
+        spec["telemetry"]["use_lidar_udp"] = True
+    if _define_bool(content, "USE_DUAL_CORE"):
+        spec["telemetry"]["use_dual_core"] = True
+
+    # Simulated drivetrain. _define_bool ignores commented-out defines, which
+    # matters because lino_base_config.h ships these options commented out.
+    if _define_bool(content, "USE_FAKE_WHEEL"):
+        sim = spec.setdefault("simulation", {})
+        sim["fake_wheel"] = True
+        mass = _define_num(content, "FAKE_ROBOT_MASS")
+        if mass is not None:
+            sim["robot_mass"] = mass
+        noise = _define_num(content, "FAKE_WHEEL_NOISE_RPM")
+        if noise is not None:
+            sim["wheel_noise_rpm"] = noise
+
+    # ------------------------------------------------------------------
+    # MCU Family detection — the header-guard name is authoritative
+    # (a mere comment mentioning "ESP32" must not flip a pico_config.h).
+    # ------------------------------------------------------------------
+    guard = (guard_match.group(1).upper() if guard_match else "")
+    cu = content.upper()
+
+    def _mcu_from(text):
+        if "ESP32_S3" in text or "ESP32S3" in text:
+            return "ESP32S3"
+        if "ESP32_S2" in text or "ESP32S2" in text:
+            return "ESP32S2"
+        if "GENDRV" in text or "WAVESHARE" in text:
+            return "GENDRV"
+        if "ESP32" in text:
+            return "ESP32"
+        if "PICO2W" in text:
+            return "PICO2W"
+        if "PICO2" in text or "RP2350" in text:
+            return "PICO2"
+        if "PICOW" in text:
+            return "PICOW"
+        if "PICO" in text or "RP2040" in text:
+            return "PICO"
+        return None
+
+    spec["mcu"] = _mcu_from(guard) or _mcu_from(cu) or spec["mcu"]
+
+    # ------------------------------------------------------------------
+    # Pins: LED
+    # ------------------------------------------------------------------
+    led = re.search(r'^[ \t]*#define\s+LED_PIN\s+(\S+)', content, re.MULTILINE)
+    if led:
+        raw = led.group(1).strip()
+        # Integer pin number (allowing -1 = "no connection / no addressable
+        # LED" — see firmware ledInit/ledWrite helpers). Anything else is
+        # treated as a symbolic alias (e.g. LED_BUILTIN).
+        if re.fullmatch(r'-?\d+', raw):
+            spec["pins"]["led"] = int(raw)
+        else:
+            spec["pins"]["led"] = raw  # e.g. LED_BUILTIN
+
+    # ------------------------------------------------------------------
+    # Pins: Encoder A/B (these are outside any #ifdef block)
+    # ------------------------------------------------------------------
+    enc = spec["pins"]["encoders"]
+    for i, key_a, key_b in [
+        (1, "m1_a", "m1_b"),
+        (2, "m2_a", "m2_b"),
+        (3, "m3_a", "m3_b"),
+        (4, "m4_a", "m4_b"),
+    ]:
+        a = re.search(rf'^[ \t]*#define\s+MOTOR{i}_ENCODER_A\s+(-?\d+)', content, re.MULTILINE)
+        b = re.search(rf'^[ \t]*#define\s+MOTOR{i}_ENCODER_B\s+(-?\d+)', content, re.MULTILINE)
+        if a:
+            enc[key_a] = int(a.group(1))
+        if b:
+            enc[key_b] = int(b.group(1))
+
+    # ------------------------------------------------------------------
+    # Pins: Encoder invert flags
+    # ------------------------------------------------------------------
+    for i, key in [(1, "m1_inv"), (2, "m2_inv"), (3, "m3_inv"), (4, "m4_inv")]:
+        inv = re.search(
+            rf'^[ \t]*#define\s+MOTOR{i}_ENCODER_INV\s+(true|false)',
+            content, re.MULTILINE | re.IGNORECASE
+        )
+        if inv:
+            enc[key] = (inv.group(1).lower() == "true")
+
+    # ------------------------------------------------------------------
+    # Pins: Motor driver pins — parse the active #ifdef block
+    # ------------------------------------------------------------------
+    driver = spec["motors"]["driver_type"]
+
+    driver_macro_map = {
+        "BTS7960":    "USE_BTS7960_MOTOR_DRIVER",
+        "GENERIC_2_IN": "USE_GENERIC_2_IN_MOTOR_DRIVER",
+        "GENERIC_1_IN": "USE_GENERIC_1_IN_MOTOR_DRIVER",
+        "ESC":        "USE_ESC_MOTOR_DRIVER",
+    }
+    block_macro = driver_macro_map.get(driver, "USE_GENERIC_2_IN_MOTOR_DRIVER")
+    drv_block = _ifdef_block(content, block_macro)
+
+    # If the block is empty (possible when the main file uses a flat structure
+    # without #ifdef guards), fall back to the whole content
+    search_in = drv_block if drv_block.strip() else content
+
+    for i in range(1, 5):
+        pwm  = _define_int(search_in, f"MOTOR{i}_PWM")
+        in_a = _define_int(search_in, f"MOTOR{i}_IN_A")
+        in_b = _define_int(search_in, f"MOTOR{i}_IN_B")
+        mk   = f"motor{i}"
+
+        if driver == "BTS7960":
+            # BTS7960 uses two outputs only: MOTORx_IN_A = RPWM, MOTORx_IN_B = LPWM.
+            # MOTORx_PWM is an unused placeholder in the header / driver class.
+            spec["pins"][mk] = {
+                "in_a": in_a,
+                "in_b": in_b,
+                "pwm":  pwm,
+                # legacy keys kept for older importers
+                "pwm_l": in_a,
+                "en":    in_b,
+                "pwm_r": -1,
+                "dir":   -1,
+            }
+        elif driver == "GENERIC_1_IN":
+            spec["pins"][mk] = {
+                "pwm":   pwm,
+                "dir":   in_a,
+                "in_a":  in_a,
+                "in_b":  -1,
+                "pwm_r": -1, "pwm_l": -1, "en": -1,
+            }
+        elif driver == "ESC":
+            spec["pins"][mk] = {
+                "pwm":   pwm,
+                "in_a":  -1, "in_b": -1, "dir": -1,
+                "pwm_r": -1, "pwm_l": -1, "en":  -1,
+            }
+        else:  # GENERIC_2_IN (default)
+            spec["pins"][mk] = {
+                "pwm":   pwm,
+                "in_a":  in_a,
+                "in_b":  in_b,
+                "dir":   -1,
+                "pwm_r": -1, "pwm_l": -1, "en": -1,
+            }
+
+    # ------------------------------------------------------------------
+    # Pins: I2C, Battery, Sonar — mirror into pins sub-section
+    # ------------------------------------------------------------------
+    spec["pins"]["i2c"]["sda"] = spec["sensors"]["i2c_sda"]
+    spec["pins"]["i2c"]["scl"] = spec["sensors"]["i2c_scl"]
+    spec["pins"]["battery_pin"] = spec["sensors"]["battery_pin"]
+    if "dac_pin" in spec["sensors"]:
+        spec["pins"]["dac_pin"] = spec["sensors"]["dac_pin"]
+    spec["pins"]["sonar"]["trig"] = spec["sensors"]["sonar_trig"]
+    spec["pins"]["sonar"]["echo"] = spec["sensors"]["sonar_echo"]
+
+    # ------------------------------------------------------------------
+    # Modeled advanced telemetry values (editable in the Web UI, so they
+    # must round-trip through the spec, not the verbatim passthrough).
+    # ------------------------------------------------------------------
+    adv = spec.setdefault("advanced", {})
+
+    def _ipv4(macro: str):
+        mm = re.search(rf'^[ \t]*#define\s+{macro}\s*\{{\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\}}',
+                       content, re.MULTILINE)
+        return ".".join(mm.groups()) if mm else None
+    def _num(macro: str):
+        mm = re.search(rf'^[ \t]*#define\s+{macro}\s+(\d+)', content, re.MULTILINE)
+        return int(mm.group(1)) if mm else None
+    def _str(macro: str):
+        mm = re.search(rf'^[ \t]*#define\s+{macro}\s+"([^"]*)"', content, re.MULTILINE)
+        return mm.group(1) if mm else None
+
+    for key, fn, macro in [
+        ("syslog_ip",     _ipv4, "SYSLOG_SERVER"),
+        ("syslog_port",   _num,  "SYSLOG_PORT"),
+        ("wifi_monitor",  _num,  "WIFI_MONITOR"),
+        ("lidar_ip",      _ipv4, "LIDAR_SERVER"),
+        ("lidar_port",    _num,  "LIDAR_PORT"),
+        ("lidar_baudrate", _num, "LIDAR_BAUDRATE"),
+        ("lidar_rxd",     _num,  "LIDAR_RXD"),
+        ("lidar_serial",  _num,  "LIDAR_SERIAL"),
+        ("agent_ip",      _ipv4, "AGENT_IP"),
+        ("ota_hostname",  _str,  "OTA_HOSTNAME"),
+        ("ota_password",  _str,  "OTA_PASSWORD"),
+        ("topic_prefix",  _str,  "TOPIC_PREFIX"),
+    ]:
+        v = fn(macro)
+        if v is not None:
+            adv[key] = v
+    if _define_bool(content, "USE_SHORT_BRAKE"):
+        adv["use_short_brake"] = True
+
+    # ------------------------------------------------------------------
+    # Verbatim passthrough of every other uncommented #define, so an
+    # imported header round-trips without silently dropping anything
+    # (covariances, RCCHECK, board hooks, LIDAR_* the UI does not model…).
+    # The generator re-emits these only if it did not already produce a
+    # #define of the same name.
+    # ------------------------------------------------------------------
+    # A #define is "unconditional" if every preprocessor guard enclosing it is
+    # benign — the header guard, an `#if __has_include(...)` wifi_config probe,
+    # or `#ifndef BAUDRATE`. Anything guarded by a feature macro we model
+    # (USE_WIFI, USE_SYSLOG, USE_*_MOTOR_DRIVER, USE_LIDAR_UDP, …) is logic we
+    # regenerate ourselves and must NOT hoist to the top level.
+    guard_name = f"{spec['robot_name'].upper()}_CONFIG_H"
+    benign = {guard_name, "BAUDRATE"}
+    # Macros now captured into the structured spec above (editable in the UI);
+    # the generator re-emits them from the spec, so keep them out of the
+    # verbatim passthrough or they would double-emit / ignore a UI clear.
+    modeled = {"K_P", "K_I", "K_D", "MAG_BIAS", "ACCEL_COV", "GYRO_COV",
+               "ORI_COV", "MAG_COV", "POSE_COV", "TWIST_COV", "ENV_COV",
+               "TOPIC_PREFIX", "USE_BMP280", "BMP280_ADDR", "DAC_PIN",
+               "USE_ADC_LUT", "ADC_LUT", "USE_SONAR"}
+    src_lines = content.split("\n")
+    raw_defines: List[Dict[str, str]] = []
+    stack: List[str] = []
+    i = 0
+    while i < len(src_lines):
+        ln = src_lines[i]
+        bare = ln.strip()
+        mif = re.match(r'#if(n?def)?\b(.*)', bare)
+        if mif:
+            rest = mif.group(2)
+            if "__has_include" in rest:
+                stack.append("__has_include")
+            else:
+                tok = re.search(r'([A-Za-z_]\w*)', rest)
+                stack.append(tok.group(1) if tok else "?")
+        elif bare.startswith("#endif"):
+            if stack:
+                stack.pop()
+        elif re.match(r'^[ \t]*#define[ \t]', ln) and all(
+                g in benign or g == "__has_include" for g in stack):
+            nm = re.match(r'^[ \t]*#define[ \t]+([A-Za-z_]\w*)', ln)
+            block = [ln]
+            while block[-1].rstrip().endswith("\\") and i + 1 < len(src_lines):
+                i += 1
+                block.append(src_lines[i])
+            if nm and nm.group(1) not in modeled:
+                raw_defines.append({"name": nm.group(1), "text": "\n".join(block).rstrip()})
+        i += 1
+    spec["raw_defines"] = raw_defines
+
+    return spec
+
+
+def merge_wifi_config(spec: Dict[str, Any], wifi_content: str) -> Dict[str, Any]:
+    """Fold the git-ignored config/custom/wifi_config.h into a parsed spec so
+    the Web UI form shows the real SSID / password / host IPs. Mutates & returns
+    `spec`. Safe to call with an empty string (no-op)."""
+    if not wifi_content:
+        return spec
+    ap = re.search(r'#define\s+WIFI_AP_LIST\s*\{\s*\{\s*"([^"]*)"\s*,\s*"([^"]*)"',
+                   wifi_content)
+    ssid_m = re.search(r'#define\s+WIFI_SSID\s+"([^"]*)"', wifi_content)
+    pw_m = re.search(r'#define\s+WIFI_PASSWORD\s+"([^"]*)"', wifi_content)
+    ssid = ap.group(1) if ap else (ssid_m.group(1) if ssid_m else "")
+    password = ap.group(2) if ap else (pw_m.group(1) if pw_m else "")
+    if not ssid:
+        return spec
+
+    def _ip(macro):
+        mm = re.search(rf'#define\s+{macro}\s*\{{\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\}}',
+                       wifi_content)
+        return ".".join(mm.groups()) if mm else None
+
+    ws = spec.setdefault("wifi_settings", {})
+    ws["ssid"] = ssid
+    ws["password"] = password
+    adv = spec.setdefault("advanced", {})
+    agent_ip = _ip("AGENT_IP")
+    if agent_ip:
+        adv["agent_ip"] = agent_ip
+        ws["agent_ip"] = agent_ip
+    syslog_ip = _ip("SYSLOG_SERVER")
+    if syslog_ip:
+        adv["syslog_ip"] = syslog_ip
+    lidar_ip = _ip("LIDAR_SERVER")
+    if lidar_ip:
+        adv["lidar_ip"] = lidar_ip
+    ota_pw = re.search(r'#define\s+OTA_PASSWORD\s+"([^"]*)"', wifi_content)
+    if ota_pw:
+        adv["ota_password"] = ota_pw.group(1)
+    # Present a real SSID -> the studio should show the WiFi block.
+    spec["enable_ota_syslog"] = True
+    return spec
+
+
+def merge_configurations(base_spec: Dict[str, Any], override_spec: Dict[str, Any]) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """
+    Deep-merges an override specification into an existing base specification.
+    Returns (merged_spec, list_of_changes).
+    """
+    merged = json.loads(json.dumps(base_spec))  # Deep copy
+    changes = []
+
+    def deep_merge(target, source, prefix=""):
+        for k, v in source.items():
+            field_name = f"{prefix}.{k}" if prefix else k
+            if isinstance(v, dict) and k in target and isinstance(target[k], dict):
+                deep_merge(target[k], v, field_name)
+            else:
+                old_val = target.get(k)
+                if old_val != v:
+                    changes.append({"field": field_name, "old": old_val, "new": v})
+                    target[k] = v
+
+    deep_merge(merged, override_spec)
+    _sync_sensor_alias(merged, changes, "imu", "imu_type", "_IMU")
+    _sync_sensor_alias(merged, changes, "mag", "mag_type", "_MAG")
+    return merged, changes
+
+
+def _sync_sensor_alias(merged: Dict[str, Any], changes: List[Dict[str, Any]], short_key: str, full_key: str, suffix: str) -> None:
+    """Keep sensors.<short_key> (form-shape, e.g. "imu") and
+    sensors.<full_key> (parser-shape, e.g. "imu_type") in agreement after a
+    merge. generator.py checks the short key first (see its comments there),
+    so an overlay that only touches one of the pair must still make the
+    *other* one agree, or a base spec's stale copy of whichever key the
+    overlay didn't touch would win (or lose) unpredictably depending on
+    which key happened to be set in that particular caller -- this is the
+    same key-mismatch bug class as the battery/sonar/INA219/i2c fixes,
+    showing up here because two different, equally legitimate callers use
+    the two different key names (the real web-UI form always sends the
+    short key; a hand-built/legacy overlay -- e.g. a merge test fixture, or
+    an older API caller -- may send only the full key).
+    """
+    sensors = merged.get("sensors")
+    if not isinstance(sensors, dict):
+        return
+    touched_short = any(c["field"] == f"sensors.{short_key}" for c in changes)
+    touched_full = any(c["field"] == f"sensors.{full_key}" for c in changes)
+    if touched_full and not touched_short:
+        v = sensors.get(full_key)
+        if v:
+            sensors[short_key] = str(v).replace("USE_", "").replace(suffix, "")
+    elif touched_short and not touched_full:
+        v = sensors.get(short_key)
+        if v:
+            sensors[full_key] = v if str(v).startswith("USE_") else f"USE_{v}{suffix}"

--- a/tools/robot_config_engine/schema.json
+++ b/tools/robot_config_engine/schema.json
@@ -1,0 +1,317 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Linorobot2 Hardware Specification",
+  "type": "object",
+  "required": [
+    "robot_name",
+    "kinematics",
+    "mcu",
+    "transport",
+    "geometry",
+    "motors",
+    "pins"
+  ],
+  "properties": {
+    "robot_name": {
+      "type": "string",
+      "pattern": "^[a-z0-9_]+$"
+    },
+    "kinematics": {
+      "type": "string",
+      "enum": [
+        "DIFFERENTIAL_DRIVE",
+        "SKID_STEER",
+        "MECANUM"
+      ]
+    },
+    "mcu": {
+      "type": "string",
+      "enum": [
+        "PICO",
+        "PICO2",
+        "PICOW",
+        "PICO2W",
+        "ESP32",
+        "ESP32S2",
+        "ESP32S3",
+        "GENDRV"
+      ]
+    },
+    "transport": {
+      "type": "string",
+      "enum": [
+        "SERIAL",
+        "WIFI_UDP"
+      ]
+    },
+    "serial_interface": {
+      "type": "string",
+      "enum": [
+        "CDC",
+        "BRIDGE"
+      ],
+      "default": "CDC"
+    },
+    "wifi_settings": {
+      "type": "object",
+      "properties": {
+        "ssid": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "agent_ip": {
+          "type": "string"
+        },
+        "agent_port": {
+          "type": "integer",
+          "default": 8888
+        },
+        "syslog_server": {
+          "type": "string"
+        }
+      }
+    },
+    "geometry": {
+      "type": "object",
+      "required": [
+        "wheel_diameter",
+        "track_width"
+      ],
+      "properties": {
+        "wheel_diameter": {
+          "type": "number",
+          "minimum": 0.01
+        },
+        "track_width": {
+          "type": "number",
+          "minimum": 0.05
+        },
+        "wheelbase": {
+          "type": "number",
+          "minimum": 0.05
+        },
+        "weight": {
+          "type": "number",
+          "minimum": 0.05
+        }
+      }
+    },
+    "motors": {
+      "type": "object",
+      "required": [
+        "driver_type",
+        "max_rpm",
+        "cpr"
+      ],
+      "properties": {
+        "driver_type": {
+          "type": "string",
+          "enum": [
+            "BTS7960",
+            "GENERIC_2_IN",
+            "GENERIC_1_IN",
+            "ESC"
+          ]
+        },
+        "max_rpm": {
+          "type": "number",
+          "minimum": 1
+        },
+        "cpr": {
+          "type": "number",
+          "minimum": 1
+        },
+        "operating_voltage": {
+          "type": "number",
+          "default": 12.0
+        },
+        "max_voltage": {
+          "type": "number",
+          "default": 12.0
+        },
+        "rated_torque": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "rated_voltage": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "pwm_frequency": {
+          "type": "integer",
+          "default": 20000
+        },
+        "pwm_bits": {
+          "type": "integer",
+          "default": 10
+        },
+        "motor1_inv": {
+          "type": "boolean",
+          "default": false
+        },
+        "motor2_inv": {
+          "type": "boolean",
+          "default": true
+        },
+        "motor3_inv": {
+          "type": "boolean",
+          "default": false
+        },
+        "motor4_inv": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "sensors": {
+      "type": "object",
+      "properties": {
+        "imu": {
+          "type": "string",
+          "enum": [
+            "MPU6050",
+            "BNO085",
+            "QMI8658",
+            "MPU9250",
+            "FAKE",
+            "FAKE_IMU",
+            "NONE"
+          ]
+        },
+        "mag": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "QMC5883L",
+            "AK09918",
+            "HMC5883L"
+          ]
+        },
+        "mag_bias": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "battery_monitor": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "ADC_DIVIDER",
+            "INA219"
+          ]
+        },
+        "battery_nominal_voltage": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "battery_capacity": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "battery_min_voltage": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "battery_max_voltage": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "battery_dip": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "battery_r1": {
+          "type": "number",
+          "minimum": 1.0,
+          "default": 30000.0
+        },
+        "battery_r2": {
+          "type": "number",
+          "minimum": 1.0,
+          "default": 7500.0
+        },
+        "battery_adc_cap": {
+          "type": "number",
+          "minimum": 0.0,
+          "default": 1000.0
+        },
+        "sonar": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "pins": {
+      "type": "object",
+      "properties": {
+        "led": {
+          "type": "integer"
+        },
+        "motor1": {
+          "type": "object"
+        },
+        "motor2": {
+          "type": "object"
+        },
+        "motor3": {
+          "type": "object"
+        },
+        "motor4": {
+          "type": "object"
+        },
+        "encoders": {
+          "type": "object"
+        },
+        "i2c": {
+          "type": "object",
+          "properties": {
+            "sda": {
+              "type": "integer"
+            },
+            "scl": {
+              "type": "integer"
+            }
+          }
+        },
+        "battery_pin": {
+          "type": "integer"
+        },
+        "sonar": {
+          "type": "object",
+          "properties": {
+            "trig": {
+              "type": "integer"
+            },
+            "echo": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "wifi_telemetry": {
+      "type": "boolean",
+      "default": false
+    },
+    "watchdog": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "timeout_sec": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 300,
+          "default": 60
+        }
+      }
+    }
+  }
+}

--- a/tools/robot_config_engine/schema.json
+++ b/tools/robot_config_engine/schema.json
@@ -1,0 +1,382 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Linorobot2 Hardware Specification",
+  "type": "object",
+  "required": [
+    "robot_name",
+    "kinematics",
+    "mcu",
+    "transport",
+    "geometry",
+    "motors",
+    "pins"
+  ],
+  "properties": {
+    "robot_name": {
+      "type": "string",
+      "pattern": "^[a-z0-9_]+$"
+    },
+    "kinematics": {
+      "type": "string",
+      "enum": [
+        "DIFFERENTIAL_DRIVE",
+        "SKID_STEER",
+        "MECANUM"
+      ]
+    },
+    "mcu": {
+      "type": "string",
+      "enum": [
+        "PICO",
+        "PICO2",
+        "PICOW",
+        "PICO2W",
+        "ESP32",
+        "ESP32S2",
+        "ESP32S3",
+        "GENDRV"
+      ]
+    },
+    "transport": {
+      "type": "string",
+      "enum": [
+        "SERIAL",
+        "WIFI_UDP"
+      ]
+    },
+    "serial_interface": {
+      "type": "string",
+      "enum": [
+        "CDC",
+        "BRIDGE"
+      ],
+      "default": "CDC"
+    },
+    "wifi_settings": {
+      "type": "object",
+      "properties": {
+        "ssid": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "agent_ip": {
+          "type": "string"
+        },
+        "agent_port": {
+          "type": "integer",
+          "default": 8888
+        },
+        "syslog_server": {
+          "type": "string"
+        }
+      }
+    },
+    "geometry": {
+      "type": "object",
+      "required": [
+        "wheel_diameter",
+        "track_width"
+      ],
+      "properties": {
+        "wheel_diameter": {
+          "type": "number",
+          "minimum": 0.01
+        },
+        "track_width": {
+          "type": "number",
+          "minimum": 0.05
+        },
+        "wheelbase": {
+          "type": "number",
+          "minimum": 0.05
+        },
+        "weight": {
+          "type": "number",
+          "minimum": 0.05
+        }
+      }
+    },
+    "motors": {
+      "type": "object",
+      "required": [
+        "driver_type",
+        "max_rpm",
+        "cpr"
+      ],
+      "properties": {
+        "driver_type": {
+          "type": "string",
+          "enum": [
+            "BTS7960",
+            "GENERIC_2_IN",
+            "GENERIC_1_IN",
+            "ESC"
+          ]
+        },
+        "max_rpm": {
+          "type": "number",
+          "minimum": 1
+        },
+        "cpr": {
+          "type": "number",
+          "minimum": 1
+        },
+        "operating_voltage": {
+          "type": "number",
+          "default": 6.0
+        },
+        "max_voltage": {
+          "type": "number",
+          "default": 12.0
+        },
+        "rated_torque": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "rated_voltage": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "pwm_frequency": {
+          "type": "integer",
+          "default": 20000
+        },
+        "pwm_bits": {
+          "type": "integer",
+          "default": 10
+        },
+        "motor1_inv": {
+          "type": "boolean",
+          "default": false
+        },
+        "motor2_inv": {
+          "type": "boolean",
+          "default": true
+        },
+        "motor3_inv": {
+          "type": "boolean",
+          "default": false
+        },
+        "motor4_inv": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "sensors": {
+      "type": "object",
+      "properties": {
+        "imu": {
+          "type": "string",
+          "enum": [
+            "MPU6050",
+            "BNO085",
+            "QMI8658",
+            "MPU9250",
+            "FAKE",
+            "FAKE_IMU",
+            "NONE"
+          ]
+        },
+        "mag": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "QMC5883L",
+            "AK09918",
+            "HMC5883L"
+          ]
+        },
+        "mag_bias": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "battery_monitor": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "ADC_DIVIDER",
+            "INA219"
+          ]
+        },
+        "battery_nominal_voltage": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "battery_capacity": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "battery_min_voltage": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "battery_max_voltage": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "battery_dip": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "battery_r1": {
+          "type": "number",
+          "minimum": 1.0,
+          "default": 30000.0
+        },
+        "battery_r2": {
+          "type": "number",
+          "minimum": 1.0,
+          "default": 7500.0
+        },
+        "battery_adc_cap": {
+          "type": "number",
+          "minimum": 0.0,
+          "default": 1000.0
+        },
+        "sonar": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "pins": {
+      "type": "object",
+      "properties": {
+        "led": {
+          "type": "integer"
+        },
+        "motor1": {
+          "type": "object"
+        },
+        "motor2": {
+          "type": "object"
+        },
+        "motor3": {
+          "type": "object"
+        },
+        "motor4": {
+          "type": "object"
+        },
+        "encoders": {
+          "type": "object"
+        },
+        "i2c": {
+          "type": "object",
+          "properties": {
+            "sda": {
+              "type": "integer"
+            },
+            "scl": {
+              "type": "integer"
+            }
+          }
+        },
+        "battery_pin": {
+          "type": "integer"
+        },
+        "sonar": {
+          "type": "object",
+          "properties": {
+            "trig": {
+              "type": "integer"
+            },
+            "echo": {
+              "type": "integer"
+            }
+          }
+        },
+        "lidar_rxd": {
+          "type": "integer",
+          "description": "MCU pin the LiDAR data line is on. With fake LD19 this is the pin the simulated scan is transmitted from.",
+          "minimum": -1
+        }
+      }
+    },
+    "wifi_telemetry": {
+      "type": "boolean",
+      "default": false
+    },
+    "watchdog": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "timeout_sec": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 300,
+          "default": 60
+        }
+      }
+    },
+    "simulation": {
+      "type": "object",
+      "description": "Simulate a drivetrain and LiDAR on a bare module with no hardware attached.",
+      "properties": {
+        "fake_wheel": {
+          "type": "boolean",
+          "default": false
+        },
+        "robot_mass": {
+          "type": "number",
+          "minimum": 0.1,
+          "maximum": 200.0
+        },
+        "wheel_noise_rpm": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 20.0
+        },
+        "fake_ld19": {
+          "type": "boolean",
+          "default": false
+        },
+        "map_width": {
+          "type": "number",
+          "default": 10.0,
+          "minimum": 1.0,
+          "maximum": 50.0
+        },
+        "map_height": {
+          "type": "number",
+          "default": 12.0,
+          "minimum": 1.0,
+          "maximum": 50.0
+        },
+        "wall_obstacle": {
+          "type": "boolean",
+          "default": true
+        },
+        "wall_x1": {
+          "type": "number",
+          "default": 2.0
+        },
+        "wall_y1": {
+          "type": "number",
+          "default": -1.5
+        },
+        "wall_x2": {
+          "type": "number",
+          "default": 2.0
+        },
+        "wall_y2": {
+          "type": "number",
+          "default": 1.5
+        },
+        "fake_sonar": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    }
+  }
+}

--- a/tools/robot_config_engine/test_config_engine.py
+++ b/tools/robot_config_engine/test_config_engine.py
@@ -116,6 +116,33 @@ class TestRobotConfigEngine(unittest.TestCase):
         header = generate_config_header(parsed)
         self.assertIn("#define LED_PIN -1", header)
 
+    def test_bts7960_two_output_roundtrip(self):
+        # BTS7960 drives exactly two pins: MOTORx_IN_A (RPWM) and MOTORx_IN_B
+        # (LPWM). MOTORx_PWM is an unused placeholder and must be emitted as -1
+        # with no BOARD_INIT enable-drive lines.
+        spec = json.loads(json.dumps(self.valid_pico_spec))
+        spec["motors"]["driver_type"] = "BTS7960"
+        spec["pins"]["motor1"] = {"in_a": 12, "in_b": 13}
+        spec["pins"]["motor2"] = {"in_a": 10, "in_b": 11}
+        header = generate_config_header(spec)
+        self.assertIn("#define MOTOR1_PWM -1", header)
+        self.assertIn("#define MOTOR1_IN_A 12", header)
+        self.assertIn("#define MOTOR1_IN_B 13", header)
+        self.assertNotIn("pinMode(MOTOR1_PWM", header)
+
+        parsed = parse_header_to_spec(header)
+        self.assertEqual(parsed["motors"]["driver_type"], "BTS7960")
+        self.assertEqual(parsed["pins"]["motor1"]["in_a"], 12)
+        self.assertEqual(parsed["pins"]["motor1"]["in_b"], 13)
+
+        ok, errors, _ = validate_robot_spec(spec)
+        self.assertTrue(ok, errors)
+
+        # A duplicate across the two real outputs is still a conflict.
+        spec["pins"]["motor2"]["in_a"] = 12
+        ok, errors, _ = validate_robot_spec(spec)
+        self.assertFalse(ok)
+
     def test_negative_encoder_pins_valid(self):
         # Negative values stand for "no connection" and must not trigger
         # pin-conflict or out-of-range errors, even when repeated.

--- a/tools/robot_config_engine/test_config_engine.py
+++ b/tools/robot_config_engine/test_config_engine.py
@@ -170,6 +170,65 @@ class TestRobotConfigEngine(unittest.TestCase):
         self.assertFalse(ok)
         self.assertTrue(any("assigned to multiple functions" in str(e) for e in errors))
 
+    def test_bmp280_env_roundtrip(self):
+        raw = """
+#ifndef ENVBOT_CONFIG_H
+#define ENVBOT_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define USE_BTS7960_MOTOR_DRIVER
+#define USE_BMP280
+#define BMP280_ADDR 0x76
+#define ENV_COV { 1.0, 0.01, 0.0025 }
+#define BAUDRATE 921600
+#endif
+"""
+        spec = parse_header_to_spec(raw)
+        self.assertTrue(spec["sensors"].get("use_bmp280"))
+        self.assertEqual(spec["sensors"].get("env_type"), "BMP280")
+        self.assertEqual(spec["sensors"].get("bmp280_addr"), "0x76")
+        self.assertEqual(spec["imu_tuning"]["env_cov"], [1.0, 0.01, 0.0025])
+
+        h = generate_config_header(spec)
+        self.assertEqual(h.count("#define USE_BMP280"), 1)
+        self.assertIn("#define BMP280_ADDR 0x76", h)
+        self.assertIn("#define ENV_COV { 1, 0.01, 0.0025 }", h)  # _n() trims 1.0 -> 1
+        self.assertEqual(h.count("#define ENV_COV"), 1)
+
+        # From the front-end form shape (sensors.env = "BME280")
+        fe = json.loads(json.dumps(self.valid_pico_spec))
+        fe["sensors"]["env"] = "BME280"
+        h2 = generate_config_header(fe)
+        self.assertIn("#define USE_BMP280", h2)
+
+    def test_modern_imu_roundtrip(self):
+        for imu, macro in (("LSM6DSOX", "USE_LSM6DSOX_IMU"),
+                           ("ICM20948", "USE_ICM20948_IMU")):
+            fe = json.loads(json.dumps(self.valid_pico_spec))
+            fe["sensors"]["imu"] = imu
+            h = generate_config_header(fe)
+            self.assertIn(f"#define {macro}", h)
+
+        # Enabling a known IMU with no explicit covariance -> datasheet default
+        fe = json.loads(json.dumps(self.valid_pico_spec))
+        fe["sensors"]["imu"] = "LSM6DSOX"
+        fe.pop("imu_tuning", None)
+        h = generate_config_header(fe)
+        self.assertIn("#define ACCEL_COV { 4.7e-05, 4.7e-05, 4.7e-05 }", h)
+        self.assertIn("#define GYRO_COV { 4.4e-07, 4.4e-07, 4.4e-07 }", h)
+        # An explicit value still wins over the default.
+        fe["imu_tuning"] = {"accel_cov": 0.02}
+        h = generate_config_header(fe)
+        self.assertIn("#define ACCEL_COV { 0.02, 0.02, 0.02 }", h)
+        self.assertEqual(h.count("#define ACCEL_COV"), 1)
+        raw = ("#ifndef ICMBOT_CONFIG_H\n#define ICMBOT_CONFIG_H\n"
+               "#define USE_ICM20948_IMU\n#define USE_ICM20948_MAG\n#endif\n")
+        spec = parse_header_to_spec(raw)
+        self.assertEqual(spec["sensors"]["imu_type"], "USE_ICM20948_IMU")
+        self.assertEqual(spec["sensors"]["mag_type"], "USE_ICM20948_MAG")
+        h = generate_config_header(spec)
+        self.assertEqual(h.count("#define USE_ICM20948_IMU"), 1)
+        self.assertIn("#define USE_ICM20948_MAG", h)
+
     def test_pid_magbias_covariance_topicprefix_roundtrip(self):
         raw = """
 #ifndef TUNEBOT_CONFIG_H

--- a/tools/robot_config_engine/test_config_engine.py
+++ b/tools/robot_config_engine/test_config_engine.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026 Thomas Chou, Paul Bouchier, Linorobot contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import unittest
+import os
+from validator import validate_robot_spec
+from generator import generate_config_header
+from parser import parse_header_to_spec, merge_configurations
+
+class TestRobotConfigEngine(unittest.TestCase):
+    def setUp(self):
+        self.valid_pico_spec = {
+            "robot_name": "scout_pico2",
+            "kinematics": "DIFFERENTIAL_DRIVE",
+            "mcu": "PICO2",
+            "transport": "SERIAL",
+            "geometry": {
+                "wheel_diameter": 0.065,
+                "track_width": 0.20,
+                "weight": 3.5
+            },
+            "motors": {
+                "driver_type": "GENERIC_2_IN",
+                "max_rpm": 330,
+                "cpr": 1320,
+                "rated_torque": 1.5,
+                "rated_voltage": 12.0
+            },
+            "sensors": {
+                "imu": "MPU6050",
+                "mag": "NONE",
+                "battery_monitor": "ADC_DIVIDER",
+                "battery_capacity": 2.2,
+                "battery_nominal_voltage": 11.1,
+                "battery_min_voltage": 9.0,
+                "battery_max_voltage": 12.6,
+                "sonar": True
+            },
+            "pins": {
+                "led": 25,
+                "motor1": { "pwm": 14, "in_a": 12, "in_b": 13 },
+                "motor2": { "pwm": 15, "in_a": 10, "in_b": 11 },
+                "encoders": { "m1_a": 2, "m1_b": 3, "m2_a": 4, "m2_b": 5 },
+                "i2c": { "sda": 8, "scl": 9 },
+                "battery_pin": 26,
+                "sonar": { "trig": 16, "echo": 17 }
+            }
+        }
+
+    def test_validation_success(self):
+        valid, errors, stats = validate_robot_spec(self.valid_pico_spec)
+        self.assertTrue(valid)
+        self.assertEqual(len(errors), 0)
+        self.assertAlmostEqual(stats["max_linear_speed_m_s"], 0.954, places=2)
+        self.assertIn("max_accel_m_s2", stats)
+
+    def test_pin_conflict_detection(self):
+        bad_spec = dict(self.valid_pico_spec)
+        bad_spec["pins"] = dict(self.valid_pico_spec["pins"])
+        bad_spec["pins"]["motor1"] = { "pwm": 2, "in_a": 12, "in_b": 13 }
+        valid, errors, stats = validate_robot_spec(bad_spec)
+        self.assertFalse(valid)
+        self.assertTrue(any("assigned to multiple functions" in str(e) for e in errors))
+
+    def test_header_generation(self):
+        header = generate_config_header(self.valid_pico_spec)
+        self.assertIn("#define LINO_BASE DIFFERENTIAL_DRIVE", header)
+        self.assertIn("#define USE_GENERIC_2_IN_MOTOR_DRIVER", header)
+        self.assertIn("#define USE_MPU6050_IMU", header)
+        self.assertIn("#define BATTERY_CAP 2.2", header)
+        self.assertIn("#define BATTERY_MIN 9", header)
+        self.assertIn("#define BATTERY_MAX 12.6", header)
+        self.assertIn("#define ROBOT_WEIGHT 3.5", header)
+
+    def test_header_parsing_fake_sensors(self):
+        # Sample C++ header with Fake IMU and Fake Mag
+        raw_header = """
+#ifndef TESTBOT_CONFIG_H
+#define TESTBOT_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define WHEEL_DIAMETER 0.0650
+#define LR_WHEELS_DISTANCE 0.2000
+#define USE_BTS7960_MOTOR_DRIVER
+#define MOTOR_MAX_RPM 300
+#define COUNTS_PER_REV1 1320
+#define USE_FAKE_IMU
+#define USE_FAKE_MAG
+#define BAUDRATE 921600
+#endif
+"""
+        parsed = parse_header_to_spec(raw_header)
+        self.assertEqual(parsed["robot_name"], "testbot")
+        self.assertEqual(parsed["kinematics"], "DIFFERENTIAL_DRIVE")
+        self.assertEqual(parsed["motors"]["driver_type"], "BTS7960")
+        self.assertEqual(parsed["sensors"]["imu_type"], "USE_FAKE_IMU")
+        self.assertEqual(parsed["sensors"]["mag_type"], "USE_FAKE_MAG")
+        self.assertEqual(parsed["telemetry"]["baudrate"], 921600)
+
+    def test_negative_led_pin_roundtrip(self):
+        # LED_PIN -1 means "no addressable LED" (e.g. Waveshare GenDrv).
+        # It must parse to int -1 and regenerate as "#define LED_PIN -1".
+        parsed = parse_header_to_spec("#define LED_PIN -1\n")
+        self.assertEqual(parsed["pins"]["led"], -1)
+        header = generate_config_header(parsed)
+        self.assertIn("#define LED_PIN -1", header)
+
+    def test_negative_encoder_pins_valid(self):
+        # Negative values stand for "no connection" and must not trigger
+        # pin-conflict or out-of-range errors, even when repeated.
+        neg = json.loads(json.dumps(self.valid_pico_spec))
+        neg["pins"] = {
+            "led": 25,
+            "encoders": {
+                "m1_a": -1, "m1_b": -1, "m2_a": -1, "m2_b": -1,
+                "m3_a": -1, "m3_b": -1, "m4_a": -1, "m4_b": -1,
+                "m1_inv": False, "m2_inv": False, "m3_inv": False, "m4_inv": False,
+            },
+            "motor1": {"pwm": 14, "in_a": 12, "in_b": 13},
+            "motor2": {"pwm": 15, "in_a": 10, "in_b": 11},
+            "motor3": {"pwm": -1, "in_a": -1, "in_b": -1},
+            "motor4": {"pwm": -1, "in_a": -1, "in_b": -1},
+            "i2c": {"sda": 4, "scl": 5},
+        }
+        ok, errors, _ = validate_robot_spec(neg)
+        self.assertTrue(ok)
+        self.assertEqual(errors, [])
+
+        # But a genuine positive-pin duplicate must still be an error.
+        neg["pins"]["motor2"]["in_a"] = 14  # duplicates motor1.in_a == 14
+        ok, errors, _ = validate_robot_spec(neg)
+        self.assertFalse(ok)
+        self.assertTrue(any("assigned to multiple functions" in str(e) for e in errors))
+
+    def test_pid_magbias_covariance_topicprefix_roundtrip(self):
+        raw = """
+#ifndef TUNEBOT_CONFIG_H
+#define TUNEBOT_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define USE_BTS7960_MOTOR_DRIVER
+#define K_P 0.75
+#define K_I 0.9
+#define K_D 0.42
+#define MAG_BIAS { 12.5, -3.0, 7.25 }
+#define ACCEL_COV { 0.01, 0.01, 0.01 }
+#define GYRO_COV { 0.002, 0.002, 0.002 }
+#define ORI_COV { 0.03, 0.03, 0.03 }
+#define TOPIC_PREFIX "robot1/"
+#define BAUDRATE 921600
+#endif
+"""
+        spec = parse_header_to_spec(raw)
+        self.assertEqual(spec["pid"], {"kp": 0.75, "ki": 0.9, "kd": 0.42})
+        self.assertEqual(spec["imu_tuning"]["mag_bias"], [12.5, -3.0, 7.25])
+        self.assertEqual(spec["imu_tuning"]["accel_cov"], 0.01)
+        self.assertEqual(spec["imu_tuning"]["gyro_cov"], 0.002)
+        self.assertEqual(spec["advanced"]["topic_prefix"], "robot1/")
+
+        h = generate_config_header(spec)
+        self.assertIn("#define K_P 0.75", h)
+        self.assertIn("#define K_I 0.9", h)
+        self.assertIn("#define K_D 0.42", h)
+        self.assertIn("#define MAG_BIAS { 12.5, -3, 7.25 }", h)
+        self.assertIn("#define ACCEL_COV { 0.01, 0.01, 0.01 }", h)
+        self.assertIn("#define GYRO_COV { 0.002, 0.002, 0.002 }", h)
+        self.assertIn('#define TOPIC_PREFIX "robot1/"', h)
+        # exactly one definition of each (no passthrough double-emit)
+        self.assertEqual(h.count("#define ACCEL_COV"), 1)
+        self.assertEqual(h.count("#define TOPIC_PREFIX"), 1)
+        self.assertEqual(h.count("#define K_P"), 1)
+
+    def test_user_modify_and_merge_workflow(self):
+        # 1. User starts with an existing header (Fake IMU/Mag)
+        raw_header = """
+#ifndef MYROBOT_CONFIG_H
+#define MYROBOT_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define WHEEL_DIAMETER 0.0800
+#define LR_WHEELS_DISTANCE 0.2200
+#define USE_GENERIC_2_IN_MOTOR_DRIVER
+#define MOTOR_MAX_RPM 330
+#define COUNTS_PER_REV1 1440
+#define USE_FAKE_IMU
+#define USE_FAKE_MAG
+#define BAUDRATE 921600
+#endif
+"""
+        base_spec = parse_header_to_spec(raw_header)
+        self.assertEqual(base_spec["sensors"]["imu_type"], "USE_FAKE_IMU")
+
+        # 2. User modifies settings in Web UI: adds QMI8658 IMU, AK09918 Mag, Sonar, and Dual-Core
+        modified_settings = {
+            "sensors": {
+                "imu_type": "USE_QMI8658_IMU",
+                "mag_type": "USE_AK09918_MAG",
+                "sonar_trig": 19,
+                "sonar_echo": 18
+            },
+            "telemetry": {
+                "use_dual_core": True,
+                "baudrate": 921600
+            }
+        }
+
+        merged_spec, changes = merge_configurations(base_spec, modified_settings)
+        self.assertGreater(len(changes), 0)
+
+        # 3. Generate merged C++ header
+        updated_header = generate_config_header(merged_spec)
+        self.assertIn("#define USE_QMI8658_IMU", updated_header)
+        self.assertIn("#define USE_AK09918_MAG", updated_header)
+        self.assertIn("#define TRIG_PIN 19", updated_header)
+        self.assertIn("#define ECHO_PIN 18", updated_header)
+        self.assertIn("#define USE_DUAL_CORE", updated_header)
+        self.assertNotIn("#define USE_FAKE_IMU", updated_header)
+        self.assertNotIn("#define USE_FAKE_MAG", updated_header)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/robot_config_engine/test_config_engine.py
+++ b/tools/robot_config_engine/test_config_engine.py
@@ -1,0 +1,1169 @@
+# Copyright (c) 2026 Thomas Chou, Paul Bouchier, Linorobot contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import unittest
+import os
+from validator import validate_robot_spec
+from generator import generate_config_header
+from parser import parse_header_to_spec, merge_configurations
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "web"))
+import server
+
+class TestRobotConfigEngine(unittest.TestCase):
+    def setUp(self):
+        self.valid_pico_spec = {
+            "robot_name": "scout_pico2",
+            "kinematics": "DIFFERENTIAL_DRIVE",
+            "mcu": "PICO2",
+            "transport": "SERIAL",
+            "geometry": {
+                "wheel_diameter": 0.065,
+                "track_width": 0.20,
+                "weight": 3.5
+            },
+            "motors": {
+                "driver_type": "GENERIC_2_IN",
+                "max_rpm": 330,
+                "cpr": 1320,
+                "rated_torque": 1.5,
+                "rated_voltage": 12.0
+            },
+            "sensors": {
+                "imu": "MPU6050",
+                "mag": "NONE",
+                "battery_monitor": "ADC_DIVIDER",
+                "battery_capacity": 2.2,
+                "battery_nominal_voltage": 11.1,
+                "battery_min_voltage": 9.0,
+                "battery_max_voltage": 12.6,
+                "sonar": True
+            },
+            "pins": {
+                "led": 25,
+                "motor1": { "pwm": 14, "in_a": 12, "in_b": 13 },
+                "motor2": { "pwm": 15, "in_a": 10, "in_b": 11 },
+                "encoders": { "m1_a": 2, "m1_b": 3, "m2_a": 4, "m2_b": 5 },
+                "i2c": { "sda": 8, "scl": 9 },
+                "battery_pin": 26,
+                "sonar": { "trig": 16, "echo": 17 }
+            }
+        }
+
+    def test_validation_success(self):
+        valid, errors, stats = validate_robot_spec(self.valid_pico_spec)
+        self.assertTrue(valid)
+        self.assertEqual(len(errors), 0)
+        self.assertAlmostEqual(stats["max_linear_speed_m_s"], 0.954, places=2)
+        self.assertIn("max_accel_m_s2", stats)
+
+    def test_pin_conflict_detection(self):
+        bad_spec = dict(self.valid_pico_spec)
+        bad_spec["pins"] = dict(self.valid_pico_spec["pins"])
+        bad_spec["pins"]["motor1"] = { "pwm": 2, "in_a": 12, "in_b": 13 }
+        valid, errors, stats = validate_robot_spec(bad_spec)
+        self.assertFalse(valid)
+        self.assertTrue(any("assigned to multiple functions" in str(e) for e in errors))
+
+    def _esp32_diff_spec(self):
+        """A minimal, otherwise-valid ESP32 differential spec for pin-rule tests."""
+        return {
+            "robot_name": "esp32_bot",
+            "kinematics": "DIFFERENTIAL_DRIVE",
+            "mcu": "ESP32",
+            "transport": "SERIAL",
+            "geometry": {"wheel_diameter": 0.065, "track_width": 0.20, "weight": 3.5},
+            "motors": {"driver_type": "GENERIC_2_IN", "max_rpm": 330, "cpr": 1320,
+                       "rated_torque": 1.5, "rated_voltage": 12.0},
+            "sensors": {"imu": "MPU6050", "mag": "NONE", "battery_monitor": "NONE"},
+            "pins": {
+                "led": 13,
+                "motor1": {"pwm": 25, "in_a": 26, "in_b": 27},
+                "motor2": {"pwm": 32, "in_a": 33, "in_b": 4},
+                "encoders": {"m1_a": 16, "m1_b": 17, "m2_a": 18, "m2_b": 19},
+                "i2c": {"sda": 21, "scl": 22},
+            },
+        }
+
+    def test_esp32_strapping_pin_as_motor_output_warns(self):
+        spec = self._esp32_diff_spec()
+        spec["pins"]["motor1"]["pwm"] = 12  # MTDI strapping pin, driven as PWM output
+        ok, errors, _ = validate_robot_spec(spec)
+        self.assertFalse(ok)  # GPIO 12 as output is an ERROR
+        self.assertTrue(any("GPIO 12" in str(e) and "boot" in str(e).lower() for e in errors))
+
+    def test_esp32_strapping_pin_15_output_is_warning_not_error(self):
+        spec = self._esp32_diff_spec()
+        spec["pins"]["led"] = 15  # strapping pin, but not the flash-voltage one
+        ok, errors, _ = validate_robot_spec(spec)
+        self.assertTrue(ok)
+        self.assertTrue(any("GPIO 15" in str(e) and e.level == "WARNING" for e in errors))
+
+    def test_esp32_input_only_encoder_pullup_warning(self):
+        spec = self._esp32_diff_spec()
+        spec["pins"]["encoders"]["m1_a"] = 34  # input-only, no internal pull-up
+        ok, errors, _ = validate_robot_spec(spec)
+        self.assertTrue(ok)
+        self.assertTrue(any("pull-up" in str(e) for e in errors))
+
+    def test_esp32_adc2_battery_pin_with_wifi_errors(self):
+        spec = self._esp32_diff_spec()
+        spec["transport"] = "WIFI_UDP"
+        spec["sensors"]["battery_monitor"] = "ADC_DIVIDER"
+        spec["pins"]["battery_pin"] = 4  # ADC2 -> unusable with WiFi
+        ok, errors, _ = validate_robot_spec(spec)
+        self.assertFalse(ok)
+        self.assertTrue(any("ADC2" in str(e) for e in errors))
+        # Same pin is fine on serial transport.
+        spec["transport"] = "SERIAL"
+        ok2, errors2, _ = validate_robot_spec(spec)
+        self.assertFalse(any("ADC2" in str(e) for e in errors2))
+
+    def test_header_generation(self):
+        header = generate_config_header(self.valid_pico_spec)
+        self.assertIn("#define LINO_BASE DIFFERENTIAL_DRIVE", header)
+        self.assertIn("#define USE_GENERIC_2_IN_MOTOR_DRIVER", header)
+        self.assertIn("#define USE_MPU6050_IMU", header)
+        self.assertIn("#define BATTERY_CAP 2.2", header)
+        self.assertIn("#define BATTERY_MIN 9", header)
+        self.assertIn("#define BATTERY_MAX 12.6", header)
+        self.assertIn("#define ROBOT_WEIGHT 3.5", header)
+        # Sonar enabled in the fixture (sensors.sonar=True, pins.sonar trig/echo)
+        self.assertIn("#define USE_SONAR", header)
+        self.assertIn("#define TRIG_PIN 16", header)
+        self.assertIn("#define ECHO_PIN 17", header)
+
+    def test_header_parsing_fake_sensors(self):
+        # Sample C++ header with Fake IMU and Fake Mag
+        raw_header = """
+#ifndef TESTBOT_CONFIG_H
+#define TESTBOT_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define WHEEL_DIAMETER 0.0650
+#define LR_WHEELS_DISTANCE 0.2000
+#define USE_BTS7960_MOTOR_DRIVER
+#define MOTOR_MAX_RPM 300
+#define COUNTS_PER_REV1 1320
+#define USE_FAKE_IMU
+#define USE_FAKE_MAG
+#define BAUDRATE 921600
+#endif
+"""
+        parsed = parse_header_to_spec(raw_header)
+        self.assertEqual(parsed["robot_name"], "testbot")
+        self.assertEqual(parsed["kinematics"], "DIFFERENTIAL_DRIVE")
+        self.assertEqual(parsed["motors"]["driver_type"], "BTS7960")
+        self.assertEqual(parsed["sensors"]["imu_type"], "USE_FAKE_IMU")
+        self.assertEqual(parsed["sensors"]["mag_type"], "USE_FAKE_MAG")
+        self.assertEqual(parsed["telemetry"]["baudrate"], 921600)
+
+    def test_negative_led_pin_roundtrip(self):
+        # LED_PIN -1 means "no addressable LED" (e.g. Waveshare GenDrv).
+        # It must parse to int -1 and regenerate as "#define LED_PIN -1".
+        parsed = parse_header_to_spec("#define LED_PIN -1\n")
+        self.assertEqual(parsed["pins"]["led"], -1)
+        header = generate_config_header(parsed)
+        self.assertIn("#define LED_PIN -1", header)
+
+    def test_bts7960_two_output_roundtrip(self):
+        # BTS7960 drives exactly two pins: MOTORx_IN_A (RPWM) and MOTORx_IN_B
+        # (LPWM). MOTORx_PWM is an unused placeholder and must be emitted as -1
+        # with no BOARD_INIT enable-drive lines.
+        spec = json.loads(json.dumps(self.valid_pico_spec))
+        spec["motors"]["driver_type"] = "BTS7960"
+        spec["pins"]["motor1"] = {"in_a": 12, "in_b": 13}
+        spec["pins"]["motor2"] = {"in_a": 10, "in_b": 11}
+        header = generate_config_header(spec)
+        self.assertIn("#define MOTOR1_PWM -1", header)
+        self.assertIn("#define MOTOR1_IN_A 12", header)
+        self.assertIn("#define MOTOR1_IN_B 13", header)
+        self.assertNotIn("pinMode(MOTOR1_PWM", header)
+
+        parsed = parse_header_to_spec(header)
+        self.assertEqual(parsed["motors"]["driver_type"], "BTS7960")
+        self.assertEqual(parsed["pins"]["motor1"]["in_a"], 12)
+        self.assertEqual(parsed["pins"]["motor1"]["in_b"], 13)
+
+        ok, errors, _ = validate_robot_spec(spec)
+        self.assertTrue(ok, errors)
+
+        # A duplicate across the two real outputs is still a conflict.
+        spec["pins"]["motor2"]["in_a"] = 12
+        ok, errors, _ = validate_robot_spec(spec)
+        self.assertFalse(ok)
+
+    def test_negative_encoder_pins_valid(self):
+        # Negative values stand for "no connection" and must not trigger
+        # pin-conflict or out-of-range errors, even when repeated.
+        neg = json.loads(json.dumps(self.valid_pico_spec))
+        neg["pins"] = {
+            "led": 25,
+            "encoders": {
+                "m1_a": -1, "m1_b": -1, "m2_a": -1, "m2_b": -1,
+                "m3_a": -1, "m3_b": -1, "m4_a": -1, "m4_b": -1,
+                "m1_inv": False, "m2_inv": False, "m3_inv": False, "m4_inv": False,
+            },
+            "motor1": {"pwm": 14, "in_a": 12, "in_b": 13},
+            "motor2": {"pwm": 15, "in_a": 10, "in_b": 11},
+            "motor3": {"pwm": -1, "in_a": -1, "in_b": -1},
+            "motor4": {"pwm": -1, "in_a": -1, "in_b": -1},
+            "i2c": {"sda": 4, "scl": 5},
+        }
+        ok, errors, _ = validate_robot_spec(neg)
+        self.assertTrue(ok)
+        self.assertEqual(errors, [])
+
+        # But a genuine positive-pin duplicate must still be an error.
+        neg["pins"]["motor2"]["in_a"] = 14  # duplicates motor1.in_a == 14
+        ok, errors, _ = validate_robot_spec(neg)
+        self.assertFalse(ok)
+        self.assertTrue(any("assigned to multiple functions" in str(e) for e in errors))
+
+    def test_bmp280_env_roundtrip(self):
+        raw = """
+#ifndef ENVBOT_CONFIG_H
+#define ENVBOT_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define USE_BTS7960_MOTOR_DRIVER
+#define USE_BMP280
+#define BMP280_ADDR 0x76
+#define ENV_COV { 1.0, 0.01, 0.0025 }
+#define BAUDRATE 921600
+#endif
+"""
+        spec = parse_header_to_spec(raw)
+        self.assertTrue(spec["sensors"].get("use_bmp280"))
+        self.assertEqual(spec["sensors"].get("env_type"), "BMP280")
+        self.assertEqual(spec["sensors"].get("bmp280_addr"), "0x76")
+        self.assertEqual(spec["imu_tuning"]["env_cov"], [1.0, 0.01, 0.0025])
+
+        h = generate_config_header(spec)
+        self.assertEqual(h.count("#define USE_BMP280"), 1)
+        self.assertIn("#define BMP280_ADDR 0x76", h)
+        self.assertIn("#define ENV_COV { 1, 0.01, 0.0025 }", h)  # _n() trims 1.0 -> 1
+        self.assertEqual(h.count("#define ENV_COV"), 1)
+
+        # From the front-end form shape (sensors.env = "BME280")
+        fe = json.loads(json.dumps(self.valid_pico_spec))
+        fe["sensors"]["env"] = "BME280"
+        h2 = generate_config_header(fe)
+        self.assertIn("#define USE_BMP280", h2)
+
+    def test_modern_imu_roundtrip(self):
+        for imu, macro in (("LSM6DSOX", "USE_LSM6DSOX_IMU"),
+                           ("ICM20948", "USE_ICM20948_IMU")):
+            fe = json.loads(json.dumps(self.valid_pico_spec))
+            fe["sensors"]["imu"] = imu
+            h = generate_config_header(fe)
+            self.assertIn(f"#define {macro}", h)
+
+        # Enabling a known IMU with no explicit covariance -> datasheet default
+        fe = json.loads(json.dumps(self.valid_pico_spec))
+        fe["sensors"]["imu"] = "LSM6DSOX"
+        fe.pop("imu_tuning", None)
+        h = generate_config_header(fe)
+        self.assertIn("#define ACCEL_COV { 4.7e-05, 4.7e-05, 4.7e-05 }", h)
+        self.assertIn("#define GYRO_COV { 4.4e-07, 4.4e-07, 4.4e-07 }", h)
+        # An explicit value still wins over the default.
+        fe["imu_tuning"] = {"accel_cov": 0.02}
+        h = generate_config_header(fe)
+        self.assertIn("#define ACCEL_COV { 0.02, 0.02, 0.02 }", h)
+        self.assertEqual(h.count("#define ACCEL_COV"), 1)
+        raw = ("#ifndef ICMBOT_CONFIG_H\n#define ICMBOT_CONFIG_H\n"
+               "#define USE_ICM20948_IMU\n#define USE_ICM20948_MAG\n#endif\n")
+        spec = parse_header_to_spec(raw)
+        self.assertEqual(spec["sensors"]["imu_type"], "USE_ICM20948_IMU")
+        self.assertEqual(spec["sensors"]["mag_type"], "USE_ICM20948_MAG")
+        h = generate_config_header(spec)
+        self.assertEqual(h.count("#define USE_ICM20948_IMU"), 1)
+        self.assertIn("#define USE_ICM20948_MAG", h)
+
+    def test_pid_magbias_covariance_topicprefix_roundtrip(self):
+        raw = """
+#ifndef TUNEBOT_CONFIG_H
+#define TUNEBOT_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define USE_BTS7960_MOTOR_DRIVER
+#define K_P 0.75
+#define K_I 0.9
+#define K_D 0.42
+#define MAG_BIAS { 12.5, -3.0, 7.25 }
+#define ACCEL_COV { 0.01, 0.01, 0.01 }
+#define GYRO_COV { 0.002, 0.002, 0.002 }
+#define ORI_COV { 0.03, 0.03, 0.03 }
+#define TOPIC_PREFIX "robot1/"
+#define BAUDRATE 921600
+#endif
+"""
+        spec = parse_header_to_spec(raw)
+        self.assertEqual(spec["pid"], {"kp": 0.75, "ki": 0.9, "kd": 0.42})
+        self.assertEqual(spec["imu_tuning"]["mag_bias"], [12.5, -3.0, 7.25])
+        self.assertEqual(spec["imu_tuning"]["accel_cov"], 0.01)
+        self.assertEqual(spec["imu_tuning"]["gyro_cov"], 0.002)
+        self.assertEqual(spec["advanced"]["topic_prefix"], "robot1/")
+
+        h = generate_config_header(spec)
+        self.assertIn("#define K_P 0.75", h)
+        self.assertIn("#define K_I 0.9", h)
+        self.assertIn("#define K_D 0.42", h)
+        self.assertIn("#define MAG_BIAS { 12.5, -3, 7.25 }", h)
+        self.assertIn("#define ACCEL_COV { 0.01, 0.01, 0.01 }", h)
+        self.assertIn("#define GYRO_COV { 0.002, 0.002, 0.002 }", h)
+        self.assertIn('#define TOPIC_PREFIX "robot1/"', h)
+        # exactly one definition of each (no passthrough double-emit)
+        self.assertEqual(h.count("#define ACCEL_COV"), 1)
+        self.assertEqual(h.count("#define TOPIC_PREFIX"), 1)
+        self.assertEqual(h.count("#define K_P"), 1)
+
+    def test_dac_pin_roundtrip_and_mcu_gating(self):
+        # ESP32 header with a non-default DAC pin -> parsed, then re-emitted.
+        raw = """
+#ifndef DACBOT_CONFIG_H
+#define DACBOT_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define USE_BTS7960_MOTOR_DRIVER
+#define BATTERY_PIN 33
+#define DAC_PIN 26
+#define BATTERY_ADJUST(v) ((v) * ((30 + 7.5) / 7.5) / 1000.0)
+#define BAUDRATE 921600
+#endif
+"""
+        spec = parse_header_to_spec(raw)
+        self.assertEqual(spec["sensors"].get("dac_pin"), 26)
+        self.assertEqual(spec["pins"].get("dac_pin"), 26)
+        spec["mcu"] = "ESP32"
+        h = generate_config_header(spec)
+        self.assertIn("#define DAC_PIN 26", h)
+        self.assertEqual(h.count("#define DAC_PIN"), 1)
+
+        # Same spec on a DAC-less MCU (Pico) -> DAC_PIN must NOT be emitted.
+        pico = json.loads(json.dumps(self.valid_pico_spec))
+        pico["pins"]["dac_pin"] = 25
+        hp = generate_config_header(pico)
+        self.assertNotIn("#define DAC_PIN", hp)
+
+        # ESP32 form-shape spec with a DAC pin -> emitted.
+        esp = json.loads(json.dumps(self.valid_pico_spec))
+        esp["mcu"] = "ESP32"
+        esp["pins"]["dac_pin"] = 25
+        he = generate_config_header(esp)
+        self.assertIn("#define DAC_PIN 25", he)
+
+    def test_adc_lut_roundtrip_and_merge_preserves_it(self):
+        # A previously-calibrated header with a short LUT (real ones are
+        # always 4096 entries; a short one exercises the same regex/format).
+        raw = """
+#ifndef LUTBOT_CONFIG_H
+#define LUTBOT_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define BATTERY_PIN 33
+#define DAC_PIN 25
+#define USE_ADC_LUT
+const int16_t ADC_LUT[4096] = {
+    0, 50, 53, 57, 60, 64, 65, 66,
+    3959, 3967
+};
+#define BAUDRATE 921600
+#endif
+"""
+        spec = parse_header_to_spec(raw)
+        self.assertEqual(spec["sensors"].get("adc_lut"),
+                          [0, 50, 53, 57, 60, 64, 65, 66, 3959, 3967])
+
+        spec["mcu"] = "ESP32"
+        h = generate_config_header(spec)
+        self.assertIn("#define USE_ADC_LUT", h)
+        self.assertIn("const int16_t ADC_LUT[4096] = {", h)
+        self.assertIn("ADC_LUT[v]", h)   # LUT-linearized BATTERY_ADJUST
+        self.assertEqual(h.count("#define USE_ADC_LUT"), 1)
+
+        # merge_configurations: an overlay that doesn't touch sensors.adc_lut
+        # must NOT drop the calibrated LUT already on disk.
+        overlay_no_lut = {"sensors": {"battery_min_voltage": 9.5}}
+        merged, _ = merge_configurations(spec, overlay_no_lut)
+        self.assertEqual(merged["sensors"]["adc_lut"], spec["sensors"]["adc_lut"])
+        self.assertEqual(merged["sensors"]["battery_min_voltage"], 9.5)
+
+        # An overlay that DOES set a new LUT (e.g. a fresh calibration run)
+        # replaces the old one — overlay wins, per merge_configurations.
+        overlay_new_lut = {"sensors": {"adc_lut": [1, 2, 3]}}
+        merged3, changes = merge_configurations(spec, overlay_new_lut)
+        self.assertEqual(merged3["sensors"]["adc_lut"], [1, 2, 3])
+        self.assertTrue(any(c["field"] == "sensors.adc_lut" for c in changes))
+
+    def test_adc_lut_wins_over_stale_raw_battery_adjust(self):
+        # Regression: a header this generator wrote WITHOUT a LUT (e.g. the
+        # config-sync that runs at the start of an adc_calibrate upload,
+        # before the sweep has produced anything yet) contains a literal
+        # #define BATTERY_ADJUST(...). A re-parse can't tell that apart from
+        # a hand-written override, so it lands in raw_defines — which used to
+        # make the "only emit BATTERY_ADJUST if raw_defines doesn't already
+        # have one" guard block a LATER regenerate (the auto-commit that
+        # follows a completed sweep) from ever emitting the LUT-based
+        # formula, silently dropping the whole calibration. The LUT must win
+        # unconditionally once it exists, and BATTERY_ADJUST must appear only
+        # once (not doubled by the raw_defines passthrough).
+        raw = """
+#ifndef PRELUT_CONFIG_H
+#define PRELUT_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define BATTERY_PIN 33
+#define DAC_PIN 25
+#define BATTERY_ADJUST(v) ((v) * ((30 + 7.5) / 7.5) / 1000.0)
+#define BAUDRATE 921600
+#endif
+"""
+        base = parse_header_to_spec(raw)
+        self.assertTrue(any(d.get("name") == "BATTERY_ADJUST" for d in base.get("raw_defines", [])))
+
+        overlay = {"sensors": {"battery_monitor": "ADC_DIVIDER", "adc_lut": list(range(4096))}, "mcu": "ESP32"}
+        merged, _ = merge_configurations(base, overlay)
+        h = generate_config_header(merged)
+        self.assertEqual(h.count("#define BATTERY_ADJUST"), 1)
+        self.assertIn("#define USE_ADC_LUT", h)
+        self.assertIn("ADC_LUT[v]", h)   # the LUT-linearized formula, not the plain one
+
+    def test_ina219_form_shape_emits_use_ina219(self):
+        # Regression, found running a real GenDrv Full Deploy through the web
+        # UI: generator.py checked only sensors.use_ina219 (a boolean parser.py
+        # sets when it parses an existing #define USE_INA219). The web-UI form
+        # (readSpecFromForm()) only ever sets sensors.battery_monitor to the
+        # string "INA219" — never that boolean — so a brand-new robot (i2c
+        # auto-detect having just set battery_monitor="INA219" in the form,
+        # nothing on disk yet to merge with) silently got NO #define USE_INA219
+        # at all, and /battery never appeared on the robot.
+        overlay = {
+            "robot_name": "gendrv_test", "mcu": "GENDRV", "kinematics": "DIFFERENTIAL_DRIVE",
+            "motors": {"driver_type": "BTS7960", "max_rpm": 150, "cpr": 900},
+            "geometry": {"wheel_diameter": 0.056, "track_width": 0.224, "weight": 2},
+            "sensors": {"battery_monitor": "INA219", "sonar": False},
+        }
+        h = generate_config_header(overlay)
+        self.assertIn("#define USE_INA219", h)
+
+        # And parser.py now sets the same form-shape key when it parses one
+        # back, so a later merge treats it as the SAME field (overlay wins),
+        # not two differently-named copies that silently diverge.
+        raw = "#ifndef X_H\n#define X_H\n#define LINO_BASE DIFFERENTIAL_DRIVE\n#define USE_INA219\n#define BAUDRATE 921600\n#endif\n"
+        parsed = parse_header_to_spec(raw)
+        self.assertTrue(parsed["sensors"]["use_ina219"])
+        self.assertEqual(parsed["sensors"]["battery_monitor"], "INA219")
+
+    def test_merge_overlay_wins_over_parsed_battery_fields(self):
+        # Regression: parser.py used to store BATTERY_MIN/MAX/CAP and the
+        # divider resistors under different key names than the web-UI form
+        # overlay uses (battery_min vs. battery_min_voltage, etc). Because
+        # merge_configurations() does a deep key-merge, that mismatch meant
+        # an overlay's new value landed under its own key while the OLD
+        # value stayed live under the base's key — and generator.py's
+        # fallback chain checked the stale key first, so the overlay's
+        # change was silently dropped. This locks in that the same key is
+        # used both ways, so a merge genuinely overwrites.
+        raw = """
+#ifndef VOLTBOT_CONFIG_H
+#define VOLTBOT_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define BATTERY_PIN 33
+#define BATTERY_MIN 9
+#define BAUDRATE 921600
+#endif
+"""
+        base = parse_header_to_spec(raw)
+        self.assertEqual(base["sensors"]["battery_min_voltage"], 9.0)
+        self.assertEqual(base["sensors"]["battery_r1"], 30000.0)
+        self.assertEqual(base["sensors"]["battery_r2"], 7500.0)
+
+        # Overlay changes the min-cutoff voltage (form field name) — must win.
+        overlay = {"sensors": {"battery_min_voltage": 7.5}}
+        merged, changes = merge_configurations(base, overlay)
+        self.assertEqual(merged["sensors"]["battery_min_voltage"], 7.5)
+        self.assertFalse("battery_min" in merged["sensors"])  # no stale duplicate key
+
+        base["mcu"] = "ESP32"
+        merged["mcu"] = "ESP32"
+        h_before = generate_config_header(base)
+        h_after = generate_config_header(merged)
+        self.assertIn("#define BATTERY_MIN 9", h_before)
+        self.assertIn("#define BATTERY_MIN 7.5", h_after)
+        self.assertNotIn("#define BATTERY_MIN 9", h_after)
+
+    def test_user_modify_and_merge_workflow(self):
+        # 1. User starts with an existing header (Fake IMU/Mag)
+        raw_header = """
+#ifndef MYROBOT_CONFIG_H
+#define MYROBOT_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define WHEEL_DIAMETER 0.0800
+#define LR_WHEELS_DISTANCE 0.2200
+#define USE_GENERIC_2_IN_MOTOR_DRIVER
+#define MOTOR_MAX_RPM 330
+#define COUNTS_PER_REV1 1440
+#define USE_FAKE_IMU
+#define USE_FAKE_MAG
+#define BAUDRATE 921600
+#endif
+"""
+        base_spec = parse_header_to_spec(raw_header)
+        self.assertEqual(base_spec["sensors"]["imu_type"], "USE_FAKE_IMU")
+
+        # 2. User modifies settings in Web UI: adds QMI8658 IMU, AK09918 Mag, Sonar, and Dual-Core
+        modified_settings = {
+            "sensors": {
+                "imu_type": "USE_QMI8658_IMU",
+                "mag_type": "USE_AK09918_MAG",
+                "sonar_trig": 19,
+                "sonar_echo": 18
+            },
+            "telemetry": {
+                "use_dual_core": True,
+                "baudrate": 921600
+            }
+        }
+
+        merged_spec, changes = merge_configurations(base_spec, modified_settings)
+        self.assertGreater(len(changes), 0)
+
+        # 3. Generate merged C++ header
+        updated_header = generate_config_header(merged_spec)
+        self.assertIn("#define USE_QMI8658_IMU", updated_header)
+        self.assertIn("#define USE_AK09918_MAG", updated_header)
+        self.assertIn("#define TRIG_PIN 19", updated_header)
+        self.assertIn("#define ECHO_PIN 18", updated_header)
+        self.assertIn("#define USE_DUAL_CORE", updated_header)
+        self.assertNotIn("#define USE_FAKE_IMU", updated_header)
+        self.assertNotIn("#define USE_FAKE_MAG", updated_header)
+
+    def test_imu_mag_form_shape_wins_on_merge(self):
+        # Regression, same key-mismatch class as INA219/battery/sonar: the
+        # real web-UI form (readSpecFromForm()) only ever sets the form-shape
+        # sensors.imu / sensors.mag (short names, e.g. "QMI8658") — never the
+        # parser-shape sensors.imu_type / sensors.mag_type. A base spec
+        # parsed from an existing FAKE_IMU/FAKE_MAG header always carries a
+        # non-null imu_type/mag_type placeholder, so a form-shape-only
+        # overlay was previously silently ignored on merge.
+        raw = """
+#ifndef X_CONFIG_H
+#define X_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define USE_GENERIC_2_IN_MOTOR_DRIVER
+#define USE_FAKE_IMU
+#define USE_FAKE_MAG
+#define BAUDRATE 921600
+#endif
+"""
+        base = parse_header_to_spec(raw)
+        overlay = {"sensors": {"imu": "QMI8658", "mag": "AK09918"}}
+        merged, changes = merge_configurations(base, overlay)
+        self.assertGreater(len(changes), 0)
+        header = generate_config_header(merged)
+        self.assertIn("#define USE_QMI8658_IMU", header)
+        self.assertIn("#define USE_AK09918_MAG", header)
+        self.assertNotIn("#define USE_FAKE_IMU", header)
+        self.assertNotIn("#define USE_FAKE_MAG", header)
+
+    def test_i2c_pins_form_shape_wins_on_merge(self):
+        # Regression, same key-mismatch class: the web-UI form always sets
+        # pins.i2c.sda / pins.i2c.scl, never sensors.i2c_sda / i2c_scl. A
+        # base spec parsed from an existing header carries the latter, and
+        # generator.py used to check it first, so a fresh i2c pin choice
+        # from the form was silently dropped on merge.
+        raw = """
+#ifndef X_CONFIG_H
+#define X_CONFIG_H
+#define LINO_BASE DIFFERENTIAL_DRIVE
+#define USE_GENERIC_2_IN_MOTOR_DRIVER
+#define SDA_PIN 21
+#define SCL_PIN 22
+#define BAUDRATE 921600
+#endif
+"""
+        base = parse_header_to_spec(raw)
+        overlay = {"pins": {"i2c": {"sda": 32, "scl": 33}}}
+        merged, changes = merge_configurations(base, overlay)
+        header = generate_config_header(merged)
+        self.assertIn("#define SDA_PIN 32", header)
+        self.assertIn("#define SCL_PIN 33", header)
+
+
+    def test_agent_port_parse_output_free(self):
+        import sys
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "web"))
+        from server import _parse_port_check_output
+        raw = """---FUSER---
+---CONTAINERS---
+---PROCESSES---
+"""
+        res = {"status": "ok", "in_use": False, "pids": [], "holder_type": "none"}
+        out = _parse_port_check_output(raw, "/dev/ttyUSB0", "serial", 8888, res)
+        self.assertFalse(out["in_use"])
+        self.assertEqual(out["holder_type"], "none")
+
+    def test_agent_port_parse_output_container(self):
+        import sys
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "web"))
+        from server import _parse_port_check_output
+        raw = """---FUSER---
+---CONTAINERS---
+e4d82a17cb21|uros_agent_serial|microros/micro-ros-agent:jazzy|micro_ros_agent serial --dev /dev/ttyUSB0 -b 921600
+---PROCESSES---
+"""
+        res = {"status": "ok", "in_use": False, "pids": [], "holder_type": "none"}
+        out = _parse_port_check_output(raw, "/dev/ttyUSB0", "serial", 8888, res)
+        self.assertTrue(out["in_use"])
+        self.assertEqual(out["holder_type"], "container")
+        self.assertEqual(out["container_name"], "uros_agent_serial")
+        self.assertTrue(out["is_microros"])
+
+    def test_agent_port_parse_output_process(self):
+        import sys
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "web"))
+        from server import _parse_port_check_output
+        raw = """---FUSER---
+54321 /dev/ttyUSB0:
+---CONTAINERS---
+---PROCESSES---
+54321 ros2 run micro_ros_agent micro_ros_agent serial --dev /dev/ttyUSB0
+"""
+        res = {"status": "ok", "in_use": False, "pids": [], "holder_type": "none"}
+        out = _parse_port_check_output(raw, "/dev/ttyUSB0", "serial", 8888, res)
+        self.assertTrue(out["in_use"])
+        self.assertEqual(out["holder_type"], "process")
+        self.assertIn("54321", out["pids"])
+        self.assertTrue(out["is_microros"])
+
+    def test_agent_port_parse_output_udp(self):
+        import sys
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "web"))
+        from server import _parse_port_check_output
+        raw = """---FUSER---
+98765 8888/udp:
+---CONTAINERS---
+---PROCESSES---
+98765 python3 -m micro_ros
+"""
+        res = {"status": "ok", "in_use": False, "pids": [], "holder_type": "none"}
+        out = _parse_port_check_output(raw, "/dev/ttyUSB0", "udp", 8888, res)
+        self.assertTrue(out["in_use"])
+        self.assertEqual(out["holder_type"], "process")
+        self.assertIn("98765", out["pids"])
+
+    def test_workflow_settings_persistence(self):
+        import sys
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "web"))
+        from server import load_workflow_settings, save_workflow_settings, WORKFLOW_SETTINGS_PATH
+        saved = save_workflow_settings({"ros_distro": "rolling", "build_engine": "podman"})
+        self.assertEqual(saved["ros_distro"], "rolling")
+        self.assertEqual(saved["build_engine"], "podman")
+        loaded = load_workflow_settings()
+        self.assertEqual(loaded["ros_distro"], "rolling")
+        self.assertEqual(loaded["build_engine"], "podman")
+        # Clean up
+        if os.path.exists(WORKFLOW_SETTINGS_PATH):
+            try:
+                os.remove(WORKFLOW_SETTINGS_PATH)
+            except Exception:
+                pass
+
+    def test_rootless_info(self):
+        import sys
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "web"))
+        from server import get_rootless_info
+        info = get_rootless_info()
+        self.assertEqual(info["status"], "ok")
+        self.assertIn("commands", info)
+        self.assertIn("ubuntu_debian", info["commands"])
+
+    def test_container_install_and_rootless_setup(self):
+        res_d = server.install_container_engine("docker")
+        self.assertIn("status", res_d)
+        self.assertIn("installed", res_d)
+        self.assertEqual(res_d["engine"], "docker")
+
+        res_p = server.install_container_engine("podman")
+        self.assertIn("status", res_p)
+        self.assertIn("installed", res_p)
+        self.assertEqual(res_p["engine"], "podman")
+
+        res_rootless = server.setup_rootless_docker()
+        self.assertIn("status", res_rootless)
+        self.assertIn("is_rootless", res_rootless)
+
+
+    def test_docker_builder_and_agent_deploy_script(self):
+        # Verify Dockerfile.builder exists
+        df_path = os.path.join(os.path.dirname(__file__), "docker", "Dockerfile.builder")
+        self.assertTrue(os.path.exists(df_path), "Dockerfile.builder must exist in docker/")
+        with open(df_path, "r", encoding="utf-8") as f:
+            df_content = f.read()
+        self.assertIn("platformio", df_content)
+
+        # Verify app.js deploy script generation rules for containerized workflow
+        app_js_path = os.path.join(os.path.dirname(__file__), "web", "app.js")
+        with open(app_js_path, "r", encoding="utf-8") as f:
+            app_js = f.read()
+        self.assertIn("Containerized micro-ROS Agent selected", app_js)
+        self.assertIn("linorobot2-builder:latest", app_js)
+        self.assertIn("microros/micro-ros-agent", app_js)
+
+    def test_configurable_container_registry(self):
+        # 1. Check default workflow settings in server.py
+        self.assertIn("container_registry", server.DEFAULT_WORKFLOW_SETTINGS)
+        self.assertEqual(server.DEFAULT_WORKFLOW_SETTINGS["container_registry"], "auto")
+
+        # 2. Check UI elements in index.html
+        html_path = os.path.join(os.path.dirname(__file__), "web", "index.html")
+        with open(html_path, "r", encoding="utf-8") as f:
+            html = f.read()
+        self.assertIn('id="hdr-container-registry"', html)
+        self.assertIn('id="cfg-container-registry"', html)
+        self.assertIn('id="hdr-custom-registry"', html)
+
+        # 3. Check app.js configurable probe generator
+        app_js_path = os.path.join(os.path.dirname(__file__), "web", "app.js")
+        with open(app_js_path, "r", encoding="utf-8") as f:
+            app_js = f.read()
+        self.assertIn("buildRegistryProbeList", app_js)
+        self.assertIn("containerRegistry", app_js)
+
+
+class TestFakeWheelMode(unittest.TestCase):
+    """Fake wheel mode: the checkbox has to reach the generated header."""
+
+    BASE = {
+        "robot_name": "sim", "kinematics": "DIFFERENTIAL_DRIVE", "mcu": "ESP32",
+        "geometry": {"wheel_diameter": 0.065, "track_width": 0.20, "weight": 3.5},
+        "motors": {}, "sensors": {}, "pins": {},
+    }
+
+    def _header(self, simulation=None, lidar_rxd=None, lidar_udp=False):
+        """lidar_rxd / lidar_udp give the simulated scan a route off the board.
+        Without one the emulator is deliberately left disabled, so any test that
+        expects USE_FAKE_LD19 has to supply one."""
+        spec = dict(self.BASE)
+        if simulation is not None:
+            spec["simulation"] = simulation
+        if lidar_rxd is not None:
+            spec["pins"] = dict(spec.get("pins") or {}, lidar_rxd=lidar_rxd)
+        if lidar_udp:
+            spec["telemetry"] = dict(spec.get("telemetry") or {}, use_lidar_udp=True)
+        return generate_config_header(spec)
+
+    def test_unchecked_emits_nothing(self):
+        self.assertNotIn("USE_FAKE_WHEEL", self._header())
+        self.assertNotIn("USE_FAKE_WHEEL", self._header({"fake_wheel": False}))
+
+    def test_checked_emits_define(self):
+        self.assertIn("#define USE_FAKE_WHEEL", self._header({"fake_wheel": True}))
+
+    def test_tuning_values_are_optional(self):
+        self.assertNotIn("FAKE_ROBOT_MASS", self._header({"fake_wheel": True}))
+        tuned = self._header({"fake_wheel": True, "robot_mass": 6.0, "wheel_noise_rpm": 1.5})
+        self.assertIn("#define FAKE_ROBOT_MASS 6", tuned)
+        self.assertIn("#define FAKE_WHEEL_NOISE_RPM 1.5", tuned)
+
+    def test_robot_weight_is_emitted_for_the_simulated_mass(self):
+        # with no explicit mass, the firmware falls back to ROBOT_WEIGHT
+        self.assertIn("#define ROBOT_WEIGHT 3.5", self._header({"fake_wheel": True}))
+
+    def test_round_trips_through_the_parser(self):
+        header = self._header({"fake_wheel": True, "robot_mass": 6.0, "wheel_noise_rpm": 1.5})
+        sim = parse_header_to_spec(header)["simulation"]
+        self.assertTrue(sim["fake_wheel"])
+        self.assertEqual(sim["robot_mass"], 6.0)
+        self.assertEqual(sim["wheel_noise_rpm"], 1.5)
+
+    def test_commented_sample_is_not_parsed_as_enabled(self):
+        # lino_base_config.h ships the options commented out
+        self.assertNotIn("simulation", parse_header_to_spec("// #define USE_FAKE_WHEEL\n"))
+
+
+    def test_fake_ld19_emits_define_and_geometry(self):
+        sim_spec = {
+            "fake_ld19": True,
+            "map_width": 8.0,
+            "map_height": 5.0,
+            "wall_obstacle": True,
+            "wall_x1": 1.2,
+            "wall_y1": -0.5,
+            "wall_x2": 1.2,
+            "wall_y2": 0.5
+        }
+        header = self._header(sim_spec, lidar_rxd=4)
+        self.assertIn("#define USE_FAKE_LD19", header)
+        self.assertIn("#define LIDAR_RXD 4", header)
+        self.assertIn("#define FAKE_MAP_WIDTH 8.0f", header)
+        self.assertIn("#define FAKE_MAP_HEIGHT 5.0f", header)
+        self.assertIn("#define FAKE_WALL_OBSTACLE 1", header)
+        self.assertIn("#define FAKE_WALL_X1 1.20f", header)
+
+    def test_fake_ld19_round_trips_through_parser(self):
+        sim_spec = {
+            "fake_wheel": True,
+            "fake_ld19": True,
+            "map_width": 6.0,
+            "map_height": 4.0,
+            "wall_obstacle": True,
+            "wall_x1": 1.0,
+            "wall_y1": -0.8,
+            "wall_x2": 1.0,
+            "wall_y2": 0.8
+        }
+        header = self._header(sim_spec, lidar_rxd=4)
+        parsed = parse_header_to_spec(header)["simulation"]
+        self.assertTrue(parsed["fake_wheel"])
+        self.assertTrue(parsed["fake_ld19"])
+        self.assertEqual(parsed["map_width"], 6.0)
+        self.assertEqual(parsed["map_height"], 4.0)
+        self.assertTrue(parsed["wall_obstacle"])
+        self.assertEqual(parsed["wall_x1"], 1.0)
+        self.assertEqual(parsed["wall_y1"], -0.8)
+        self.assertEqual(parsed["wall_x2"], 1.0)
+        self.assertEqual(parsed["wall_y2"], 0.8)
+
+
+
+class TestSimulationDefaultsAndWarning(unittest.TestCase):
+    """Reference designs ship simulated, and a simulated header must say so."""
+
+    BASE = {
+        "robot_name": "sim", "kinematics": "DIFFERENTIAL_DRIVE", "mcu": "ESP32",
+        "geometry": {"wheel_diameter": 0.065, "track_width": 0.20, "weight": 3.5},
+        "motors": {}, "sensors": {}, "pins": {},
+    }
+
+    def _header(self, **over):
+        spec = dict(self.BASE)
+        spec.update(over)
+        return generate_config_header(spec)
+
+    def test_warning_present_for_fake_wheel(self):
+        self.assertIn("SIMULATION MODE IS ENABLED", self._header(simulation={"fake_wheel": True}))
+
+    def test_warning_present_for_fake_lidar_alone(self):
+        # a real drivetrain with a simulated scan still is not a real robot config
+        self.assertIn("SIMULATION MODE IS ENABLED", self._header(simulation={"fake_ld19": True}))
+
+    def test_no_warning_on_a_real_robot_config(self):
+        self.assertNotIn("SIMULATION MODE IS ENABLED", self._header())
+        self.assertNotIn("SIMULATION MODE IS ENABLED", self._header(simulation={"fake_wheel": False}))
+
+    def test_warning_precedes_the_defines_it_refers_to(self):
+        header = self._header(simulation={"fake_wheel": True, "fake_ld19": True})
+        self.assertLess(header.index("SIMULATION MODE IS ENABLED"),
+                        header.index("#define USE_FAKE_WHEEL"))
+
+    def test_simulated_wifi_design_emits_lidar_udp(self):
+        # the esp32_wifi_ld19 reference design relays the simulated scan over UDP
+        header = self._header(transport="WIFI_UDP",
+                              wifi_settings={"ssid": "S", "password": "P",
+                                             "agent_ip": "192.168.1.100", "agent_port": 8888},
+                              telemetry={"transport": "WIFI_UDP", "use_lidar_udp": True},
+                              simulation={"fake_wheel": True, "fake_ld19": True})
+        self.assertIn("#define USE_FAKE_LD19", header)
+        # the header carries the switch; the address lives in the secrets file
+        self.assertIn("#define USE_LIDAR_UDP", header)
+
+    def test_fake_lidar_emits_its_output_pin(self):
+        # without LIDAR_RXD the firmware starts the emulator with tx_pin -1 and
+        # transmits nothing: it builds, the board looks fine, no scan appears
+        header = self._header(simulation={"fake_ld19": True}, pins={"lidar_rxd": 4})
+        self.assertIn("#define USE_FAKE_LD19", header)
+        self.assertIn("#define LIDAR_RXD 4", header)
+
+    def test_fake_lidar_pin_is_emitted_for_serial_transport_too(self):
+        # it used to be emitted only on the WiFi + LiDAR-UDP path
+        header = self._header(transport="SERIAL", simulation={"fake_ld19": True},
+                              pins={"lidar_rxd": 4})
+        self.assertIn("#define LIDAR_RXD 4", header)
+
+    def test_serial_design_defines_a_lidar_pin_and_udp_design_does_not(self):
+        # the scan leaves over the LiDAR UART on the serial design, and over
+        # WiFi UDP on the other -- where no UART pin is involved at all
+        here = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(here, "web", "app.js")) as f:
+            app_js = f.read()
+        import re
+
+        def design_body(key):
+            # bound at the next preset key or the end of the PRESETS object,
+            # since the last entry closes differently from the others
+            body = app_js.split(key + ": {", 1)[1]
+            end = re.search(r"\n  \},|\n  \}\n\};", body)
+            return body[:end.start()] if end else body
+
+        # an actual assignment, not a mention of the name in a comment
+        assigned = lambda body: re.search(r"^\s*lidar_rxd:\s*-?\d", body, re.M) is not None
+
+        serial_design = design_body("gendrv_serial_ld19")
+        self.assertTrue(assigned(serial_design), "serial design needs a LiDAR UART pin")
+
+        udp_design = design_body("esp32_wifi_ld19")
+        self.assertFalse(assigned(udp_design),
+                         "UDP design must not pin a UART: the scan goes over WiFi")
+        self.assertIn("use_lidar_udp: true", udp_design)
+
+    def test_warns_when_a_simulated_scan_has_nowhere_to_go(self):
+        spec = {
+            "robot_name": "s", "kinematics": "DIFFERENTIAL_DRIVE", "mcu": "ESP32",
+            "geometry": {"wheel_diameter": 0.065, "track_width": 0.20},
+            "motors": {}, "sensors": {}, "pins": {},
+            "simulation": {"fake_ld19": True},
+        }
+        _, errors, _ = validate_robot_spec(spec)
+        msgs = " ".join(e.message for e in errors if e.level == "WARNING")
+        self.assertIn("left DISABLED", msgs)
+        self.assertIn("no route off the board", msgs)
+
+    def test_no_warning_when_the_scan_goes_out_over_udp(self):
+        spec = {
+            "robot_name": "s", "kinematics": "DIFFERENTIAL_DRIVE", "mcu": "ESP32",
+            "geometry": {"wheel_diameter": 0.065, "track_width": 0.20},
+            "motors": {}, "sensors": {}, "pins": {},
+            "telemetry": {"transport": "WIFI_UDP", "use_lidar_udp": True},
+            "simulation": {"fake_ld19": True},
+        }
+        _, errors, _ = validate_robot_spec(spec)
+        self.assertNotIn("nowhere to go", " ".join(e.message for e in errors))
+
+    def test_no_warning_when_a_lidar_pin_is_set(self):
+        spec = {
+            "robot_name": "s", "kinematics": "DIFFERENTIAL_DRIVE", "mcu": "GENDRV",
+            "geometry": {"wheel_diameter": 0.065, "track_width": 0.20},
+            "motors": {}, "sensors": {}, "pins": {"lidar_rxd": 4},
+            "simulation": {"fake_ld19": True},
+        }
+        _, errors, _ = validate_robot_spec(spec)
+        self.assertNotIn("nowhere to go", " ".join(e.message for e in errors))
+
+
+
+class TestReferenceDesignsAreSimulated(unittest.TestCase):
+    """Every reference design in the studio starts in fake wheel mode, and the
+    two simulation-first designs exist. Parsed out of app.js, which is where
+    the presets live."""
+
+    @classmethod
+    def setUpClass(cls):
+        here = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(here, "web", "app.js")) as f:
+            cls.app_js = f.read()
+
+    def test_simulation_designs_exist(self):
+        self.assertIn("gendrv_serial_ld19:", self.app_js)
+        self.assertIn("esp32_wifi_ld19:", self.app_js)
+
+    def test_simulation_designs_are_selectable(self):
+        here = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(here, "web", "index.html")) as f:
+            html = f.read()
+        self.assertIn('value="gendrv_serial_ld19"', html)
+        self.assertIn('value="esp32_wifi_ld19"', html)
+
+    def test_every_preset_defaults_to_fake_wheel(self):
+        # the normalization loop applies it to all presets, so it cannot be
+        # forgotten when a new design is added
+        self.assertIn("p.simulation = Object.assign({ fake_wheel: true }, p.simulation || {});",
+                      self.app_js)
+
+    def test_simulation_designs_keep_their_own_pinout(self):
+        # fake wheels are driven by the PID's PWM, but the design still needs a
+        # coherent pinout rather than the all -1 bare map
+        self.assertIn("const PINNED_PRESETS =", self.app_js)
+        for key in ("gendrv_serial_ld19", "esp32_wifi_ld19"):
+            self.assertIn(f'"{key}"', self.app_js.split("const PINNED_PRESETS =")[1][:200])
+
+    def test_new_module_defaults_to_simulation(self):
+        self.assertIn("function defaultSimulationForDetectedModule", self.app_js)
+        self.assertIn("defaultSimulationForDetectedModule(guessed.chipName);", self.app_js)
+
+    def test_user_choice_is_not_overridden(self):
+        self.assertIn("if (userTouchedSimulation) return;", self.app_js)
+
+
+class TestDualCoreAndSimulation(unittest.TestCase):
+    """The dual-core control task and simulation mode must never both reach the
+    header. The fake LiDAR drives the simulated pose and its UART from the loop
+    while the control task drives the same pose from the other core with no lock
+    between them, and the board crash-loops -- a failure that only shows up on
+    hardware, as a reconnect storm, long after the config was generated."""
+
+    BASE = {
+        "robot_name": "sim", "kinematics": "DIFFERENTIAL_DRIVE", "mcu": "ESP32",
+        "geometry": {"wheel_diameter": 0.065, "track_width": 0.20, "weight": 3.5},
+        "motors": {}, "sensors": {}, "pins": {},
+    }
+
+    def _header(self, dual_core, simulation=None, lidar_rxd=4):
+        spec = dict(self.BASE)
+        spec["telemetry"] = {"use_dual_core": dual_core}
+        if simulation is not None:
+            spec["simulation"] = simulation
+        # give the scan a route, or the emulator is left disabled on purpose
+        spec["pins"] = dict(spec.get("pins") or {}, lidar_rxd=lidar_rxd)
+        return generate_config_header(spec)
+
+    def test_dual_core_emitted_on_a_real_robot(self):
+        self.assertIn("#define USE_DUAL_CORE", self._header(True))
+
+    def test_dual_core_absent_when_not_asked_for(self):
+        self.assertNotIn("USE_DUAL_CORE", self._header(False))
+
+    def test_simulation_suppresses_dual_core(self):
+        for sim in ({"fake_wheel": True}, {"fake_ld19": True},
+                    {"fake_wheel": True, "fake_ld19": True}):
+            with self.subTest(sim=sim):
+                self.assertNotIn("USE_DUAL_CORE", self._header(True, sim))
+
+    def test_fake_sonar_and_safety_stop_default_on_with_the_lidar(self):
+        """The range comes from the same raycast as the scan, so it costs no
+        pins -- a simulated robot should get the protection a real one has."""
+        header = self._header(False, {"fake_wheel": True, "fake_ld19": True})
+        self.assertIn("#define USE_FAKE_SONAR", header)
+        self.assertIn("#define USE_SAFETY_STOP", header)
+
+    def test_fake_sonar_can_be_turned_off(self):
+        header = self._header(
+            False, {"fake_wheel": True, "fake_ld19": True, "fake_sonar": False})
+        self.assertNotIn("USE_FAKE_SONAR", header)
+        self.assertNotIn("USE_SAFETY_STOP", header)
+
+    def test_no_sonar_without_the_fake_lidar(self):
+        """The cone is raycast against the simulated room; with no room there is
+        nothing to measure."""
+        self.assertNotIn("USE_FAKE_SONAR", self._header(False, {"fake_wheel": True}))
+
+
+class TestReferenceDesignsAreExplicit(unittest.TestCase):
+    """The simulated reference designs must state their own settings. Relying on
+    the form defaults is how gendrv_serial_ld19 came to ship a 6x4 m room after
+    the default grew to 16x12, and a LIDAR_RXD of -1 that silenced the scan."""
+
+    @classmethod
+    def setUpClass(cls):
+        here = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(here, "web", "app.js")) as f:
+            cls.app_js = f.read()
+
+    def _preset(self, name):
+        body = self.app_js.split(f"{name}: {{", 1)[1]
+        # up to the start of the next top-level preset, which is enough context
+        return body[:2500]
+
+    def _preset_code(self, name):
+        """Preset body with // comments removed, so an assertion about a key
+        cannot be satisfied (or defeated) by prose mentioning it."""
+        return "\n".join(
+            line.split("//", 1)[0] for line in self._preset(name).splitlines())
+
+    def test_simulated_designs_disable_dual_core(self):
+        for name in ("gendrv_serial_ld19", "esp32_wifi_ld19"):
+            with self.subTest(design=name):
+                self.assertIn("dual_core: false", self._preset(name))
+
+    def test_simulated_designs_pin_their_room(self):
+        for name in ("gendrv_serial_ld19", "esp32_wifi_ld19"):
+            with self.subTest(design=name):
+                body = self._preset(name)
+                self.assertIn("map_width: 10.0", body)
+                self.assertIn("map_height: 6.0", body)
+                self.assertIn("fake_sonar: true", body)
+
+    def test_serial_design_declares_its_wired_lidar_pin(self):
+        """IO4 is wired to the LiDAR data line on the reference gendrv, so the
+        design names it and the scan has a route out. A board without that wire
+        sets -1, and TestFakeLd19NeedsARouteOffTheBoard covers what then
+        happens: the emulator is left disabled rather than writing into a pad."""
+        self.assertIn("lidar_rxd: 4", self._preset_code("gendrv_serial_ld19"))
+
+    def test_udp_design_has_no_lidar_pin_at_all(self):
+        """It ships the scan over WiFi, so the pin is not merely unset -- the
+        design has no business naming one."""
+        self.assertNotIn("lidar_rxd", self._preset_code("esp32_wifi_ld19"))
+
+
+class TestFakeLd19NeedsARouteOffTheBoard(unittest.TestCase):
+    """The emulated scan leaves over the LiDAR UART pin or over WiFi UDP. With
+    neither, the emulator is not enabled at all: it would burn the control loop
+    building packets and writing them into an unconnected pad while the board
+    reported success and no scan ever reached ROS. On a stock board nothing is
+    wired to that pin, so unset is the honest default."""
+
+    BASE = {
+        "robot_name": "sim", "kinematics": "DIFFERENTIAL_DRIVE", "mcu": "ESP32",
+        "geometry": {"wheel_diameter": 0.065, "track_width": 0.20, "weight": 3.5},
+        "motors": {}, "sensors": {},
+    }
+
+    def _header(self, pins=None, telemetry=None):
+        spec = dict(self.BASE)
+        spec["simulation"] = {"fake_wheel": True, "fake_ld19": True}
+        spec["pins"] = pins or {}
+        spec["telemetry"] = telemetry or {}
+        return generate_config_header(spec)
+
+    def test_disabled_when_nothing_carries_the_scan(self):
+        header = self._header()
+        self.assertNotIn("#define USE_FAKE_LD19", header)
+        self.assertNotIn("#define LIDAR_RXD", header)
+        self.assertIn("NOT enabled", header)
+
+    def test_disabled_when_the_pin_is_explicitly_unwired(self):
+        self.assertNotIn("#define USE_FAKE_LD19", self._header(pins={"lidar_rxd": -1}))
+
+    def test_enabled_once_the_pin_is_wired(self):
+        header = self._header(pins={"lidar_rxd": 4})
+        self.assertIn("#define USE_FAKE_LD19", header)
+        self.assertIn("#define LIDAR_RXD 4", header)
+
+    def test_enabled_over_udp_without_any_pin(self):
+        header = self._header(telemetry={"use_lidar_udp": True})
+        self.assertIn("#define USE_FAKE_LD19", header)
+        self.assertNotIn("#define LIDAR_RXD", header)
+
+    def test_fake_wheel_survives_a_disabled_lidar(self):
+        """Losing the scan must not cost the drivetrain simulation, which is
+        what makes a bare module drivable in the first place."""
+        self.assertIn("#define USE_FAKE_WHEEL", self._header())
+
+
+class TestContainerRegistryIsAPreference(unittest.TestCase):
+    """The registry is a user setting, never a hardcoded host: a LAN or cluster
+    registry is site specific, so there is no default to ship."""
+
+    @classmethod
+    def setUpClass(cls):
+        here = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(here, "web", "app.js")) as f:
+            cls.app_js = f.read()
+
+    def test_no_registry_host_is_hardcoded(self):
+        """A bare registry hostname in the source would override the user's
+        choice on every machine that runs the studio."""
+        for host in ("registry-1632", ".ts.net", "localhost:5000"):
+            with self.subTest(host=host):
+                self.assertNotIn(host, self.app_js)
+
+    def test_agent_image_goes_through_the_preference(self):
+        self.assertIn("function configuredRegistryHosts", self.app_js)
+        self.assertIn("_resolve_agent_img", self.app_js)
+
+    def test_agent_image_no_longer_pulls_docker_hub_directly(self):
+        """Every containerised agent path must resolve the image first."""
+        self.assertNotIn('podman pull "$IMG"', self.app_js)
+        self.assertNotIn('$_DK pull "$IMG"', self.app_js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/robot_config_engine/validator.py
+++ b/tools/robot_config_engine/validator.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 Thomas Chou, Paul Bouchier, Linorobot contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Linorobot2 Hardware Rule Validator
+Validates robot hardware configurations against electrical and MCU-specific constraints.
+"""
+
+import math
+from typing import Dict, List, Tuple, Any
+
+ESP32_STRAPPING_PINS = {0, 2, 12, 14, 15}
+ESP32_INPUT_ONLY_PINS = {34, 35, 36, 39}
+ESP32_FLASH_PINS = {6, 7, 8, 9, 10, 11}
+ESP32S3_STRAPPING_PINS = {0, 3, 45, 46}
+RP2040_ADC_PINS = {26, 27, 28, 29}
+
+
+class ValidationError:
+    def __init__(self, level: str, field: str, message: str):
+        self.level = level  # "ERROR" or "WARNING"
+        self.field = field
+        self.message = message
+
+    def __str__(self):
+        return f"[{self.level}] {self.field}: {self.message}"
+
+
+def validate_robot_spec(spec: Dict[str, Any]) -> Tuple[bool, List[ValidationError], Dict[str, Any]]:
+    errors: List[ValidationError] = []
+    stats: Dict[str, Any] = {}
+
+    robot_name = spec.get("robot_name", "unnamed_robot")
+    mcu = spec.get("mcu", "").upper()
+    kinematics = spec.get("kinematics", "")
+    geometry = spec.get("geometry", {})
+    motors = spec.get("motors", {})
+    pins = spec.get("pins", {})
+    sensors = spec.get("sensors", {})
+
+    # 1. Physics & Kinematics Calculations
+    wheel_d = geometry.get("wheel_diameter", 0.0)
+    track_w = geometry.get("track_width", 0.0)
+    max_rpm = motors.get("max_rpm", 0.0)
+    cpr = motors.get("cpr", 0.0)
+    weight_kg = geometry.get("weight", 0.0)
+    torque_kg_cm = motors.get("rated_torque", 0.0)
+    num_motors = 2 if kinematics == "DIFFERENTIAL_DRIVE" else 4
+
+    if wheel_d <= 0:
+        errors.append(ValidationError("ERROR", "geometry.wheel_diameter", "Wheel diameter must be positive (> 0 m)"))
+    if track_w <= 0:
+        errors.append(ValidationError("ERROR", "geometry.track_width", "Track width must be positive (> 0 m)"))
+    if max_rpm <= 0:
+        errors.append(ValidationError("ERROR", "motors.max_rpm", "Max motor RPM must be positive (> 0)"))
+    if cpr <= 0:
+        errors.append(ValidationError("ERROR", "motors.cpr", "Encoder CPR must be positive (> 0)"))
+
+    if wheel_d > 0 and max_rpm > 0 and cpr > 0:
+        wheel_circ = math.pi * wheel_d
+        max_linear_speed = (wheel_circ * max_rpm / 60.0) * 0.85  # 85% PID headroom
+        max_angular_speed = (2.0 * max_linear_speed) / track_w if track_w > 0 else 0.0
+        ticks_per_meter = cpr / wheel_circ
+
+        stats["wheel_circumference_m"] = round(wheel_circ, 4)
+        stats["max_linear_speed_m_s"] = round(max_linear_speed, 3)
+        stats["max_angular_speed_rad_s"] = round(max_angular_speed, 3)
+        stats["ticks_per_meter"] = round(ticks_per_meter, 1)
+
+        # Acceleration Estimation if weight and torque are provided
+        if weight_kg > 0 and torque_kg_cm > 0:
+            torque_nm = torque_kg_cm * 0.0980665
+            wheel_r = wheel_d / 2.0
+            total_thrust_n = (num_motors * torque_nm) / wheel_r
+            max_accel = total_thrust_n / weight_kg
+            stats["total_thrust_n"] = round(total_thrust_n, 2)
+            stats["max_accel_m_s2"] = round(max_accel, 2)
+
+    # 2. Pin Conflict Detection (No single pin assigned twice)
+    assigned_pins: Dict[int, List[str]] = {}
+
+    def register_pin(pin: Any, name: str, is_output: bool = False):
+        if pin is None or not isinstance(pin, int):
+            return
+        # A negative value means "no connection / pin not assigned" — skip
+        # conflict detection and MCU-specific GPIO range checks.
+        if pin < 0:
+            return
+        if pin not in assigned_pins:
+            assigned_pins[pin] = []
+        assigned_pins[pin].append(name)
+
+        # Check MCU Specific Constraints
+        if mcu in ["ESP32", "GENDRV"]:
+            if pin in ESP32_FLASH_PINS:
+                errors.append(ValidationError("ERROR", name, f"GPIO {pin} is connected to internal SPI Flash! Strictly forbidden."))
+            if is_output and pin in ESP32_INPUT_ONLY_PINS:
+                errors.append(ValidationError("ERROR", name, f"GPIO {pin} is an INPUT-ONLY pin and cannot output PWM/DIR signals!"))
+            if not is_output and pin in ESP32_STRAPPING_PINS:
+                errors.append(ValidationError("WARNING", name, f"GPIO {pin} is an ESP32 strapping pin. Connecting encoders may cause boot failures if pulled LOW at power-on."))
+        elif mcu == "ESP32S3":
+            if not is_output and pin in ESP32S3_STRAPPING_PINS:
+                errors.append(ValidationError("WARNING", name, f"GPIO {pin} is an ESP32-S3 strapping pin."))
+        elif mcu in ["PICO", "PICO2", "PICOW", "PICO2W"]:
+            if pin < 0 or pin > 29:
+                errors.append(ValidationError("ERROR", name, f"GP{pin} is out of range for RP2040/RP2350 (0-29)."))
+            if mcu in ["PICOW", "PICO2W"] and pin in {23, 24, 25, 29}:
+                errors.append(ValidationError("WARNING", name, f"GP{pin} is connected to the CYW43439 WiFi chip on Pico W / Pico 2 W."))
+
+    # Register motor pins
+    driver_type = motors.get("driver_type", "")
+
+    for i in range(1, num_motors + 1):
+        m_pins = pins.get(f"motor{i}", {})
+        if driver_type == "BTS7960":
+            register_pin(m_pins.get("pwm_r"), f"motor{i}.pwm_r", is_output=True)
+            register_pin(m_pins.get("pwm_l"), f"motor{i}.pwm_l", is_output=True)
+            register_pin(m_pins.get("en"), f"motor{i}.en", is_output=True)
+        elif driver_type == "GENERIC_2_IN":
+            register_pin(m_pins.get("pwm"), f"motor{i}.pwm", is_output=True)
+            register_pin(m_pins.get("in_a"), f"motor{i}.in_a", is_output=True)
+            register_pin(m_pins.get("in_b"), f"motor{i}.in_b", is_output=True)
+        elif driver_type == "GENERIC_1_IN":
+            register_pin(m_pins.get("pwm"), f"motor{i}.pwm", is_output=True)
+            register_pin(m_pins.get("dir"), f"motor{i}.dir", is_output=True)
+
+    # Register encoder pins
+    enc_pins = pins.get("encoders", {})
+    for i in range(1, num_motors + 1):
+        register_pin(enc_pins.get(f"m{i}_a"), f"encoders.m{i}_a", is_output=False)
+        register_pin(enc_pins.get(f"m{i}_b"), f"encoders.m{i}_b", is_output=False)
+
+    # Register I2C pins
+    i2c = pins.get("i2c", {})
+    register_pin(i2c.get("sda"), "i2c.sda", is_output=False)
+    register_pin(i2c.get("scl"), "i2c.scl", is_output=False)
+
+    # Register LED pin
+    register_pin(pins.get("led"), "pins.led", is_output=True)
+
+    # Register Battery ADC pin
+    if sensors.get("battery_monitor") == "ADC_DIVIDER":
+        bat_pin = pins.get("battery_pin")
+        register_pin(bat_pin, "pins.battery_pin", is_output=False)
+        if mcu in ["PICO", "PICO2", "PICOW", "PICO2W"] and bat_pin is not None and bat_pin not in RP2040_ADC_PINS:
+            errors.append(ValidationError("ERROR", "pins.battery_pin", f"GP{bat_pin} is not an analog ADC pin on RP2040/RP2350 (Must be GP26, GP27, or GP28)."))
+
+        r1 = float(sensors.get("battery_r1", 30000.0))
+        r2 = float(sensors.get("battery_r2", 7500.0))
+        max_v = float(sensors.get("battery_max_voltage", 12.6))
+        if r1 > 0 and r2 > 0 and max_v > 0:
+            adc_max_v = max_v * (r2 / (r1 + r2))
+            stats["adc_voltage_max_v"] = round(adc_max_v, 3)
+            stats["adc_divider_ratio"] = round(r2 / (r1 + r2), 4)
+            if adc_max_v > 3.0:
+                errors.append(ValidationError("WARNING", "sensors.battery_r2", f"ADC input voltage will reach {adc_max_v:.2f}V at {max_v:.1f}V battery charge, exceeding the recommended 3.0V limit! Increase R1 or decrease R2."))
+
+    # Register Sonar pins
+    if sensors.get("sonar", False):
+        sonar = pins.get("sonar", {})
+        register_pin(sonar.get("trig"), "sonar.trig", is_output=True)
+        register_pin(sonar.get("echo"), "sonar.echo", is_output=False)
+
+    # Watchdog validation
+    wdt = spec.get("watchdog", {})
+    if isinstance(wdt, dict) and wdt.get("enabled", False):
+        to = wdt.get("timeout_sec", 60)
+        if not (1 <= to <= 300):
+            errors.append(ValidationError("WARNING", "watchdog.timeout_sec", f"Watchdog timeout {to}s is out of recommended range (1 to 300 seconds)."))
+
+    # Check for duplicate pin assignments
+    for pin_num, pin_usages in assigned_pins.items():
+        if len(pin_usages) > 1:
+            errors.append(ValidationError("ERROR", "pins", f"Pin {pin_num} is assigned to multiple functions: {', '.join(pin_usages)}"))
+
+    is_valid = not any(e.level == "ERROR" for e in errors)
+    return is_valid, errors, stats

--- a/tools/robot_config_engine/validator.py
+++ b/tools/robot_config_engine/validator.py
@@ -124,9 +124,11 @@ def validate_robot_spec(spec: Dict[str, Any]) -> Tuple[bool, List[ValidationErro
     for i in range(1, num_motors + 1):
         m_pins = pins.get(f"motor{i}", {})
         if driver_type == "BTS7960":
-            register_pin(m_pins.get("pwm_r"), f"motor{i}.pwm_r", is_output=True)
-            register_pin(m_pins.get("pwm_l"), f"motor{i}.pwm_l", is_output=True)
-            register_pin(m_pins.get("en"), f"motor{i}.en", is_output=True)
+            # Two outputs only: RPWM -> IN_A, LPWM -> IN_B (accept legacy pwm_l/en).
+            in_a = m_pins["in_a"] if "in_a" in m_pins else m_pins.get("pwm_l")
+            in_b = m_pins["in_b"] if "in_b" in m_pins else m_pins.get("en")
+            register_pin(in_a, f"motor{i}.in_a", is_output=True)
+            register_pin(in_b, f"motor{i}.in_b", is_output=True)
         elif driver_type == "GENERIC_2_IN":
             register_pin(m_pins.get("pwm"), f"motor{i}.pwm", is_output=True)
             register_pin(m_pins.get("in_a"), f"motor{i}.in_a", is_output=True)

--- a/tools/robot_config_engine/validator.py
+++ b/tools/robot_config_engine/validator.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2026 Thomas Chou, Paul Bouchier, Linorobot contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Linorobot2 Hardware Rule Validator
+Validates robot hardware configurations against electrical and MCU-specific constraints.
+"""
+
+import math
+from typing import Dict, List, Tuple, Any
+
+ESP32_STRAPPING_PINS = {0, 2, 12, 14, 15}
+ESP32_INPUT_ONLY_PINS = {34, 35, 36, 39}
+ESP32_FLASH_PINS = {6, 7, 8, 9, 10, 11}
+ESP32S3_STRAPPING_PINS = {0, 3, 45, 46}
+RP2040_ADC_PINS = {26, 27, 28, 29}
+# ESP32 ADC2 channels: unusable for analogRead() while WiFi is active.
+ESP32_ADC2_PINS = {0, 2, 4, 12, 13, 14, 15, 25, 26, 27}
+
+
+class ValidationError:
+    def __init__(self, level: str, field: str, message: str):
+        self.level = level  # "ERROR" or "WARNING"
+        self.field = field
+        self.message = message
+
+    def __str__(self):
+        return f"[{self.level}] {self.field}: {self.message}"
+
+
+def validate_robot_spec(spec: Dict[str, Any]) -> Tuple[bool, List[ValidationError], Dict[str, Any]]:
+    errors: List[ValidationError] = []
+    stats: Dict[str, Any] = {}
+
+    simulation = spec.get("simulation") or {}
+    if simulation.get("fake_ld19"):
+        # The emulator reaches ROS either over the LiDAR UART or over WiFi UDP.
+        # With neither, the firmware still builds and the board looks healthy,
+        # but it starts with no output pin and no scan ever arrives.
+        _tele = spec.get("telemetry") or {}
+        _over_udp = bool(_tele.get("use_lidar_udp"))
+        _pin = (spec.get("pins") or {}).get("lidar_rxd")
+        if _pin is None:
+            _pin = (spec.get("advanced") or {}).get("lidar_rxd")
+        if not _over_udp and (_pin is None or int(_pin) < 0):
+            errors.append(ValidationError(
+                "WARNING", "simulation.fake_ld19",
+                "Fake LD19 is requested with no LiDAR UDP and no pins.lidar_rxd, "
+                "so it has been left DISABLED: the simulated scan would have no "
+                "route off the board. Any LiDAR route over the serial pin needs "
+                "a physical wire -- fake LD19 over serial transmits the emulated "
+                "scan on that pin, and a real LD19 (even when forwarded over UDP) "
+                "must be wired into it, because UDP only carries what the board "
+                "receives. The one option needing no wire is fake LD19 over WiFi "
+                "UDP, where the scan is generated on the board and sent straight "
+                "over the network. So either turn on LiDAR over WiFi UDP, or wire "
+                "the board's LiDAR UART pin (IO4 on a gendrv) and set "
+                "pins.lidar_rxd to it."))
+
+    robot_name = spec.get("robot_name", "unnamed_robot")
+    mcu = spec.get("mcu", "").upper()
+    kinematics = spec.get("kinematics", "")
+    geometry = spec.get("geometry", {})
+    motors = spec.get("motors", {})
+    pins = spec.get("pins", {})
+    sensors = spec.get("sensors", {})
+
+    # 1. Physics & Kinematics Calculations
+    wheel_d = geometry.get("wheel_diameter", 0.0)
+    track_w = geometry.get("track_width", 0.0)
+    max_rpm = motors.get("max_rpm", 0.0)
+    cpr = motors.get("cpr", 0.0)
+    weight_kg = geometry.get("weight", 0.0)
+    torque_kg_cm = motors.get("rated_torque", 0.0)
+    num_motors = 2 if kinematics == "DIFFERENTIAL_DRIVE" else 4
+
+    if wheel_d <= 0:
+        errors.append(ValidationError("ERROR", "geometry.wheel_diameter", "Wheel diameter must be positive (> 0 m)"))
+    if track_w <= 0:
+        errors.append(ValidationError("ERROR", "geometry.track_width", "Track width must be positive (> 0 m)"))
+    if max_rpm <= 0:
+        errors.append(ValidationError("ERROR", "motors.max_rpm", "Max motor RPM must be positive (> 0)"))
+    if cpr <= 0:
+        errors.append(ValidationError("ERROR", "motors.cpr", "Encoder CPR must be positive (> 0)"))
+
+    if wheel_d > 0 and max_rpm > 0 and cpr > 0:
+        wheel_circ = math.pi * wheel_d
+        max_linear_speed = (wheel_circ * max_rpm / 60.0) * 0.85  # 85% PID headroom
+        max_angular_speed = (2.0 * max_linear_speed) / track_w if track_w > 0 else 0.0
+        ticks_per_meter = cpr / wheel_circ
+
+        stats["wheel_circumference_m"] = round(wheel_circ, 4)
+        stats["max_linear_speed_m_s"] = round(max_linear_speed, 3)
+        stats["max_angular_speed_rad_s"] = round(max_angular_speed, 3)
+        stats["ticks_per_meter"] = round(ticks_per_meter, 1)
+
+        # Acceleration Estimation if weight and torque are provided
+        if weight_kg > 0 and torque_kg_cm > 0:
+            torque_nm = torque_kg_cm * 0.0980665
+            wheel_r = wheel_d / 2.0
+            total_thrust_n = (num_motors * torque_nm) / wheel_r
+            max_accel = total_thrust_n / weight_kg
+            stats["total_thrust_n"] = round(total_thrust_n, 2)
+            stats["max_accel_m_s2"] = round(max_accel, 2)
+
+    # 2. Pin Conflict Detection (No single pin assigned twice)
+    assigned_pins: Dict[int, List[str]] = {}
+
+    def register_pin(pin: Any, name: str, is_output: bool = False):
+        if pin is None or not isinstance(pin, int):
+            return
+        # A negative value means "no connection / pin not assigned" — skip
+        # conflict detection and MCU-specific GPIO range checks.
+        if pin < 0:
+            return
+        if pin not in assigned_pins:
+            assigned_pins[pin] = []
+        assigned_pins[pin].append(name)
+
+        # Check MCU Specific Constraints
+        if mcu in ["ESP32", "GENDRV"]:
+            if pin in ESP32_FLASH_PINS:
+                errors.append(ValidationError("ERROR", name, f"GPIO {pin} is connected to internal SPI Flash! Strictly forbidden."))
+            if is_output and pin in ESP32_INPUT_ONLY_PINS:
+                errors.append(ValidationError("ERROR", name, f"GPIO {pin} is an INPUT-ONLY pin and cannot output PWM/DIR signals!"))
+            if not is_output and pin in ESP32_INPUT_ONLY_PINS:
+                errors.append(ValidationError("WARNING", name, f"GPIO {pin} has no internal pull-up/pull-down; an encoder channel here needs an external pull-up resistor."))
+            if pin in ESP32_STRAPPING_PINS:
+                if pin == 12:
+                    errors.append(ValidationError("ERROR" if is_output else "WARNING", name, f"GPIO 12 (MTDI) is an ESP32 strapping pin that selects flash voltage at boot. Driving it{' as an output' if is_output else ''} can prevent the board from booting."))
+                elif is_output:
+                    errors.append(ValidationError("WARNING", name, f"GPIO {pin} is an ESP32 strapping pin; a driver/LED wired here can hold it at the wrong level during power-on and block boot. Add a series resistor or move the signal."))
+                else:
+                    errors.append(ValidationError("WARNING", name, f"GPIO {pin} is an ESP32 strapping pin. Connecting encoders may cause boot failures if pulled LOW at power-on."))
+        elif mcu == "ESP32S3":
+            if is_output and pin in ESP32S3_STRAPPING_PINS:
+                errors.append(ValidationError("WARNING", name, f"GPIO {pin} is an ESP32-S3 strapping pin; an output wired here can block boot if held at the wrong level at power-on."))
+            elif not is_output and pin in ESP32S3_STRAPPING_PINS:
+                errors.append(ValidationError("WARNING", name, f"GPIO {pin} is an ESP32-S3 strapping pin."))
+        elif mcu in ["PICO", "PICO2", "PICOW", "PICO2W"]:
+            if pin < 0 or pin > 29:
+                errors.append(ValidationError("ERROR", name, f"GP{pin} is out of range for RP2040/RP2350 (0-29)."))
+            if mcu in ["PICOW", "PICO2W"] and pin in {23, 24, 25, 29}:
+                errors.append(ValidationError("WARNING", name, f"GP{pin} is connected to the CYW43439 WiFi chip on Pico W / Pico 2 W."))
+
+    # Register motor pins
+    driver_type = motors.get("driver_type", "")
+
+    for i in range(1, num_motors + 1):
+        m_pins = pins.get(f"motor{i}", {})
+        if driver_type == "BTS7960":
+            # Two outputs only: RPWM -> IN_A, LPWM -> IN_B (accept legacy pwm_l/en).
+            in_a = m_pins["in_a"] if "in_a" in m_pins else m_pins.get("pwm_l")
+            in_b = m_pins["in_b"] if "in_b" in m_pins else m_pins.get("en")
+            register_pin(in_a, f"motor{i}.in_a", is_output=True)
+            register_pin(in_b, f"motor{i}.in_b", is_output=True)
+        elif driver_type == "GENERIC_2_IN":
+            register_pin(m_pins.get("pwm"), f"motor{i}.pwm", is_output=True)
+            register_pin(m_pins.get("in_a"), f"motor{i}.in_a", is_output=True)
+            register_pin(m_pins.get("in_b"), f"motor{i}.in_b", is_output=True)
+        elif driver_type == "GENERIC_1_IN":
+            register_pin(m_pins.get("pwm"), f"motor{i}.pwm", is_output=True)
+            register_pin(m_pins.get("dir"), f"motor{i}.dir", is_output=True)
+
+    # Register encoder pins
+    enc_pins = pins.get("encoders", {})
+    for i in range(1, num_motors + 1):
+        register_pin(enc_pins.get(f"m{i}_a"), f"encoders.m{i}_a", is_output=False)
+        register_pin(enc_pins.get(f"m{i}_b"), f"encoders.m{i}_b", is_output=False)
+
+    # Register I2C pins
+    i2c = pins.get("i2c", {})
+    register_pin(i2c.get("sda"), "i2c.sda", is_output=False)
+    register_pin(i2c.get("scl"), "i2c.scl", is_output=False)
+
+    # Register LED pin
+    register_pin(pins.get("led"), "pins.led", is_output=True)
+
+    telemetry = spec.get("telemetry", {})
+    use_wifi = bool(
+        telemetry.get("use_wifi")
+        or "WIFI" in str(spec.get("transport", "")).upper()
+        or "WIFI" in str(telemetry.get("transport", "")).upper()
+        or "UDP" in str(spec.get("transport", "")).upper()
+    )
+
+    # Register Battery ADC pin
+    if sensors.get("battery_monitor") == "ADC_DIVIDER":
+        bat_pin = pins.get("battery_pin")
+        register_pin(bat_pin, "pins.battery_pin", is_output=False)
+        if mcu in ["PICO", "PICO2", "PICOW", "PICO2W"] and bat_pin is not None and bat_pin not in RP2040_ADC_PINS:
+            errors.append(ValidationError("ERROR", "pins.battery_pin", f"GP{bat_pin} is not an analog ADC pin on RP2040/RP2350 (Must be GP26, GP27, or GP28)."))
+        if mcu in ["ESP32", "GENDRV"] and use_wifi and isinstance(bat_pin, int) and bat_pin in ESP32_ADC2_PINS:
+            errors.append(ValidationError("ERROR", "pins.battery_pin", f"GPIO {bat_pin} is on ADC2, which analogRead() cannot use while WiFi is active. Move the battery sense wire to an ADC1 pin (GPIO 32-39)."))
+
+        r1 = float(sensors.get("battery_r1", 30000.0))
+        r2 = float(sensors.get("battery_r2", 7500.0))
+        max_v = float(sensors.get("battery_max_voltage", 12.6))
+        if r1 > 0 and r2 > 0 and max_v > 0:
+            adc_max_v = max_v * (r2 / (r1 + r2))
+            stats["adc_voltage_max_v"] = round(adc_max_v, 3)
+            stats["adc_divider_ratio"] = round(r2 / (r1 + r2), 4)
+            if adc_max_v > 3.0:
+                errors.append(ValidationError("WARNING", "sensors.battery_r2", f"ADC input voltage will reach {adc_max_v:.2f}V at {max_v:.1f}V battery charge, exceeding the recommended 3.0V limit! Increase R1 or decrease R2."))
+
+    # Register Sonar pins
+    if sensors.get("sonar", False):
+        sonar = pins.get("sonar", {})
+        register_pin(sonar.get("trig"), "sonar.trig", is_output=True)
+        register_pin(sonar.get("echo"), "sonar.echo", is_output=False)
+
+    # Watchdog validation
+    wdt = spec.get("watchdog", {})
+    if isinstance(wdt, dict) and wdt.get("enabled", False):
+        to = wdt.get("timeout_sec", 60)
+        if not (1 <= to <= 300):
+            errors.append(ValidationError("WARNING", "watchdog.timeout_sec", f"Watchdog timeout {to}s is out of recommended range (1 to 300 seconds)."))
+
+    # Check for duplicate pin assignments
+    for pin_num, pin_usages in assigned_pins.items():
+        if len(pin_usages) > 1:
+            errors.append(ValidationError("ERROR", "pins", f"Pin {pin_num} is assigned to multiple functions: {', '.join(pin_usages)}"))
+
+    is_valid = not any(e.level == "ERROR" for e in errors)
+    return is_valid, errors, stats

--- a/tools/robot_config_engine/web/app.js
+++ b/tools/robot_config_engine/web/app.js
@@ -1,0 +1,5085 @@
+// Hardware USB MCU Classifier & Auto-detection Engine
+function guessMcuFromUsbDetail(detail) {
+  if (!detail) return null;
+  const vid = (detail.vid || "").toLowerCase();
+  const pid = (detail.pid || "").toLowerCase();
+  const chip = (detail.chip || "").toLowerCase();
+  const product = (detail.product || "").toLowerCase();
+  const mfr = (detail.manufacturer || "").toLowerCase();
+
+  // Raspberry Pi (VID 2e8a): distinguish RP2350 (Pico 2) from RP2040 (Pico) by
+  // USB PID / product string — BOOTSEL is only a mode label, never the deciding
+  // factor (a Pico 2 in BOOTSEL is 2e8a:000f, still an RP2350).
+  if (vid === "2e8a" || chip.includes("rp204") || chip.includes("rp235") || product.includes("pico")) {
+    const isPico2 = ["000f", "0005", "0009"].includes(pid)
+      || chip.includes("rp2350") || chip.includes("pico 2") || product.includes("pico 2");
+    const bootsel = !!detail.is_bootsel;
+    return isPico2
+      ? { mcu: "PICO2", baudrate: 921600, preset: "bare", isBootsel: bootsel,
+          chipName: "Raspberry Pi Pico 2 (RP2350)" + (bootsel ? " [BOOTSEL Mode]" : "") }
+      : { mcu: "PICO", baudrate: 921600, preset: "bare", isBootsel: bootsel,
+          chipName: "Raspberry Pi Pico (RP2040)" + (bootsel ? " [BOOTSEL Mode]" : "") };
+  }
+  if (vid === "303a" || chip.includes("esp32-s3") || product.includes("esp32-s3")) {
+    return { mcu: "ESP32S3", baudrate: 921600, chipName: "ESP32-S3 (Native USB CDC)", preset: "bare" };
+  }
+  if (chip.includes("gendrv") || product.includes("general driver") || (chip.includes("cp2102") && mfr.includes("silicon"))) {
+    return { mcu: "ESP32", baudrate: 921600, chipName: "ESP32 DevKit (CP2102N)", preset: "bare" };
+  }
+  if (chip.includes("esp32") || chip.includes("cp210") || chip.includes("ch340") || chip.includes("ftdi")) {
+    return { mcu: "ESP32", baudrate: 921600, chipName: "ESP32 Microcontroller", preset: "bare" };
+  }
+  return null;
+}
+
+/**
+ * Linorobot2 Robot Configuration Engine - Client-Side App Logic
+ * Pure JavaScript - 100% Client-Side Safe, Zero-Dependency
+ */
+
+// When a board is auto-detected, propose a unique robot name postfixed with
+// the MCU family (e.g. rover_esp32s3) — but never overwrite a name the user
+// deliberately typed or picked. Returns null when the current name looks
+// intentional.
+function proposeMcuRobotName(mcu) {
+  const el = document.getElementById("cfg-robot-name");
+  if (!el || !mcu) return null;
+  const cur = (el.value || "").trim().toLowerCase();
+  let presetNames = [];
+  try { presetNames = Object.values(PRESETS || {}).map(p => p && p.robot_name).filter(Boolean); } catch (e) {}
+  const replaceable = new Set(["", "my_robot", "robot", "scout_pico2", ...presetNames]);
+  if (!replaceable.has(cur) && !/^rover_[a-z0-9]+(_\d+)?$/.test(cur)) return null;
+  const base = `rover_${String(mcu).toLowerCase().replace(/[^a-z0-9]/g, "")}`;
+  const taken = new Set((typeof existingConfigsList !== "undefined" ? existingConfigsList : [])
+    .map(c => String(c.filename || "").replace(/_config\.h$/, "")));
+  if (!taken.has(base)) return base;
+  for (let i = 2; i < 50; i++) if (!taken.has(`${base}_${i}`)) return `${base}_${i}`;
+  return base;
+}
+
+function applyMcuRobotName(mcu) {
+  const name = proposeMcuRobotName(mcu);
+  if (!name) return;
+  const el = document.getElementById("cfg-robot-name");
+  el.value = name;
+  el.dispatchEvent(new Event("input"));
+}
+
+// MCU Pin Constraints Constants
+const ESP32_STRAPPING_PINS = [0, 2, 12, 14, 15];
+const ESP32_INPUT_ONLY_PINS = [34, 35, 36, 39];
+const ESP32_FLASH_PINS = [6, 7, 8, 9, 10, 11];
+const ESP32S3_STRAPPING_PINS = [0, 3, 45, 46];
+const RP2040_ADC_PINS = [26, 27, 28, 29];
+
+// Reference Build Presets
+const PRESETS = {
+  // Bare module: nothing wired. Every pin is -1 ("no connection") so the
+  // firmware never drives a line that might be connected to an external
+  // peripheral — including the I2C bus (see firmware.ino: SDA_PIN/SCL_PIN < 0
+  // skips Wire.begin()). This is the initial state.
+  bare: {
+    robot_name: "bare_module", kinematics: "DIFFERENTIAL_DRIVE", mcu: "PICO2", transport: "SERIAL",
+    geometry: { wheel_diameter: 0.065, track_width: 0.20, wheelbase: 0.15, weight: 2.5 },
+    motors: { driver_type: "BTS7960", max_rpm: 330, cpr: 1320, operating_voltage: 12.0,
+              motor1_inv: false, motor2_inv: true, motor3_inv: false, motor4_inv: true },
+    sensors: { imu: "FAKE", mag: "NONE", battery_monitor: "NONE", sonar: false },
+    pins: {
+      led: -1,
+      motor1: { pwm: -1, in_a: -1, in_b: -1, pwm_r: -1, pwm_l: -1, en: -1, dir: -1 },
+      motor2: { pwm: -1, in_a: -1, in_b: -1, pwm_r: -1, pwm_l: -1, en: -1, dir: -1 },
+      motor3: { pwm: -1, in_a: -1, in_b: -1, pwm_r: -1, pwm_l: -1, en: -1, dir: -1 },
+      motor4: { pwm: -1, in_a: -1, in_b: -1, pwm_r: -1, pwm_l: -1, en: -1, dir: -1 },
+      encoders: { m1_a: -1, m1_b: -1, m2_a: -1, m2_b: -1, m3_a: -1, m3_b: -1, m4_a: -1, m4_b: -1 },
+      i2c: { sda: -1, scl: -1 }, battery_pin: -1, sonar: { trig: -1, echo: -1 }
+    }
+  },
+  pico2_diff: {
+    robot_name: "pico2_diff", kinematics: "DIFFERENTIAL_DRIVE", mcu: "PICO2", transport: "SERIAL",
+    geometry: { wheel_diameter: 0.065, track_width: 0.20, wheelbase: 0.15, weight: 2.5 },
+    motors: { driver_type: "BTS7960", max_rpm: 330, cpr: 1320, operating_voltage: 12.0,
+              motor1_inv: false, motor2_inv: true, motor3_inv: false, motor4_inv: true },
+    sensors: { imu: "FAKE", mag: "NONE", battery_monitor: "NONE", sonar: false },
+    pins: {
+      led: 25,
+      motor1: { pwm_r: 10, pwm_l: 11, en: 12 }, motor2: { pwm_r: 13, pwm_l: 14, en: 15 },
+      encoders: { m1_a: 2, m1_b: 3, m2_a: 4, m2_b: 5 },
+      i2c: { sda: 0, scl: 1 }, battery_pin: 26, sonar: { trig: 22, echo: 27 }
+    }
+  },
+  pico2_mecanum: {
+    robot_name: "pico2_mecanum", kinematics: "MECANUM", mcu: "PICO2", transport: "SERIAL",
+    geometry: { wheel_diameter: 0.08, track_width: 0.26, wheelbase: 0.22, weight: 4.0 },
+    motors: { driver_type: "BTS7960", max_rpm: 330, cpr: 1440, operating_voltage: 12.0,
+              motor1_inv: false, motor2_inv: true, motor3_inv: false, motor4_inv: true },
+    sensors: { imu: "FAKE", mag: "NONE", battery_monitor: "NONE", sonar: false },
+    pins: {
+      led: 25,
+      motor1: { pwm_r: 6, pwm_l: 7, en: 8 }, motor2: { pwm_r: 9, pwm_l: 10, en: 11 },
+      motor3: { pwm_r: 12, pwm_l: 13, en: 14 }, motor4: { pwm_r: 15, pwm_l: 16, en: 17 },
+      encoders: { m1_a: 0, m1_b: 1, m2_a: 2, m2_b: 3, m3_a: 4, m3_b: 5, m4_a: 18, m4_b: 19 },
+      i2c: { sda: 20, scl: 21 }, battery_pin: 26, sonar: { trig: 22, echo: 27 }
+    }
+  },
+  pico2_skid: {
+    robot_name: "pico2_skid", kinematics: "SKID_STEER", mcu: "PICO2", transport: "SERIAL",
+    geometry: { wheel_diameter: 0.08, track_width: 0.24, wheelbase: 0.20, weight: 4.0 },
+    motors: { driver_type: "BTS7960", max_rpm: 330, cpr: 1440, operating_voltage: 12.0,
+              motor1_inv: false, motor2_inv: true, motor3_inv: false, motor4_inv: true },
+    sensors: { imu: "FAKE", mag: "NONE", battery_monitor: "NONE", sonar: false },
+    pins: {
+      led: 25,
+      motor1: { pwm_r: 6, pwm_l: 7, en: 8 }, motor2: { pwm_r: 9, pwm_l: 10, en: 11 },
+      motor3: { pwm_r: 12, pwm_l: 13, en: 14 }, motor4: { pwm_r: 15, pwm_l: 16, en: 17 },
+      encoders: { m1_a: 0, m1_b: 1, m2_a: 2, m2_b: 3, m3_a: 4, m3_b: 5, m4_a: 18, m4_b: 19 },
+      i2c: { sda: 20, scl: 21 }, battery_pin: 26, sonar: { trig: 22, echo: 27 }
+    }
+  },
+  scout_pico2w: {
+    robot_name: "scout_pico2w",
+    kinematics: "DIFFERENTIAL_DRIVE",
+    mcu: "PICO2W",
+    transport: "SERIAL",
+    wifi_telemetry: false,
+    geometry: { wheel_diameter: 0.08, track_width: 0.22, wheelbase: 0.20, weight: 3.5 },
+    motors: { driver_type: "BTS7960", max_rpm: 330, cpr: 1320, motor1_inv: false, motor2_inv: true },
+    sensors: { imu: "FAKE", mag: "NONE", battery_monitor: "NONE", sonar: false }
+    ,
+    pins: {
+      motor1: { pwm: 14, in_a: 15, in_b: 13 },
+      motor2: { pwm: 16, in_a: 17, in_b: 12 },
+      encoders: { m1_a: 2, m1_b: 3, m2_a: 4, m2_b: 5 },
+      i2c: { sda: 8, scl: 9 },
+      battery_pin: 26,
+      sonar: { trig: 18, echo: 19 }
+    }
+  },
+  scout_pico2: {
+    robot_name: "scout_pico2",
+    kinematics: "DIFFERENTIAL_DRIVE",
+    mcu: "PICO2",
+    transport: "SERIAL",
+    geometry: {
+      wheel_diameter: 0.08,
+      track_width: 0.22,
+      wheelbase: 0.20,
+      weight: 3.5
+    },
+    motors: {
+      driver_type: "GENERIC_2_IN",
+      max_rpm: 330,
+      cpr: 1320,
+      operating_voltage: 12.0,
+      rated_torque: 1.5,
+      rated_voltage: 12.0,
+      motor1_inv: false,
+      motor2_inv: true,
+      motor3_inv: false,
+      motor4_inv: true
+    },
+    sensors: {
+      imu: "FAKE",
+      mag: "NONE",
+      battery_monitor: "NONE",
+      sonar: false
+    }
+    ,
+    pins: {
+      led: 25,
+      motor1: { pwm: 10, in_a: 11, in_b: 12 },
+      motor2: { pwm: 13, in_a: 14, in_b: 15 },
+      motor3: { pwm: 16, in_a: 17, in_b: 18 },
+      motor4: { pwm: 19, in_a: 20, in_b: 21 },
+      encoders: { m1_a: 2, m1_b: 3, m2_a: 4, m2_b: 5, m3_a: 6, m3_b: 7, m4_a: 8, m4_b: 9 },
+      i2c: { sda: 0, scl: 1 },
+      battery_pin: 26,
+      sonar: { trig: 22, echo: 27 }
+    }
+  },
+
+  mech_pico2: {
+    robot_name: "mech_pico2",
+    kinematics: "MECANUM",
+    mcu: "PICO2",
+    transport: "SERIAL",
+    geometry: {
+      wheel_diameter: 0.08,
+      track_width: 0.26,
+      wheelbase: 0.22,
+      weight: 4.0
+    },
+    motors: {
+      driver_type: "GENERIC_2_IN",
+      max_rpm: 330,
+      cpr: 1440,
+      operating_voltage: 12.0,
+      rated_torque: 2.0,
+      rated_voltage: 12.0,
+      motor1_inv: false,
+      motor2_inv: true,
+      motor3_inv: false,
+      motor4_inv: true
+    },
+    sensors: {
+      imu: "FAKE",
+      mag: "NONE",
+      battery_monitor: "ADC_DIVIDER",
+      battery_capacity: 3.0,
+      battery_nominal_voltage: 11.1,
+      battery_min_voltage: 9.0,
+      battery_max_voltage: 12.6,
+      battery_dip: 0.98,
+      sonar: true
+    },
+    pins: {
+      led: 25,
+      motor1: { pwm: 10, in_a: 11, in_b: 12 },
+      motor2: { pwm: 13, in_a: 14, in_b: 15 },
+      motor3: { pwm: 16, in_a: 17, in_b: 18 },
+      motor4: { pwm: 19, in_a: 20, in_b: 21 },
+      encoders: { m1_a: 2, m1_b: 3, m2_a: 4, m2_b: 5, m3_a: 6, m3_b: 7, m4_a: 8, m4_b: 9 },
+      i2c: { sda: 0, scl: 1 },
+      battery_pin: 26,
+      sonar: { trig: 22, echo: 27 }
+    }
+  },
+
+  mech_esp32: {
+    robot_name: "mech_esp32",
+    kinematics: "MECANUM",
+    mcu: "ESP32",
+    transport: "WIFI_UDP",
+    wifi_settings: {
+      ssid: "YOUR_WIFI_SSID",
+      password: "YOUR_WIFI_PASSWORD",
+      agent_ip: "192.168.1.100",
+      agent_port: 8888
+    },
+    geometry: {
+      wheel_diameter: 0.08,
+      track_width: 0.28,
+      wheelbase: 0.24
+    },
+    motors: {
+      driver_type: "GENERIC_2_IN",
+      max_rpm: 300,
+      cpr: 1500,
+      operating_voltage: 12.0,
+      motor1_inv: false,
+      motor2_inv: true,
+      motor3_inv: false,
+      motor4_inv: true
+    },
+    sensors: {
+      imu: "BNO085",
+      mag: "NONE",
+      battery_monitor: "INA219",
+      sonar: false
+    },
+    pins: {
+      led: 2,
+      motor1: { pwm: 13, in_a: 14, in_b: 27 },
+      motor2: { pwm: 25, in_a: 26, in_b: 33 },
+      motor3: { pwm: 18, in_a: 19, in_b: 23 },
+      motor4: { pwm: 15, in_a: 16, in_b: 17 },
+      encoders: { m1_a: 34, m1_b: 35, m2_a: 36, m2_b: 39, m3_a: 4, m3_b: 32, m4_a: 5, m4_b: 12 },
+      i2c: { sda: 21, scl: 22 },
+      battery_pin: 36,
+      sonar: { trig: 0, echo: 0 }
+    }
+  },
+
+  crawler_esp32s3: {
+    robot_name: "crawler_esp32s3",
+    kinematics: "SKID_STEER",
+    mcu: "ESP32S3",
+    transport: "SERIAL",
+    geometry: {
+      wheel_diameter: 0.085,
+      track_width: 0.26,
+      wheelbase: 0.22
+    },
+    motors: {
+      driver_type: "GENERIC_2_IN",
+      max_rpm: 280,
+      cpr: 1400,
+      operating_voltage: 12.0,
+      motor1_inv: false,
+      motor2_inv: true,
+      motor3_inv: false,
+      motor4_inv: true
+    },
+    sensors: {
+      imu: "MPU6050",
+      mag: "NONE",
+      battery_monitor: "ADC_DIVIDER",
+      sonar: true
+    },
+    pins: {
+      led: 48,
+      motor1: { pwm: 1, in_a: 2, in_b: 4 },
+      motor2: { pwm: 5, in_a: 6, in_b: 7 },
+      motor3: { pwm: 8, in_a: 9, in_b: 10 },
+      motor4: { pwm: 11, in_a: 12, in_b: 13 },
+      encoders: { m1_a: 14, m1_b: 15, m2_a: 16, m2_b: 17, m3_a: 18, m3_b: 21, m4_a: 38, m4_b: 39 },
+      i2c: { sda: 41, scl: 42 },
+      battery_pin: 3,
+      sonar: { trig: 47, echo: 40 }
+    }
+  },
+
+  waveshare_gendrv: {
+    robot_name: "waveshare_gendrv",
+    kinematics: "DIFFERENTIAL_DRIVE",
+    mcu: "GENDRV",
+    transport: "SERIAL",
+    baudrate: 1500000,
+    dual_core: true,
+    geometry: {
+      wheel_diameter: 0.065,
+      track_width: 0.20,
+      wheelbase: 0.18
+    },
+    motors: {
+      driver_type: "BTS7960",
+      max_rpm: 330,
+      cpr: 1320,
+      operating_voltage: 12.0,
+      motor1_inv: false,
+      motor2_inv: false,
+      motor3_inv: false,
+      motor4_inv: false
+    },
+    sensors: {
+      imu: "QMI8658",
+      mag: "AK09918",
+      battery_monitor: "INA219",
+      sonar: false
+    },
+    pins: {
+      led: -1,
+      motor1: { pwm_r: 25, pwm_l: 17, en: 21 },
+      motor2: { pwm_r: 26, pwm_l: 23, en: 22 },
+      encoders: { m1_a: 34, m1_b: 35, m2_a: 16, m2_b: 27 },
+      i2c: { sda: 32, scl: 33 },
+      battery_pin: -1,
+      sonar: { trig: -1, echo: -1 }
+    }
+  }
+};
+
+// Only the Waveshare General Driver board has fixed, known wiring. Every other
+// preset is a DIY build with no committed pinout, so its pins are forced to
+// bare (-1 / "no connection") — a preset must never drive a pin the user has
+// not actually wired. Kinematics, geometry, driver and sensor picks are kept.
+for (const [key, p] of Object.entries(PRESETS)) {
+  if (key === "bare" || key === "waveshare_gendrv") continue;
+  p.pins = JSON.parse(JSON.stringify(PRESETS.bare.pins));
+}
+
+// Current Active Spec State
+let currentSpec = {};
+let activeArtifact = "tab-code-header";
+
+function isESP32(mcu) {
+  return typeof mcu === "string" && (mcu.startsWith("ESP32") || mcu === "GENDRV");
+}
+
+// DOM Elements Initialization
+document.addEventListener("DOMContentLoaded", () => {
+  initNavTabs();
+  initArtifactTabs();
+  initEventListeners();
+  initAutomationEventListeners();
+  initAdcCalibrationStudio();
+  initRos2TopicInspector();
+  loadPreset("bare");
+  detectClientOS();
+  checkServerRunnerStatus();
+  handleUrlParams();
+});
+
+// URL Query Parameter Handling (e.g. ?preset=mech_esp32&tab=tab-drive&artifact=tab-code-pio)
+function handleUrlParams() {
+  const params = new URLSearchParams(window.location.search);
+  const preset = params.get("preset");
+  const tab = params.get("tab");
+  const artifact = params.get("artifact");
+
+  if (preset && PRESETS[preset]) {
+    const sel = document.getElementById("preset-select");
+    if (sel) sel.value = preset;
+    loadPreset(preset);
+  }
+
+  if (tab) {
+    const tabBtn = document.querySelector(`[data-tab="${tab}"]`);
+    if (tabBtn) tabBtn.click();
+  }
+
+  if (artifact) {
+    const artBtn = document.querySelector(`[data-artifact="${artifact}"]`);
+    if (artBtn) artBtn.click();
+  }
+}
+
+// Tab Navigation Handlers
+function initNavTabs() {
+  const navTabs = document.querySelectorAll(".nav-tab");
+  navTabs.forEach(tab => {
+    tab.addEventListener("click", () => {
+      navTabs.forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".tab-pane").forEach(p => p.classList.remove("active"));
+      tab.classList.add("active");
+      const target = document.getElementById(tab.dataset.tab);
+      if (target) target.classList.add("active");
+    });
+  });
+}
+
+function initArtifactTabs() {
+  const artTabs = document.querySelectorAll(".artifact-tab");
+  artTabs.forEach(tab => {
+    tab.addEventListener("click", () => {
+      artTabs.forEach(t => t.classList.remove("active"));
+      tab.classList.add("active");
+      activeArtifact = tab.dataset.artifact;
+      renderActiveCode();
+    });
+  });
+}
+
+// Global Event Listeners
+function initEventListeners() {
+  // Preset Selector
+  document.getElementById("preset-select").addEventListener("change", (e) => {
+    loadPreset(e.target.value);
+  });
+
+  // Dynamic Input Form Listeners
+  const allInputs = document.querySelectorAll(".form-input, .form-select, input[type='checkbox']");
+  allInputs.forEach(input => {
+    input.addEventListener("input", handleInputChange);
+    input.addEventListener("change", handleInputChange);
+  });
+  const otaHostEl = document.getElementById("cfg-ota-hostname");
+  if (otaHostEl) otaHostEl.addEventListener("input", () => { otaHostEl.dataset.autoManaged = "false"; });
+  // show/hide password toggles
+  [["cfg-wifi-pass-show", "cfg-wifi-pass"], ["cfg-ota-password-show", "cfg-ota-password"]].forEach(([chk, fld]) => {
+    const c = document.getElementById(chk), f = document.getElementById(fld);
+    if (c && f) c.addEventListener("change", () => { f.type = c.checked ? "text" : "password"; });
+  });
+  ["cfg-agent-ip", "cfg-syslog-ip", "cfg-lidar-ip"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) el.addEventListener("input", () => { el.dataset.autoManaged = "false"; });
+  });
+
+  // Smart Auto-Assign Pinout Button
+  document.getElementById("btn-smart-alloc").addEventListener("click", autoAssignPins);
+
+  // Copy Code Button
+  document.getElementById("btn-copy-code").addEventListener("click", copyActiveCode);
+
+  // Download Artifact Button
+  document.getElementById("btn-download-artifact").addEventListener("click", downloadActiveArtifact);
+
+  // Export JSON Spec Button
+  document.getElementById("btn-export-json").addEventListener("click", exportSpecJson);
+
+  // Import JSON File
+  // Board Config Loader
+  document.getElementById("btn-load-board")?.addEventListener("click", openBoardSelector);
+  document.getElementById("btn-board-cancel")?.addEventListener("click", () => {
+    document.getElementById("modal-board-select").style.display = "none";
+  });
+  document.getElementById("btn-board-confirm")?.addEventListener("click", async () => {
+    const envName = document.getElementById("board-select").value;
+    document.getElementById("modal-board-select").style.display = "none";
+    if (envName) await loadBoardConfig(envName);
+  });
+  // Close modal on backdrop click
+  document.getElementById("modal-board-select")?.addEventListener("click", (e) => {
+    if (e.target === document.getElementById("modal-board-select"))
+      document.getElementById("modal-board-select").style.display = "none";
+  });
+  // JSON Import file listener
+  document.getElementById("import-json-file")?.addEventListener("change", handleImportFile);
+
+  // AI I2C Sensor Auto-Detection Button
+  const btnI2cDetect = document.getElementById("btn-auto-detect-i2c");
+  if (btnI2cDetect) {
+    btnI2cDetect.addEventListener("click", runI2cSensorAutoDetect);
+  }
+}
+
+// Load a Preset into State and Form
+function loadPreset(presetKey) {
+  if (!PRESETS[presetKey]) return;
+  currentSpec = JSON.parse(JSON.stringify(PRESETS[presetKey]));
+  populateFormFromSpec(currentSpec);
+  recomputeAll();
+}
+
+// Map a parsed backend header spec (parser.py shape) onto the frontend form shape.
+// The Web UI form / presets / export use `sensors.imu`, `sensors.mag`,
+// `sensors.battery_monitor`, `sensors.sonar`, `dual_core`, `baudrate`, `transport`,
+// whereas the C++ parser emits `sensors.imu_type`, `sensors.mag_type`,
+// `sensors.use_ina219`, `sensors.sonar_trig/echo`, `telemetry.*`.
+// This shim bridges the two so board-config / C++-header imports populate the form.
+// Idempotent: never overwrites a frontend-shape key that is already present.
+function normalizeSpecToFormShape(spec) {
+  if (!spec) return spec;
+  if (!spec.sensors) spec.sensors = {};
+  const s = spec.sensors;
+
+  // Only bridge parser-style keys when at least one is present and the
+  // front-end-style key has not already been supplied (stay idempotent).
+  const hasParserKeys =
+    s.imu_type != null || s.mag_type != null || s.use_ina219 !== undefined ||
+    s.sonar_trig !== undefined || s.battery_monitor == null;
+
+  if (hasParserKeys) {
+    // IMU: USE_QMI8658_IMU -> QMI8658, USE_FAKE_IMU -> FAKE
+    if (s.imu == null && s.imu_type != null) {
+      const v = String(s.imu_type).replace(/^USE_/, "").replace(/_IMU$/, "");
+      if (v && v !== "IMU") s.imu = v;
+    }
+    // MAG: USE_AK09918_MAG -> AK09918, USE_FAKE_MAG -> NONE (no mag option exists)
+    if (s.mag == null && s.mag_type != null) {
+      let v = String(s.mag_type).replace(/^USE_/, "").replace(/_MAG$/, "");
+      if (v === "FAKE") v = "NONE";
+      if (v && v !== "MAG") s.mag = v;
+    }
+    // Battery monitor: INA219 vs ADC divider vs none
+    if (s.battery_monitor == null) {
+      if (s.use_ina219) s.battery_monitor = "INA219";
+      else if (typeof s.battery_pin === "number" && s.battery_pin >= 0) s.battery_monitor = "ADC_DIVIDER";
+    }
+    // Sonar enabled when both trigger & echo pins are set
+    if (s.sonar == null &&
+        typeof s.sonar_trig === "number" && s.sonar_trig >= 0 &&
+        typeof s.sonar_echo === "number" && s.sonar_echo >= 0) {
+      s.sonar = true;
+    }
+    // Battery numeric fields use different names in the parser
+    if (s.battery_capacity == null && s.battery_cap != null)            s.battery_capacity = s.battery_cap;
+    if (s.battery_min_voltage == null && s.battery_min != null)         s.battery_min_voltage = s.battery_min;
+    if (s.battery_max_voltage == null && s.battery_max != null)         s.battery_max_voltage = s.battery_max;
+    if (s.battery_nominal_voltage == null && s.battery_nominal != null) s.battery_nominal_voltage = s.battery_nominal;
+    if (s.battery_r1 == null && s.battery_divider_r1 != null)           s.battery_r1 = s.battery_divider_r1;
+    if (s.battery_r2 == null && s.battery_divider_r2 != null)           s.battery_r2 = s.battery_divider_r2;
+  }
+
+  // Dual-core: parser puts it under telemetry / top-level may lack it
+  if (spec.dual_core == null && spec.telemetry && typeof spec.telemetry.use_dual_core === "boolean") {
+    spec.dual_core = spec.telemetry.use_dual_core;
+  }
+  // Baudrate & transport fallbacks from the telemetry block
+  if (spec.baudrate == null && spec.telemetry && spec.telemetry.baudrate != null) spec.baudrate = spec.telemetry.baudrate;
+  if (spec.transport == null && spec.telemetry && spec.telemetry.transport) spec.transport = spec.telemetry.transport;
+
+  return spec;
+}
+
+// Populate UI Form Fields from Spec Object
+function populateFormFromSpec(spec) {
+  spec = normalizeSpecToFormShape(spec);
+  document.getElementById("cfg-robot-name").value = spec.robot_name || "my_robot";
+  document.getElementById("cfg-kinematics").value = spec.kinematics || "DIFFERENTIAL_DRIVE";
+  document.getElementById("cfg-mcu").value = spec.mcu || "PICO2";
+  document.getElementById("cfg-transport").value = spec.transport || "SERIAL";
+  if (document.getElementById("cfg-baudrate")) {
+    document.getElementById("cfg-baudrate").value = String(spec.baudrate || spec.telemetry?.baudrate || (spec.mcu === "GENDRV" ? 1500000 : 921600));
+  }
+  if (document.getElementById("cfg-serial-interface")) {
+    document.getElementById("cfg-serial-interface").value = spec.serial_interface || "CDC";
+  }
+
+  if (spec.wifi_settings) {
+    document.getElementById("cfg-wifi-ssid").value = spec.wifi_settings.ssid || "";
+    document.getElementById("cfg-wifi-pass").value = spec.wifi_settings.password || "";
+    document.getElementById("cfg-agent-ip").value = spec.wifi_settings.agent_ip || "192.168.1.100";
+    document.getElementById("cfg-agent-port").value = spec.wifi_settings.agent_port || 8888;
+    // A real SSID came from config/custom/wifi_config.h — show the WiFi block.
+    const _ss = (spec.wifi_settings.ssid || "").trim();
+    if (_ss && _ss !== "YOUR_WIFI_SSID") {
+      const bg = document.getElementById("cfg-wifi-telemetry");
+      if (bg) bg.checked = true;
+    }
+  }
+
+  // Geometry
+  document.getElementById("cfg-wheel-dia").value = spec.geometry?.wheel_diameter || 0.08;
+  document.getElementById("cfg-track-width").value = spec.geometry?.track_width || 0.22;
+  document.getElementById("cfg-wheelbase").value = spec.geometry?.wheelbase || 0.20;
+  if (document.getElementById("cfg-weight")) document.getElementById("cfg-weight").value = spec.geometry?.weight || 3.5;
+
+  // Motors
+  document.getElementById("cfg-driver-type").value = spec.motors?.driver_type || "BTS7960";
+  document.getElementById("cfg-max-rpm").value = spec.motors?.max_rpm || 330;
+  document.getElementById("cfg-cpr").value = spec.motors?.cpr || 1440;
+  document.getElementById("cfg-motor-voltage").value = spec.motors?.operating_voltage || 12.0;
+  if (document.getElementById("cfg-motor-torque")) document.getElementById("cfg-motor-torque").value = spec.motors?.rated_torque || 1.5;
+
+  for (let i = 1; i <= 4; i++) {
+    const el = document.getElementById(`pin-m${i}-inv`);
+    if (el) el.checked = !!spec.motors?.[`motor${i}_inv`];
+  }
+
+  // Sensors
+  document.getElementById("cfg-imu").value = spec.sensors?.imu || "NONE";
+  document.getElementById("cfg-mag").value = spec.sensors?.mag || "NONE";
+  document.getElementById("cfg-battery").value = spec.sensors?.battery_monitor || "NONE";
+  if (document.getElementById("cfg-bat-cap")) document.getElementById("cfg-bat-cap").value = spec.sensors?.battery_capacity || 2.2;
+  if (document.getElementById("cfg-bat-nom")) document.getElementById("cfg-bat-nom").value = spec.sensors?.battery_nominal_voltage || 11.1;
+  if (document.getElementById("cfg-bat-min")) document.getElementById("cfg-bat-min").value = spec.sensors?.battery_min_voltage || 9.0;
+  if (document.getElementById("cfg-bat-max")) document.getElementById("cfg-bat-max").value = spec.sensors?.battery_max_voltage || 12.6;
+  if (document.getElementById("cfg-bat-dip")) document.getElementById("cfg-bat-dip").value = spec.sensors?.battery_dip || 0.98;
+  if (document.getElementById("cfg-bat-r1")) document.getElementById("cfg-bat-r1").value = spec.sensors?.battery_r1 || 30000;
+  if (document.getElementById("cfg-bat-r2")) document.getElementById("cfg-bat-r2").value = spec.sensors?.battery_r2 || 7500;
+  if (document.getElementById("cfg-bat-cap-val")) document.getElementById("cfg-bat-cap-val").value = spec.sensors?.battery_adc_cap || 1000;
+  document.getElementById("cfg-sonar").value = spec.sensors?.sonar ? "true" : "false";
+
+  // Dual-Core
+  if (document.getElementById("cfg-dual-core")) {
+    document.getElementById("cfg-dual-core").checked = spec.dual_core !== false;
+  }
+
+  // Hardware Watchdog
+  if (document.getElementById("cfg-wdt-enable")) {
+    const wdtEnabled = !!spec.watchdog?.enabled || (typeof spec.watchdog === "number" && spec.watchdog > 0);
+    document.getElementById("cfg-wdt-enable").checked = wdtEnabled;
+    const wdtTimeoutGroup = document.getElementById("group-wdt-timeout");
+    if (wdtTimeoutGroup) wdtTimeoutGroup.style.display = wdtEnabled ? "flex" : "none";
+    if (document.getElementById("cfg-wdt-timeout")) {
+      const to = spec.watchdog?.timeout_sec || (typeof spec.watchdog === "number" ? spec.watchdog : 60);
+      document.getElementById("cfg-wdt-timeout").value = to;
+    }
+  }
+
+  // Pins
+  const p = spec.pins || {};
+  document.getElementById("pin-led").value = p.led !== undefined ? p.led : 25;
+
+  const dt = spec.motors?.driver_type || "GENERIC_2_IN";
+  setPinVal("pin-m1-p1", dt === "BTS7960" ? p.motor1?.pwm_r : p.motor1?.pwm);
+  setPinVal("pin-m1-p2", dt === "BTS7960" ? p.motor1?.pwm_l : (dt === "GENERIC_1_IN" ? p.motor1?.dir : p.motor1?.in_a));
+  setPinVal("pin-m1-p3", dt === "BTS7960" ? p.motor1?.en : p.motor1?.in_b);
+
+  setPinVal("pin-m2-p1", dt === "BTS7960" ? p.motor2?.pwm_r : p.motor2?.pwm);
+  setPinVal("pin-m2-p2", dt === "BTS7960" ? p.motor2?.pwm_l : (dt === "GENERIC_1_IN" ? p.motor2?.dir : p.motor2?.in_a));
+  setPinVal("pin-m2-p3", dt === "BTS7960" ? p.motor2?.en : p.motor2?.in_b);
+
+  setPinVal("pin-m3-p1", dt === "BTS7960" ? p.motor3?.pwm_r : p.motor3?.pwm);
+  setPinVal("pin-m3-p2", dt === "BTS7960" ? p.motor3?.pwm_l : (dt === "GENERIC_1_IN" ? p.motor3?.dir : p.motor3?.in_a));
+  setPinVal("pin-m3-p3", dt === "BTS7960" ? p.motor3?.en : p.motor3?.in_b);
+
+  setPinVal("pin-m4-p1", dt === "BTS7960" ? p.motor4?.pwm_r : p.motor4?.pwm);
+  setPinVal("pin-m4-p2", dt === "BTS7960" ? p.motor4?.pwm_l : (dt === "GENERIC_1_IN" ? p.motor4?.dir : p.motor4?.in_a));
+  setPinVal("pin-m4-p3", dt === "BTS7960" ? p.motor4?.en : p.motor4?.in_b);
+
+  const enc = p.encoders || {};
+  setPinVal("pin-enc-1a", enc.m1_a);
+  setPinVal("pin-enc-1b", enc.m1_b);
+  setPinVal("pin-enc-2a", enc.m2_a);
+  setPinVal("pin-enc-2b", enc.m2_b);
+  setPinVal("pin-enc-3a", enc.m3_a);
+  setPinVal("pin-enc-3b", enc.m3_b);
+  setPinVal("pin-enc-4a", enc.m4_a);
+  setPinVal("pin-enc-4b", enc.m4_b);
+
+  // Encoder invert flags
+  for (let i = 1; i <= 4; i++) {
+    const cb = document.getElementById(`pin-enc-${i}-inv`);
+    if (cb) cb.checked = !!enc[`m${i}_inv`];
+  }
+
+  setPinVal("pin-i2c-sda", p.i2c?.sda);
+  setPinVal("pin-i2c-scl", p.i2c?.scl);
+
+  // advanced telemetry (syslog / LiDAR-UDP / OTA)
+  const adv = spec.advanced || {};
+  const setVal = (id, v) => { const el = document.getElementById(id); if (el && v !== undefined && v !== null && v !== "") el.value = v; };
+  const setCk  = (id, v) => { const el = document.getElementById(id); if (el) el.checked = !!v; };
+  setVal("cfg-syslog-ip", adv.syslog_ip);
+  setVal("cfg-syslog-port", adv.syslog_port);
+  setVal("cfg-lidar-ip", adv.lidar_ip);
+  setVal("cfg-lidar-port", adv.lidar_port);
+  setVal("cfg-lidar-rxd", adv.lidar_rxd);
+  setVal("cfg-lidar-uart", adv.lidar_serial);
+  setVal("cfg-ota-hostname", adv.ota_hostname);
+  setVal("cfg-ota-password", adv.ota_password);
+  setVal("cfg-ota-ip", adv.ota_ip);
+  setVal("cfg-topic-prefix", adv.topic_prefix);
+  setCk("cfg-lidar-udp", spec.telemetry?.use_lidar_udp);
+  setCk("cfg-ota-enable", adv.ota_enable);
+
+  // PID constants + IMU / mag tuning
+  const pid = spec.pid || {};
+  setVal("cfg-pid-kp", pid.kp);
+  setVal("cfg-pid-ki", pid.ki);
+  setVal("cfg-pid-kd", pid.kd);
+  const tune = spec.imu_tuning || {};
+  const setNum = (id, v) => { const el = document.getElementById(id); if (el) el.value = (v === undefined || v === null) ? "" : v; };
+  if (Array.isArray(tune.mag_bias)) {
+    setNum("cfg-mag-bias-x", tune.mag_bias[0]);
+    setNum("cfg-mag-bias-y", tune.mag_bias[1]);
+    setNum("cfg-mag-bias-z", tune.mag_bias[2]);
+  } else {
+    setNum("cfg-mag-bias-x", null); setNum("cfg-mag-bias-y", null); setNum("cfg-mag-bias-z", null);
+  }
+  const covScalar = (v) => Array.isArray(v) ? (v.every(x => x === v[0]) ? v[0] : v[0]) : v;
+  setNum("cfg-cov-accel", covScalar(tune.accel_cov));
+  setNum("cfg-cov-gyro", covScalar(tune.gyro_cov));
+  setNum("cfg-cov-ori", covScalar(tune.ori_cov));
+  setPinVal("pin-battery", p.battery_pin);
+  setPinVal("pin-sonar-trig", p.sonar?.trig);
+  setPinVal("pin-sonar-echo", p.sonar?.echo);
+
+  const robotName = spec.robot_name || "my_robot";
+  const gitBranchInput = document.getElementById("auto-git-branch");
+  if (gitBranchInput && gitBranchInput.dataset.autoManaged !== "false") {
+    gitBranchInput.value = `config/${robotName}`;
+  }
+  const gitCommitInput = document.getElementById("auto-git-commit-msg");
+  if (gitCommitInput && gitCommitInput.dataset.autoManaged !== "false") {
+    gitCommitInput.value = `feat(config): add configuration for ${robotName}`;
+  }
+  const portInput = document.getElementById("auto-flash-port");
+  if (portInput && portInput.dataset.autoManaged !== "false") {
+    const isEsp = (spec.mcu || "").toUpperCase().startsWith("ESP");
+    portInput.value = isEsp ? "/dev/ttyUSB0" : "/dev/ttyACM0";
+  }
+
+
+  updateDynamicUIState();
+}
+
+function setPinVal(id, val) {
+  const el = document.getElementById(id);
+  if (el) el.value = val !== undefined ? val : "";
+}
+
+function getInt(id, defaultVal = 0) {
+  const el = document.getElementById(id);
+  if (!el || el.value === "" || isNaN(parseInt(el.value, 10))) return defaultVal;
+  return parseInt(el.value, 10);
+}
+
+function getFloat(id, defaultVal = 0.0) {
+  const el = document.getElementById(id);
+  if (!el || el.value === "" || isNaN(parseFloat(el.value))) return defaultVal;
+  return parseFloat(el.value);
+}
+
+// Like getFloat but returns null (not a default) when the field is left blank,
+// so optional numeric settings can be "unset".
+function getFloatOrNull(id) {
+  const el = document.getElementById(id);
+  if (!el || el.value.trim() === "" || isNaN(parseFloat(el.value))) return null;
+  return parseFloat(el.value);
+}
+
+// Read Current Values from Form and update State
+function readSpecFromForm() {
+  const kinematics = document.getElementById("cfg-kinematics").value;
+  const driverType = document.getElementById("cfg-driver-type").value;
+  const transport = document.getElementById("cfg-transport").value;
+  const is4WD = kinematics !== "DIFFERENTIAL_DRIVE";
+
+  const spec = {
+    robot_name: document.getElementById("cfg-robot-name").value.trim().toLowerCase().replace(/[^a-z0-9_]/g, "_") || "my_robot",
+    kinematics: kinematics,
+    mcu: document.getElementById("cfg-mcu").value,
+    transport: transport,
+    serial_interface: document.getElementById("cfg-serial-interface") ? document.getElementById("cfg-serial-interface").value : "CDC",
+    geometry: {
+      wheel_diameter: getFloat("cfg-wheel-dia", 0.08),
+      track_width: getFloat("cfg-track-width", 0.22),
+    },
+    motors: {
+      driver_type: driverType,
+      max_rpm: getFloat("cfg-max-rpm", 330),
+      cpr: getFloat("cfg-cpr", 1440),
+      operating_voltage: getFloat("cfg-motor-voltage", 12.0),
+      motor1_inv: !!document.getElementById("pin-m1-inv")?.checked,
+      motor2_inv: !!document.getElementById("pin-m2-inv")?.checked,
+      motor3_inv: !!document.getElementById("pin-m3-inv")?.checked,
+      motor4_inv: !!document.getElementById("pin-m4-inv")?.checked
+    },
+    pid: {
+      kp: getFloat("cfg-pid-kp", 0.6),
+      ki: getFloat("cfg-pid-ki", 0.8),
+      kd: getFloat("cfg-pid-kd", 0.5)
+    },
+    sensors: {
+      imu: document.getElementById("cfg-imu").value,
+      mag: document.getElementById("cfg-mag").value,
+      battery_monitor: document.getElementById("cfg-battery").value,
+      battery_capacity: getFloat("cfg-bat-cap", 2.2),
+      battery_nominal_voltage: getFloat("cfg-bat-nom", 11.1),
+      battery_min_voltage: getFloat("cfg-bat-min", 9.0),
+      battery_max_voltage: getFloat("cfg-bat-max", 12.6),
+      battery_dip: getFloat("cfg-bat-dip", 0.98),
+      battery_r1: getFloat("cfg-bat-r1", 30000.0),
+      battery_r2: getFloat("cfg-bat-r2", 7500.0),
+      battery_adc_cap: getFloat("cfg-bat-cap-val", 1000.0),
+      sonar: document.getElementById("cfg-sonar").value === "true"
+    },
+    imu_tuning: (() => {
+      const bx = getFloatOrNull("cfg-mag-bias-x"), by = getFloatOrNull("cfg-mag-bias-y"), bz = getFloatOrNull("cfg-mag-bias-z");
+      const t = {};
+      if (bx !== null || by !== null || bz !== null) t.mag_bias = [bx || 0, by || 0, bz || 0];
+      const ac = getFloatOrNull("cfg-cov-accel"), gc = getFloatOrNull("cfg-cov-gyro"), oc = getFloatOrNull("cfg-cov-ori");
+      if (ac !== null) t.accel_cov = ac;
+      if (gc !== null) t.gyro_cov = gc;
+      if (oc !== null) t.ori_cov = oc;
+      return t;
+    })(),
+    baudrate: document.getElementById("cfg-baudrate") ? parseInt(document.getElementById("cfg-baudrate").value, 10) : 921600,
+    telemetry: {
+      use_dual_core: document.getElementById("cfg-dual-core") ? document.getElementById("cfg-dual-core").checked : true,
+      baudrate: document.getElementById("cfg-baudrate") ? parseInt(document.getElementById("cfg-baudrate").value, 10) : 921600
+    },
+    dual_core: document.getElementById("cfg-dual-core") ? document.getElementById("cfg-dual-core").checked : true,
+    watchdog: {
+      enabled: document.getElementById("cfg-wdt-enable") ? document.getElementById("cfg-wdt-enable").checked : false,
+      timeout_sec: getInt("cfg-wdt-timeout", 60)
+    },
+    pins: {
+      led: getInt("pin-led", 25),
+      encoders: {
+        m1_a: getInt("pin-enc-1a"),
+        m1_b: getInt("pin-enc-1b"),
+        m2_a: getInt("pin-enc-2a"),
+        m2_b: getInt("pin-enc-2b"),
+        m1_inv: !!(document.getElementById("pin-enc-1-inv")?.checked),
+        m2_inv: !!(document.getElementById("pin-enc-2-inv")?.checked),
+        m3_inv: !!(document.getElementById("pin-enc-3-inv")?.checked),
+        m4_inv: !!(document.getElementById("pin-enc-4-inv")?.checked)
+      },
+      i2c: {
+        sda: getInt("pin-i2c-sda"),
+        scl: getInt("pin-i2c-scl")
+      }
+    }
+  };
+
+  // Advanced telemetry: syslog / LiDAR-UDP / Arduino OTA (Sensors tab)
+  const _v = (id) => (document.getElementById(id)?.value || "").trim();
+  const _ck = (id) => !!document.getElementById(id)?.checked;
+  spec.advanced = {
+    syslog_ip: _v("cfg-syslog-ip"),
+    syslog_port: getInt("cfg-syslog-port", 514),
+    lidar_ip: _v("cfg-lidar-ip"),
+    lidar_port: getInt("cfg-lidar-port", 8889),
+    lidar_rxd: getInt("cfg-lidar-rxd", -1),
+    lidar_serial: getInt("cfg-lidar-uart", 1),
+    lidar_baudrate: 230400,
+    ota_hostname: _v("cfg-ota-hostname"),
+    ota_password: _v("cfg-ota-password"),
+    ota_ip: _v("cfg-ota-ip"),
+    ota_enable: _ck("cfg-ota-enable"),
+    topic_prefix: _v("cfg-topic-prefix")
+  };
+  spec.telemetry = Object.assign({}, spec.telemetry, { use_lidar_udp: _ck("cfg-lidar-udp") });
+  // Background WiFi (OTA/syslog while micro-ROS stays on serial) turns on
+  // whenever any of these wireless features are requested.
+  if (_ck("cfg-lidar-udp") || _ck("cfg-ota-enable")) spec.enable_ota_syslog = true;
+
+  if (is4WD) {
+    spec.geometry.wheelbase = getFloat("cfg-wheelbase", 0.20);
+    spec.pins.encoders.m3_a = getInt("pin-enc-3a");
+    spec.pins.encoders.m3_b = getInt("pin-enc-3b");
+    spec.pins.encoders.m4_a = getInt("pin-enc-4a");
+    spec.pins.encoders.m4_b = getInt("pin-enc-4b");
+  }
+
+  // Motor Pin Structures
+  const parseMotorPin = (prefix) => {
+    const p1 = getInt(`${prefix}-p1`);
+    const p2 = getInt(`${prefix}-p2`);
+    const p3 = getInt(`${prefix}-p3`);
+
+    if (driverType === "BTS7960") {
+      return { pwm_r: p1, pwm_l: p2, en: p3 };
+    } else if (driverType === "GENERIC_2_IN") {
+      return { pwm: p1, in_a: p2, in_b: p3 };
+    } else if (driverType === "GENERIC_1_IN") {
+      return { pwm: p1, dir: p2 };
+    } else {
+      return { pwm: p1 };
+    }
+  };
+
+  spec.pins.motor1 = parseMotorPin("pin-m1");
+  spec.pins.motor2 = parseMotorPin("pin-m2");
+  if (is4WD) {
+    spec.pins.motor3 = parseMotorPin("pin-m3");
+    spec.pins.motor4 = parseMotorPin("pin-m4");
+  }
+
+  if (spec.sensors.battery_monitor === "ADC_DIVIDER") {
+    spec.pins.battery_pin = getInt("pin-battery");
+  }
+  if (spec.sensors.sonar) {
+    spec.pins.sonar = {
+      trig: getInt("pin-sonar-trig"),
+      echo: getInt("pin-sonar-echo")
+    };
+  }
+
+  // WiFi credentials are needed both for WIFI_UDP transport AND for the
+  // "Enable Background WiFi for OTA & Syslog" mode (micro-ROS stays on serial
+  // but the firmware still joins WiFi for USE_SYSLOG / USE_ARDUINO_OTA).
+  const _ssidRaw = (document.getElementById("cfg-wifi-ssid")?.value || "").trim();
+  const _ssidReal = _ssidRaw && _ssidRaw !== "YOUR_WIFI_SSID";
+  // "Enable Background WiFi" only takes effect once a real SSID is entered —
+  // otherwise a bare first-run would emit WIFI_AP_LIST with the placeholder and
+  // the firmware would hang at boot trying to join "YOUR_WIFI_SSID".
+  const bgWifi = !!document.getElementById("cfg-wifi-telemetry")?.checked && _ssidReal;
+  if (transport === "WIFI_UDP" || bgWifi) {
+    spec.wifi_settings = {
+      ssid: _ssidRaw,
+      password: document.getElementById("cfg-wifi-pass").value,
+      agent_ip: document.getElementById("cfg-agent-ip").value,
+      agent_port: getInt("cfg-agent-port", 8888)
+    };
+  }
+  if (bgWifi && transport !== "WIFI_UDP") spec.enable_ota_syslog = true;
+
+  return spec;
+}
+
+// Handle Form Changes
+function handleInputChange() {
+  updateDynamicUIState();
+  recomputeAll();
+}
+
+// Update Dynamic Visibility of Form Components
+function updateDynamicUIState() {
+  const kinematics = document.getElementById("cfg-kinematics").value;
+  const is4WD = kinematics !== "DIFFERENTIAL_DRIVE";
+  const transport = document.getElementById("cfg-transport").value;
+  const driverType = document.getElementById("cfg-driver-type").value;
+  const batteryType = document.getElementById("cfg-battery").value;
+  const sonarActive = document.getElementById("cfg-sonar").value === "true";
+
+  // 4WD Elements
+  document.getElementById("group-wheelbase").style.display = is4WD ? "flex" : "none";
+  // motor 3/4 invert checkboxes live in the pinout matrix rows, which
+  // already show/hide with row-motor-3 / row-motor-4
+  document.getElementById("row-motor-3").style.display = is4WD ? "table-row" : "none";
+  document.getElementById("row-motor-4").style.display = is4WD ? "table-row" : "none";
+  document.getElementById("row-enc-3").style.display = is4WD ? "table-row" : "none";
+  document.getElementById("row-enc-4").style.display = is4WD ? "table-row" : "none";
+
+  // WiFi & Serial Baudrate Settings
+  const mcuVal = document.getElementById("cfg-mcu") ? document.getElementById("cfg-mcu").value : "";
+  const isWifiMcu = mcuVal.includes("W") || mcuVal.includes("ESP32") || mcuVal === "GENDRV";
+  const wifiTelemetry = document.getElementById("cfg-wifi-telemetry") ? document.getElementById("cfg-wifi-telemetry").checked : false;
+  document.getElementById("wifi-config-box").style.display = (transport === "WIFI_UDP" || (isWifiMcu && wifiTelemetry)) ? "block" : "none";
+  if (document.getElementById("group-serial-baudrate")) {
+    document.getElementById("group-serial-baudrate").style.display = transport === "SERIAL" ? "block" : "none";
+  }
+
+  // Watchdog Timeout Group
+  const wdtEnable = document.getElementById("cfg-wdt-enable") ? document.getElementById("cfg-wdt-enable").checked : false;
+  const wdtTimeoutGroup = document.getElementById("group-wdt-timeout");
+  if (wdtTimeoutGroup) wdtTimeoutGroup.style.display = wdtEnable ? "flex" : "none";
+
+  // Serial Interface for S2/S3
+  const mcu = document.getElementById("cfg-mcu").value;
+  const isS2S3 = (mcu === "ESP32S2" || mcu === "ESP32S3") && transport === "SERIAL";
+  const ifaceGroup = document.getElementById("group-serial-interface");
+  if (ifaceGroup) ifaceGroup.style.display = isS2S3 ? "flex" : "none";
+
+  // Battery ADC
+  document.getElementById("box-battery-pin").style.display = batteryType === "ADC_DIVIDER" ? "flex" : "none";
+
+  // Sonar
+  document.getElementById("box-sonar-trig").style.display = sonarActive ? "flex" : "none";
+  document.getElementById("box-sonar-echo").style.display = sonarActive ? "flex" : "none";
+
+  // Motor Headers based on Driver Type
+  const headerEl = document.getElementById("motor-pin-headers");
+  const invTh = `<th title="Invert this motor's spin direction">Invert</th>`;
+  if (driverType === "BTS7960") {
+    headerEl.innerHTML = `<th>Motor</th><th>PWM (n/c)</th><th>IN_A / PWM 1</th><th>IN_B / PWM 2</th>` + invTh;
+  } else if (driverType === "GENERIC_2_IN") {
+    headerEl.innerHTML = `<th>Motor</th><th>PWM (Speed)</th><th>IN_A (Dir 1)</th><th>IN_B (Dir 2)</th>` + invTh;
+  } else if (driverType === "GENERIC_1_IN") {
+    headerEl.innerHTML = `<th>Motor</th><th>PWM (Speed)</th><th>DIR (Direction)</th><th>--</th>` + invTh;
+  } else {
+    headerEl.innerHTML = `<th>Motor</th><th>PWM Signal</th><th>--</th><th>--</th>` + invTh;
+  }
+
+  // HUD Tag
+  const baseTag = document.getElementById("hud-base-tag");
+  if (kinematics === "DIFFERENTIAL_DRIVE") baseTag.innerText = "2WD Differential";
+  else if (kinematics === "SKID_STEER") baseTag.innerText = "4WD Skid Steer";
+  else baseTag.innerText = "4WD Mecanum";
+}
+
+// Master Recompute & Render
+function recomputeAll() {
+  currentSpec = readSpecFromForm();
+
+  // 1. Validate Rules
+  const validation = validateRobotSpec(currentSpec);
+  renderSafetyInspector(validation);
+
+  // 2. Compute Kinematics & Update HUD
+  renderKinematicsHUD(validation.stats);
+
+  // 3. Update Automation Previews
+  updateAutomationPreviews();
+
+  // 4. Update ADC Voltage Calculations & CAD Vector Schematic
+  updateAdcVoltageCalculations(currentSpec);
+
+  // 5. Render Active Code Viewer
+  renderActiveCode();
+}
+
+// Hardware & Electrical Rule Validation Engine
+function validateRobotSpec(spec) {
+  const errors = [];
+  const stats = {};
+
+  const mcu = (spec.mcu || "").toUpperCase();
+  const kinematics = spec.kinematics;
+  const geom = spec.geometry || {};
+  const motors = spec.motors || {};
+  const pins = spec.pins || {};
+  const sensors = spec.sensors || {};
+
+  const wheelD = geom.wheel_diameter || 0;
+  const trackW = geom.track_width || 0;
+  const maxRpm = motors.max_rpm || 0;
+  const cpr = motors.cpr || 0;
+
+  if (wheelD <= 0) errors.push({ level: "ERROR", field: "geometry.wheel_diameter", message: "Wheel diameter must be > 0 m" });
+  if (trackW <= 0) errors.push({ level: "ERROR", field: "geometry.track_width", message: "Track width must be > 0 m" });
+  if (maxRpm <= 0) errors.push({ level: "ERROR", field: "motors.max_rpm", message: "Motor RPM must be > 0" });
+  if (cpr <= 0) errors.push({ level: "ERROR", field: "motors.cpr", message: "Encoder CPR must be > 0" });
+
+  if (wheelD > 0 && maxRpm > 0 && cpr > 0) {
+    const wheelCirc = Math.PI * wheelD;
+    const maxLinearSpeed = (wheelCirc * maxRpm / 60.0) * 0.85; // 85% headroom
+    const maxAngularSpeed = trackW > 0 ? (2.0 * maxLinearSpeed) / trackW : 0;
+    const ticksPerMeter = cpr / wheelCirc;
+
+    stats.wheel_circumference_m = wheelCirc;
+    stats.max_linear_speed_m_s = maxLinearSpeed;
+    stats.max_angular_speed_rad_s = maxAngularSpeed;
+    stats.ticks_per_meter = ticksPerMeter;
+  }
+
+  // Pin Conflict Checking
+  const assignedPins = {};
+  function registerPin(pin, name, isOutput = false) {
+    if (pin === undefined || pin === null || isNaN(pin) || pin === "") return;
+    const p = parseInt(pin, 10);
+    // A negative value means "no connection / pin not assigned" — skip conflict
+    // detection and MCU-specific GPIO range checks for unassigned slots.
+    if (p < 0) return;
+    if (!assignedPins[p]) assignedPins[p] = [];
+    assignedPins[p].push(name);
+
+    // MCU Rules
+    if (mcu === "ESP32" || mcu === "GENDRV") {
+      if (ESP32_FLASH_PINS.includes(p)) {
+        errors.push({ level: "ERROR", field: name, message: `GPIO ${p} is connected to internal SPI Flash! Strictly forbidden.` });
+      }
+      if (isOutput && ESP32_INPUT_ONLY_PINS.includes(p)) {
+        errors.push({ level: "ERROR", field: name, message: `GPIO ${p} is an INPUT-ONLY pin and cannot output PWM/DIR signals!` });
+      }
+      if (!isOutput && ESP32_STRAPPING_PINS.includes(p)) {
+        errors.push({ level: "WARNING", field: name, message: `GPIO ${p} is an ESP32 strapping pin. May interfere with boot if pulled LOW.` });
+      }
+    } else if (mcu === "ESP32S3") {
+      if (!isOutput && ESP32S3_STRAPPING_PINS.includes(p)) {
+        errors.push({ level: "WARNING", field: name, message: `GPIO ${p} is an ESP32-S3 strapping pin.` });
+      }
+    } else if (["PICO", "PICO2", "PICOW", "PICO2W"].includes(mcu)) {
+      if (p < 0 || p > 29) {
+        errors.push({ level: "ERROR", field: name, message: `GP${p} is out of range for RP2040/RP2350 (0-29).` });
+      }
+      if (["PICOW", "PICO2W"].includes(mcu) && [23, 24, 25, 29].includes(p)) {
+        errors.push({ level: "WARNING", field: name, message: `GP${p} is connected to the CYW43439 WiFi chip on Pico W / Pico 2 W.` });
+      }
+    }
+  }
+
+  // Check Motors
+  const numMotors = kinematics === "DIFFERENTIAL_DRIVE" ? 2 : 4;
+  const driverType = motors.driver_type;
+
+  for (let i = 1; i <= numMotors; i++) {
+    const m = pins[`motor${i}`] || {};
+    if (driverType === "BTS7960") {
+      registerPin(m.pwm_r, `Motor ${i} PWM_R`, true);
+      registerPin(m.pwm_l, `Motor ${i} PWM_L`, true);
+      registerPin(m.en, `Motor ${i} Enable`, true);
+    } else if (driverType === "GENERIC_2_IN") {
+      registerPin(m.pwm, `Motor ${i} PWM`, true);
+      registerPin(m.in_a, `Motor ${i} IN_A`, true);
+      registerPin(m.in_b, `Motor ${i} IN_B`, true);
+    } else if (driverType === "GENERIC_1_IN") {
+      registerPin(m.pwm, `Motor ${i} PWM`, true);
+      registerPin(m.dir, `Motor ${i} DIR`, true);
+    } else {
+      registerPin(m.pwm, `Motor ${i} PWM`, true);
+    }
+  }
+
+  // Check Encoders
+  const enc = pins.encoders || {};
+  for (let i = 1; i <= numMotors; i++) {
+    registerPin(enc[`m${i}_a`], `Encoder ${i} A`, false);
+    registerPin(enc[`m${i}_b`], `Encoder ${i} B`, false);
+  }
+
+  // Check LED
+  registerPin(pins.led, "Status LED", true);
+
+  // Check I2C
+  if (pins.i2c) {
+    registerPin(pins.i2c.sda, "I2C SDA", false);
+    registerPin(pins.i2c.scl, "I2C SCL", false);
+  }
+
+  // Check Battery
+  if (sensors.battery_monitor === "ADC_DIVIDER" && pins.battery_pin !== undefined) {
+    registerPin(pins.battery_pin, "Battery ADC", false);
+    if ((mcu === "PICO" || mcu === "PICO2") && !RP2040_ADC_PINS.includes(parseInt(pins.battery_pin, 10))) {
+      errors.push({ level: "ERROR", field: "Battery ADC", message: `GP${pins.battery_pin} is not an analog ADC pin on Pico/Pico2 (Must be GP26, GP27, or GP28).` });
+    }
+  }
+
+  // Check Battery Voltage & ADC Resistor Divider Safety (Limit <= 3.0V)
+  if (sensors.battery_monitor === "ADC_DIVIDER") {
+    const r1 = parseFloat(sensors.battery_r1 || 30000);
+    const r2 = parseFloat(sensors.battery_r2 || 7500);
+    const maxV = parseFloat(sensors.battery_max_voltage || 12.6);
+    if (r1 > 0 && r2 > 0 && maxV > 0) {
+      const totalR = r1 + r2;
+      const ratio = r2 / totalR;
+      const adcMaxV = maxV * ratio;
+      stats.adc_voltage_max_v = adcMaxV;
+      stats.adc_divider_ratio = ratio;
+      if (adcMaxV > 3.0) {
+        errors.push({
+          level: "WARNING",
+          field: "ADC Resistor Divider",
+          message: `ADC pin voltage will reach ${adcMaxV.toFixed(2)}V at full charge (${maxV.toFixed(1)}V), exceeding the 3.0V safe limit! Increase R1 or reduce R2.`
+        });
+      }
+    }
+  }
+
+  // Check Sonar
+  if (sensors.sonar && pins.sonar) {
+    registerPin(pins.sonar.trig, "Sonar Trigger", true);
+    registerPin(pins.sonar.echo, "Sonar Echo", false);
+  }
+
+  // Duplicate Pin Detection
+  for (const [pinNum, names] of Object.entries(assignedPins)) {
+    if (names.length > 1) {
+      errors.push({ level: "ERROR", field: `Pin ${pinNum}`, message: `Pin ${pinNum} assigned to multiple functions: ${names.join(", ")}` });
+    }
+  }
+
+  const isValid = !errors.some(e => e.level === "ERROR");
+  return { isValid, errors, stats };
+}
+
+// Update ADC Calculations & CAD Vector Circuit Schematic
+function updateAdcVoltageCalculations(spec) {
+  const s = spec || currentSpec;
+  const sensors = s.sensors || {};
+  const r1 = parseFloat(sensors.battery_r1 !== undefined ? sensors.battery_r1 : (document.getElementById("cfg-bat-r1")?.value || 30000));
+  const r2 = parseFloat(sensors.battery_r2 !== undefined ? sensors.battery_r2 : (document.getElementById("cfg-bat-r2")?.value || 7500));
+  const cap = parseFloat(sensors.battery_adc_cap !== undefined ? sensors.battery_adc_cap : (document.getElementById("cfg-bat-cap-val")?.value || 1000));
+  const maxV = parseFloat(sensors.battery_max_voltage !== undefined ? sensors.battery_max_voltage : (document.getElementById("cfg-bat-max")?.value || 12.6));
+  const nomV = parseFloat(sensors.battery_nominal_voltage !== undefined ? sensors.battery_nominal_voltage : (document.getElementById("cfg-bat-nom")?.value || 11.1));
+  const batPin = s.pins?.battery_pin !== undefined ? s.pins.battery_pin : (document.getElementById("pin-battery")?.value || 33);
+  const mcu = s.mcu || "ESP32";
+
+  const totalR = r1 + r2;
+  const ratio = totalR > 0 ? (r2 / totalR) : 0.2;
+  const adcMaxV = maxV * ratio;
+  const adcNomV = nomV * ratio;
+  const isSafe = adcMaxV <= 3.0;
+
+  // 1. Update Tab 3 Battery Safety Banner
+  const safetyBanner = document.getElementById("bat-adc-safety-banner");
+  const iconEl = document.getElementById("safety-banner-icon");
+  const titleEl = document.getElementById("safety-banner-title");
+  const descEl = document.getElementById("safety-banner-desc");
+  const ratioLbl = document.getElementById("lbl-divider-ratio");
+  const maxVLbl = document.getElementById("lbl-adc-max-v");
+
+  if (safetyBanner) {
+    safetyBanner.className = `adc-safety-banner ${isSafe ? 'safe' : 'warning'}`;
+    if (iconEl) iconEl.innerText = isSafe ? "🛡️" : "⚠️";
+    if (titleEl) titleEl.innerText = isSafe ? "ADC Input Voltage: Safe (≤ 3.0V)" : "HIGH VOLTAGE WARNING: Exceeds 3.0V Maximum ADC Limit!";
+    if (ratioLbl) ratioLbl.innerText = `${ratio.toFixed(4)} (1:${(1 / ratio).toFixed(1)})`;
+    if (maxVLbl) maxVLbl.innerText = `${adcMaxV.toFixed(2)} V`;
+    if (descEl) {
+      if (isSafe) {
+        descEl.innerHTML = `Divider Ratio: <code>${ratio.toFixed(4)} (1:${(1 / ratio).toFixed(1)})</code> | Max ADC Pin Voltage: <code>${adcMaxV.toFixed(2)} V</code> at full charge (${maxV.toFixed(1)}V). Nominal: <code>${adcNomV.toFixed(2)} V</code>. Filter Cap: <code>${cap} pF</code>.`;
+      } else {
+        descEl.innerHTML = `⚠️ ADC input voltage reaches <code>${adcMaxV.toFixed(2)} V</code> at full charge (${maxV.toFixed(1)}V), exceeding the 3.0V safe linear limit! Risk of saturation or non-linearity. Increase R1 or decrease R2.`;
+      }
+    }
+  }
+
+  // 2. Update CAD Vector Schematic (SVG)
+  const svgR1 = document.getElementById("cad-svg-r1");
+  if (svgR1) svgR1.textContent = `R1: ${(r1 / 1000).toFixed(1)} kΩ`;
+
+  const svgR2 = document.getElementById("cad-svg-r2-val");
+  if (svgR2) svgR2.textContent = `${(r2 / 1000).toFixed(1)} kΩ`;
+
+  const svgCap = document.getElementById("cad-svg-cap");
+  if (svgCap) svgCap.textContent = `C: ${cap} pF (${(cap / 1000).toFixed(1)}nF)`;
+
+  const svgVbat = document.getElementById("cad-svg-vbat");
+  if (svgVbat) svgVbat.textContent = `${maxV.toFixed(1)} V (Full)`;
+
+  const svgAdcPin = document.getElementById("cad-svg-adc-pin");
+  if (svgAdcPin) svgAdcPin.textContent = `${isESP32(mcu) ? 'ESP32 ADC' : 'MCU ADC'} (GPIO ${batPin || 33})`;
+
+  const svgVadcRead = document.getElementById("cad-svg-vadc-read");
+  if (svgVadcRead) svgVadcRead.textContent = `V_ADC = ${adcMaxV.toFixed(2)} V (Max)`;
+
+  const cadBadgeRatio = document.getElementById("cad-badge-ratio");
+  if (cadBadgeRatio) cadBadgeRatio.textContent = `Ratio: ${ratio.toFixed(4)} (1:${(1 / ratio).toFixed(1)})`;
+
+  const cadBadgeSafety = document.getElementById("cad-badge-safety");
+  if (cadBadgeSafety) {
+    cadBadgeSafety.className = `schematic-badge ${isSafe ? 'badge-safe' : 'badge-warning'}`;
+    cadBadgeSafety.textContent = isSafe ? `🛡️ V_ADC: ${adcMaxV.toFixed(2)}V ≤ 3.0V` : `⚠️ V_ADC: ${adcMaxV.toFixed(2)}V > 3.0V (Exceeds Limit!)`;
+  }
+
+  const cadWarnBox = document.getElementById("cad-svg-warning-box");
+  if (cadWarnBox) {
+    cadWarnBox.style.display = isSafe ? "none" : "inline";
+    const cadWarnText = document.getElementById("cad-svg-warning-text");
+    if (cadWarnText) cadWarnText.textContent = `Max ${adcMaxV.toFixed(2)}V exceeds 3.0V limit`;
+  }
+}
+
+// Render Safety Inspector Results
+function renderSafetyInspector({ isValid, errors }) {
+  const dot = document.getElementById("safety-status-dot");
+  const title = document.getElementById("safety-status-title");
+  const badge = document.getElementById("safety-status-badge");
+  const list = document.getElementById("safety-messages-list");
+
+  const errCount = errors.filter(e => e.level === "ERROR").length;
+  const warnCount = errors.filter(e => e.level === "WARNING").length;
+
+  if (errCount > 0) {
+    dot.className = "status-dot status-err";
+    title.innerText = "Hardware Safety Rules: FAILED";
+    badge.className = "safety-badge badge-err";
+    badge.innerText = `${errCount} Error${errCount > 1 ? "s" : ""}`;
+  } else if (warnCount > 0) {
+    dot.className = "status-dot status-warn";
+    title.innerText = "Hardware Safety Rules: WARNINGS";
+    badge.className = "safety-badge badge-warn";
+    badge.innerText = `${warnCount} Warning${warnCount > 1 ? "s" : ""}`;
+  } else {
+    dot.className = "status-dot status-ok";
+    title.innerText = "Hardware Safety Rules: PASSED";
+    badge.className = "safety-badge badge-ok";
+    badge.innerText = "0 Errors";
+  }
+
+  if (errors.length === 0) {
+    list.innerHTML = `
+      <div class="safety-item item-ok">
+        <span class="item-icon">✅</span>
+        <span>All pin assignments, electrical constraints, and kinematics are 100% verified.</span>
+      </div>
+    `;
+  } else {
+    list.innerHTML = errors.map(err => `
+      <div class="safety-item ${err.level === 'ERROR' ? 'item-err' : 'item-warn'}">
+        <span class="item-icon">${err.level === 'ERROR' ? '❌' : '⚠️'}</span>
+        <span><strong>${err.field}:</strong> ${err.message}</span>
+      </div>
+    `).join("");
+  }
+}
+
+// Render Kinematics Metrics HUD
+function renderKinematicsHUD(stats) {
+  const speedMs = stats.max_linear_speed_m_s || 0;
+  const speedKmh = speedMs * 3.6;
+  const rads = stats.max_angular_speed_rad_s || 0;
+  const degs = rads * (180 / Math.PI);
+  const ticks = stats.ticks_per_meter || 0;
+  const circ = stats.wheel_circumference_m || 0;
+
+  document.getElementById("val-speed-ms").innerText = speedMs.toFixed(2);
+  document.getElementById("val-speed-kmh").innerText = `${speedKmh.toFixed(2)} km/h (85% Headroom)`;
+
+  document.getElementById("val-speed-rads").innerText = rads.toFixed(2);
+  document.getElementById("val-speed-degs").innerText = `${degs.toFixed(1)} deg/s`;
+
+  document.getElementById("val-ticks-m").innerText = Math.round(ticks).toLocaleString();
+  document.getElementById("val-wheel-circ").innerText = `Circumference: ${circ.toFixed(3)} m`;
+
+  if (document.getElementById("val-max-accel") && stats.max_accel_m_s2 !== undefined) {
+    document.getElementById("val-max-accel").innerText = stats.max_accel_m_s2.toFixed(2);
+    document.getElementById("val-thrust-sub").innerText = `Thrust: ${(stats.total_thrust_n || 0).toFixed(2)} N @ ${(stats.weight_kg || 3.5).toFixed(1)} kg`;
+  }
+}
+
+// Code Generators
+function generateCppHeader(spec) {
+  const name = spec.robot_name || "my_robot";
+  const nameUpper = name.toUpperCase();
+  const kinematics = spec.kinematics || "DIFFERENTIAL_DRIVE";
+  const mcu = (spec.mcu || "PICO2").toUpperCase();
+  const geom = spec.geometry || {};
+  const motors = spec.motors || {};
+  const sensors = spec.sensors || {};
+  const pins = spec.pins || {};
+  const driver = motors.driver_type || "GENERIC_2_IN";
+  const is4WD = kinematics !== "DIFFERENTIAL_DRIVE";
+
+  const lines = [
+    `// =============================================================================`,
+    `// Auto-generated Linorobot2 Configuration for ${name}`,
+    `// Microcontroller: ${mcu} | Kinematics: ${kinematics}`,
+    `// =============================================================================`,
+    `#ifndef ${nameUpper}_CONFIG_H`,
+    `#define ${nameUpper}_CONFIG_H`,
+    ``,
+    `#define LINO_BASE ${kinematics}`,
+    `#define USE_${driver}_MOTOR_DRIVER`,
+    ``,
+    `// Kinematics & Wheel Geometry`,
+    `#define WHEEL_DIAMETER ${geom.wheel_diameter || 0.08} // meters`,
+    `#define LR_WHEELS_DISTANCE ${geom.track_width || 0.22} // meters`
+  ];
+
+  if (is4WD && geom.wheelbase) {
+    lines.push(`#define FR_WHEELS_DISTANCE ${geom.wheelbase} // meters`);
+  }
+
+  lines.push(
+    ``,
+    `// Motor & Encoder Parameters`,
+    `#define MOTOR_MAX_RPM ${motors.max_rpm || 330}`,
+    `#define MAX_RPM_RATIO 0.85`,
+    `#define MOTOR_OPERATING_VOLTAGE ${motors.operating_voltage || 12.0}`,
+    `#define MOTOR_POWER_MAX_VOLTAGE ${motors.operating_voltage || 12.0}`,
+    `#define PWM_FREQUENCY 20000`,
+    `#define PWM_BITS 10`,
+    ``,
+    `#define COUNTS_PER_REV1 ${motors.cpr || 1440}`,
+    `#define COUNTS_PER_REV2 ${motors.cpr || 1440}`,
+    `#define COUNTS_PER_REV3 ${motors.cpr || 1440}`,
+    `#define COUNTS_PER_REV4 ${motors.cpr || 1440}`,
+    ``,
+    `#define MOTOR1_INV ${!!motors.motor1_inv}`,
+    `#define MOTOR2_INV ${!!motors.motor2_inv}`,
+    `#define MOTOR3_INV ${!!motors.motor3_inv}`,
+    `#define MOTOR4_INV ${!!motors.motor4_inv}`,
+    `#define MOTOR1_ENCODER_INV ${!!(pins?.encoders?.m1_inv)}`,
+    `#define MOTOR2_ENCODER_INV ${!!(pins?.encoders?.m2_inv)}`,
+    `#define MOTOR3_ENCODER_INV ${!!(pins?.encoders?.m3_inv)}`,
+    `#define MOTOR4_ENCODER_INV ${!!(pins?.encoders?.m4_inv)}`,
+    ``,
+    `// Velocity PID Tuning Constants`,
+    `#define K_P ${spec.pid?.kp ?? 0.6}`,
+    `#define K_I ${spec.pid?.ki ?? 0.8}`,
+    `#define K_D ${spec.pid?.kd ?? 0.5}`,
+    ``,
+    `// Pin Assignments`,
+    `#define LED_PIN ${pins.led !== undefined ? pins.led : (["PICOW", "PICO2W"].includes(mcu) ? "LED_BUILTIN" : (mcu.includes("PICO") ? 25 : 2))}`
+  );
+
+  // ENCODER PINS (all 4, unconditional -- matches the hand-written headers)
+  const enc = pins.encoders || {};
+  const pinVal = (v) => (v !== undefined && v !== null && v !== "") ? v : -1;
+  lines.push(``, `// ENCODER PINS`);
+  for (let i = 1; i <= 4; i++) {
+    lines.push(`#define MOTOR${i}_ENCODER_A ${pinVal(enc[`m${i}_a`])}`);
+    lines.push(`#define MOTOR${i}_ENCODER_B ${pinVal(enc[`m${i}_b`])}`);
+  }
+
+  // MOTOR PINS -- firmware.ino reads MOTORx_PWM / MOTORx_IN_A / MOTORx_IN_B for
+  // EVERY driver (see firmware/src/firmware.ino motorN_controller(...) and
+  // firmware/lib/motor/default_motor.h). Keep this identical to generator.py.
+  lines.push(``, `// MOTOR PINS`);
+  lines.push(`#ifdef USE_${driver}_MOTOR_DRIVER`);
+  for (let i = 1; i <= 4; i++) {
+    const m = pins[`motor${i}`] || {};
+    if (driver === "BTS7960") {
+      // MOTORx_PWM = RPWM (unused placeholder), IN_A = LPWM, IN_B = EN
+      lines.push(`  #define MOTOR${i}_PWM ${pinVal(m.pwm_r !== undefined ? m.pwm_r : m.pwm)} //DON'T TOUCH THIS! This is just a placeholder`);
+      lines.push(`  #define MOTOR${i}_IN_A ${pinVal(m.pwm_l !== undefined ? m.pwm_l : m.in_a)}`);
+      lines.push(`  #define MOTOR${i}_IN_B ${pinVal(m.en !== undefined ? m.en : m.in_b)}`);
+    } else if (driver === "GENERIC_1_IN") {
+      lines.push(`  #define MOTOR${i}_PWM ${pinVal(m.pwm)}`);
+      lines.push(`  #define MOTOR${i}_IN_A ${pinVal(m.dir !== undefined ? m.dir : m.in_a)}`);
+      lines.push(`  #define MOTOR${i}_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder`);
+    } else if (driver === "ESC") {
+      lines.push(`  #define MOTOR${i}_PWM ${pinVal(m.pwm)}`);
+      lines.push(`  #define MOTOR${i}_IN_A -1 //DON'T TOUCH THIS! This is just a placeholder`);
+      lines.push(`  #define MOTOR${i}_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder`);
+    } else {
+      // GENERIC_2_IN (default)
+      lines.push(`  #define MOTOR${i}_PWM ${pinVal(m.pwm)}`);
+      lines.push(`  #define MOTOR${i}_IN_A ${pinVal(m.in_a)}`);
+      lines.push(`  #define MOTOR${i}_IN_B ${pinVal(m.in_b)}`);
+    }
+  }
+  lines.push(`  #define PWM_MAX pow(2, PWM_BITS) - 1`);
+  lines.push(`  #define PWM_MIN -PWM_MAX`);
+  lines.push(`#endif`);
+
+  lines.push(``, `// Sensor Configurations`);
+  if (sensors.imu === "FAKE" || sensors.imu === "FAKE_IMU") {
+    lines.push(`#define USE_FAKE_IMU`);
+  } else if (sensors.imu && sensors.imu !== "NONE") {
+    lines.push(`#define USE_${sensors.imu}_IMU`);
+  }
+  if (sensors.mag && sensors.mag !== "NONE") {
+    lines.push(`#define USE_${sensors.mag}_MAG`);
+  } else {
+    lines.push(`#define USE_FAKE_MAG`);
+  }
+
+  // IMU / magnetometer tuning — MAG_BIAS is #ifdef-gated in firmware.ino;
+  // ACCEL_COV / GYRO_COV / ORI_COV are #ifndef-gated in imu_interface.h.
+  const tune = spec.imu_tuning || {};
+  if (Array.isArray(tune.mag_bias) && tune.mag_bias.length === 3) {
+    lines.push(`#define MAG_BIAS { ${tune.mag_bias.map(Number).join(", ")} }`);
+  }
+  const covLine = (macro, v) => {
+    if (v == null) return;
+    const t = Array.isArray(v) ? v.map(Number) : [Number(v), Number(v), Number(v)];
+    lines.push(`#define ${macro} { ${t.join(", ")} }`);
+  };
+  covLine("ACCEL_COV", tune.accel_cov);
+  covLine("GYRO_COV", tune.gyro_cov);
+  covLine("ORI_COV", tune.ori_cov);
+
+  if (sensors.battery_monitor === "ADC_DIVIDER") {
+    const numFmt = (x) => { const f = Number(x); return Number.isInteger(f) ? String(f) : String(f).replace(/0+$/,"").replace(/\.$/,""); };
+    const r1k = numFmt((sensors.battery_r1 || 30000) / 1000);
+    const r2k = numFmt((sensors.battery_r2 || 7500) / 1000);
+    const isRp2 = mcu.includes("PICO") || mcu.includes("RP2");
+    lines.push(`#define BATTERY_PIN ${pins.battery_pin ?? 26}`);
+    // firmware/lib/battery/battery.cpp calls BATTERY_ADJUST(reading) with no
+    // #ifndef fallback — an ADC battery config MUST define it. ESP32
+    // analogReadMilliVolts() returns mV; RP2040 analogRead() returns 12-bit counts.
+    if (spec.adc_lut || sensors.adc_lut) {
+      lines.push(
+        `#define USE_ADC_LUT`,
+        formatAdcLutArray(spec.adc_lut || sensors.adc_lut),
+        `#define BATTERY_ADJUST(v) (ADC_LUT[v] * (3.3 / 4096 * (${r1k} + ${r2k}) / ${r2k}))`
+      );
+    } else if (isRp2) {
+      lines.push(`#define BATTERY_ADJUST(v) ((v) * (3.3 / 4096 * (${r1k} + ${r2k}) / ${r2k}))`);
+    } else {
+      lines.push(`#define BATTERY_ADJUST(v) ((v) * ((${r1k} + ${r2k}) / ${r2k}) / 1000.0)`);
+    }
+    if (sensors.battery_min_voltage != null) lines.push(`#define BATTERY_MIN ${numFmt(sensors.battery_min_voltage)}`);
+    if (sensors.battery_max_voltage != null) lines.push(`#define BATTERY_MAX ${numFmt(sensors.battery_max_voltage)}`);
+    if (sensors.battery_capacity != null)    lines.push(`#define BATTERY_CAP ${numFmt(sensors.battery_capacity)}`);
+    if (sensors.battery_dip != null)         lines.push(`#define BATTERY_DIP ${numFmt(sensors.battery_dip)}`);
+  } else if (sensors.battery_monitor === "INA219") {
+    lines.push(`#define USE_INA219`);
+  }
+
+  if (sensors.sonar && pins.sonar) {
+    lines.push(
+      `#define USE_SONAR`,
+      `#define TRIG_PIN ${pins.sonar.trig || 0}`,
+      `#define ECHO_PIN ${pins.sonar.echo || 0}`
+    );
+  }
+
+  // I2C bus + BOARD_INIT. SDA_PIN/SCL_PIN are ONLY consulted through the
+  // BOARD_INIT macro (firmware.ino: `#ifdef BOARD_INIT ... #else Wire.begin();
+  // #endif` — firmware is never touched for this). BOARD_INIT is synthesised
+  // only when the user has defined I2C pins; a bare module leaves SDA/SCL
+  // unset and no BOARD_INIT is emitted (default Wire.begin() applies).
+  const i2c = pins.i2c || {};
+  const i2cUsed = (sensors.imu && sensors.imu !== "FAKE" && sensors.imu !== "FAKE_IMU" && sensors.imu !== "NONE")
+               || (sensors.mag && sensors.mag !== "NONE")
+               || sensors.battery_monitor === "INA219";
+  const sda = i2c.sda, scl = i2c.scl;
+  if (i2cUsed && sda !== undefined && scl !== undefined && sda >= 0 && scl >= 0) {
+    lines.push(``, `// I2C Bus`, `#define SDA_PIN ${sda}`, `#define SCL_PIN ${scl}`);
+    const bi = [`#define BOARD_INIT { \\`];
+    if (driver === "BTS7960") {
+      for (let i = 1; i <= (is4WD ? 4 : 2); i++) {
+        const mm = pins[`motor${i}`] || {};
+        const pwm = mm.pwm_r !== undefined ? mm.pwm_r : mm.pwm;
+        if (pwm !== undefined && pwm >= 0) {
+          bi.push(`    pinMode(MOTOR${i}_PWM, OUTPUT); \\`);
+          bi.push(`    digitalWrite(MOTOR${i}_PWM, HIGH); \\`);
+        }
+      }
+    }
+    bi.push(`    Wire.begin(SDA_PIN, SCL_PIN); \\`);
+    bi.push(`    Wire.setClock(400000); \\`);
+    bi.push(`}`);
+    lines.push(...bi);
+  }
+
+  // Communication & Network Settings
+  const transport = (spec.transport || "SERIAL").toUpperCase();
+  const wifi = spec.wifi_settings || {};
+  const isWifiTransport = transport.includes("WIFI") || transport.includes("UDP");
+  const enableWifiNet = isWifiTransport || !!spec.enable_ota_syslog;
+
+  if (!isWifiTransport) {
+    const baudrate = spec.baudrate || spec.telemetry?.baudrate || (mcu === "GENDRV" ? 1500000 : 921600);
+    lines.push(
+      ``,
+      `// Serial Communication Settings`,
+      `#define BAUDRATE ${baudrate}`
+    );
+  }
+
+  // ROS 2 topic namespace prefix (firmware.ino concatenates it onto each
+  // topic string literal; #ifndef-gated so blank == bare topic names).
+  const topicPrefix = (spec.advanced?.topic_prefix || "").trim();
+  if (topicPrefix) {
+    const tp = topicPrefix.endsWith("/") ? topicPrefix : topicPrefix + "/";
+    lines.push(``, `// ROS 2 Topic Namespace`, `#define TOPIC_PREFIX "${tp}"`);
+  }
+
+  // Hardware Task Watchdog (WDT)
+  if (spec.watchdog && (spec.watchdog.enabled || spec.watchdog > 0)) {
+    const to = spec.watchdog.timeout_sec || (typeof spec.watchdog === "number" ? spec.watchdog : 60);
+    lines.push(``, `// Hardware Task Watchdog`, `#define WDT_TIMEOUT ${to} // Seconds`);
+  } else {
+    lines.push(``, `// #define WDT_TIMEOUT 60 // Hardware Task Watchdog disabled`);
+  }
+
+
+  // IPv4 "a.b.c.d" -> C brace-init `{ a, b, c, d }` (the form every stock
+  // header uses; converts cleanly to IPAddress for AGENT_IP / SYSLOG_SERVER
+  // / LIDAR_SERVER).
+  const ipC = (s, fb) => {
+    const p = String(s || fb || "192.168.1.100").split(".").map(x => x.trim());
+    return p.length === 4 && p.every(x => /^\d+$/.test(x)) ? `{ ${p.join(", ")} }` : "{ 192, 168, 1, 100 }";
+  };
+  const adv = spec.advanced || {};
+
+  // Never emit WIFI_AP_LIST with a placeholder SSID — initWifis() blocks at
+  // boot until it joins, so a placeholder would brick a bare board.
+  const _haveRealSsid = wifi.ssid && wifi.ssid.trim() && wifi.ssid.trim() !== "YOUR_WIFI_SSID";
+  if (enableWifiNet && _haveRealSsid) {
+    // Secrets (WIFI_AP_LIST, AGENT_IP, SYSLOG_SERVER, LIDAR_SERVER, OTA_PASSWORD)
+    // live ONLY in the git-ignored config/custom/wifi_config.h — this tracked
+    // header carries the non-secret feature flags and pulls the rest in.
+    lines.push(
+      ``,
+      isWifiTransport
+        ? `// WiFi & micro-ROS Agent Settings`
+        : `// Background WiFi (OTA & Syslog telemetry while micro-ROS runs on Serial)`,
+      `// Credentials & host IPs are in the git-ignored config/custom/wifi_config.h`,
+      `// (regenerated by the deploy from your form; template: wifi_config.h.template).`,
+      `#if __has_include("wifi_config.h")`,
+      `  #include "wifi_config.h"`,
+      `#endif`
+    );
+    if (isWifiTransport) {
+      lines.push(`#define USE_WIFI`, `#define AGENT_PORT ${wifi.agent_port || 8888}`);
+    }
+    lines.push(`#define USE_ARDUINO_OTA`);
+    lines.push(`#define OTA_HOSTNAME "${adv.ota_hostname || spec.robot_name || "linorobot2"}"`);
+    lines.push(
+      `#define USE_SYSLOG`,
+      `#define SYSLOG_PORT ${adv.syslog_port || 514}`,
+      `#define DEVICE_HOSTNAME "${spec.robot_name || "robot"}"`,
+      `#define APP_NAME "hardware"`
+    );
+    // LiDAR-over-UDP forwarding — only when the user ticked "Forward LiDAR
+    // over UDP" (a non-blank IP field default must NOT enable it; USE_LIDAR_UDP
+    // pulls in ESP32-only HardwareSerial APIs that break the Pico build).
+    if (spec.telemetry?.use_lidar_udp) {
+      lines.push(
+        `#define USE_LIDAR_UDP`,
+        `#define LIDAR_PORT ${adv.lidar_port || 8889}`,
+        `#define LIDAR_BAUDRATE ${adv.lidar_baudrate || 230400}`,
+        `#define LIDAR_SERIAL ${adv.lidar_serial != null ? adv.lidar_serial : 1} // UART number`,
+        `#define LIDAR_RXD ${adv.lidar_rxd != null ? adv.lidar_rxd : -1}`
+      );
+    }
+  }
+
+  if (spec.dual_core !== false) {
+    lines.push(
+      ``,
+      `// Dual-Core Task Allocation (Strict 50Hz Real-Time PID on Core 1)`,
+      `#define USE_DUAL_CORE`
+    );
+  }
+
+  lines.push(``, `#endif // ${nameUpper}_CONFIG_H`, ``);
+  return lines.join("\n");
+}
+
+// Secrets file — WiFi credentials + host IPs. Written to config/custom/wifi_config.h,
+// which is git-ignored, so `git add config/` never commits them. Empty string
+// when the spec has no real WiFi SSID (nothing to write).
+function generateWifiConfig(spec) {
+  const wifi = spec.wifi_settings || {};
+  const adv = spec.advanced || {};
+  const ssid = (wifi.ssid || "").trim();
+  if (!ssid || ssid === "YOUR_WIFI_SSID") return "";
+  const transport = (spec.transport || "SERIAL").toUpperCase();
+  const isWifiTransport = /WIFI|UDP/.test(transport);
+  const enableWifiNet = isWifiTransport || !!spec.enable_ota_syslog;
+  if (!enableWifiNet) return "";
+  const password = wifi.password || "";
+  const ipC = (s, fb) => {
+    const p = String(s || fb || "192.168.1.100").split(".").map(x => x.trim());
+    return p.length === 4 && p.every(x => /^\d+$/.test(x)) ? `{ ${p.join(", ")} }` : "{ 192, 168, 1, 100 }";
+  };
+  const agentIpStr = adv.agent_ip || wifi.agent_ip || "192.168.1.100";
+  const L = [
+    `// config/custom/wifi_config.h  —  generated by the Robot Configuration Engine`,
+    `// GIT-IGNORED: your WiFi credentials and host IPs are never committed.`,
+    `// Delete this file to let the studio regenerate it, or edit it by hand`,
+    `// (multiple APs, static IPs, …). Template: wifi_config.h.template.`,
+    ``,
+    `#define WIFI_AP_LIST { { "${ssid}", "${password}" }, { NULL, NULL } }`,
+  ];
+  if (isWifiTransport) L.push(`#define AGENT_IP ${ipC(agentIpStr)}`);
+  L.push(`#define SYSLOG_SERVER ${ipC(adv.syslog_ip, agentIpStr)}`);
+  if (spec.telemetry?.use_lidar_udp) L.push(`#define LIDAR_SERVER ${ipC(adv.lidar_ip, agentIpStr)}`);
+  if (adv.ota_password) L.push(`#define OTA_PASSWORD "${adv.ota_password}"`);
+  L.push(``);
+  return L.join("\n");
+}
+
+function generatePlatformioEnv(spec) {
+  const name = spec.robot_name || "my_robot";
+  const mcu = (spec.mcu || "PICO2").toUpperCase();
+  const cfgMacro = `USE_${name.toUpperCase()}_CONFIG`;
+  const isWifi = /WIFI|UDP/i.test(spec.transport || "");
+  const wifiTransportLine = isWifi ? "board_microros_transport = wifi\n" : "";
+  const wifiFlag = isWifi ? "\n    -D USE_STAY_CONNECTED" : "";
+
+  if (mcu === "PICO" || mcu === "PICO2" || mcu === "PICOW" || mcu === "PICO2W") {
+    const boardMap = { PICO: "rpipico", PICO2: "rpipico2", PICOW: "rpipicow", PICO2W: "rpipico2w" };
+    const board = boardMap[mcu] || "rpipico";
+    const picoMacro = (mcu === "PICOW" || mcu === "PICO2W") ? `    -D ${mcu}\n` : "";
+    return `[env:${name}]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = ${board}
+monitor_port = /dev/ttyACM0
+upload_port = /dev/ttyACM0
+upload_protocol = picotool
+board_microros_user_meta = atomic.meta
+${wifiTransportLine}lib_deps =
+    \${env.lib_deps}
+    https://github.com/gbr1/rp2040-encoder-library.git
+build_flags =
+    -I ../config
+    -D PICO
+${picoMacro}    -D ${cfgMacro}${wifiFlag}
+`;
+  } else if (mcu === "ESP32" || mcu === "GENDRV") {
+    const otaIp = (spec.advanced?.ota_enable && spec.advanced?.ota_ip) ? spec.advanced.ota_ip : "";
+    const upl = otaIp
+      ? `monitor_port = /dev/ttyUSB0\nupload_port = ${otaIp}\nupload_protocol = espota`
+      : `monitor_port = /dev/ttyUSB0\nupload_port = /dev/ttyUSB0\nupload_protocol = esptool`;
+    return `[env:${name}]
+platform = espressif32
+board = nodemcu-32s
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
+board_build.partitions = min_spiffs.csv
+monitor_speed = 921600
+${upl}
+${wifiTransportLine}lib_deps =
+    \${env.lib_deps}
+    madhephaestus/ESP32Servo
+    madhephaestus/ESP32Encoder
+build_flags =
+    -I ../config
+    -D __PGMSPACE_H_
+    -D ${cfgMacro}${wifiFlag}
+`;
+  } else if (mcu === "ESP32S3") {
+    const isBridge = (spec.serial_interface || "CDC") === "BRIDGE";
+    const port = isBridge ? "/dev/ttyUSB0" : "/dev/ttyACM0";
+    const cdcFlag = isBridge ? "" : "\n    -D ARDUINO_USB_CDC_ON_BOOT";
+    return `[env:${name}]
+platform = espressif32
+board = esp32-s3-devkitc-1
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
+monitor_speed = 921600
+monitor_port = ${port}
+upload_port = ${port}
+upload_protocol = esptool
+${wifiTransportLine}lib_deps =
+    \${env.lib_deps}
+    madhephaestus/ESP32Servo
+    madhephaestus/ESP32Encoder
+build_flags =
+    -I ../config${cdcFlag}
+    -D __PGMSPACE_H_
+    -D ${cfgMacro}${wifiFlag}
+`;
+  } else if (mcu === "ESP32S2") {
+    const isBridge = (spec.serial_interface || "CDC") === "BRIDGE";
+    const port = isBridge ? "/dev/ttyUSB0" : "/dev/ttyACM0";
+    const cdcFlag = isBridge ? "" : "\n    -D ARDUINO_USB_CDC_ON_BOOT";
+    return `[env:${name}]
+platform = espressif32
+board = esp32-s2-saola-1
+monitor_speed = 921600
+monitor_port = ${port}
+upload_port = ${port}
+upload_protocol = esptool
+${wifiTransportLine}lib_deps =
+    \${env.lib_deps}
+    madhephaestus/ESP32Servo
+    madhephaestus/ESP32Encoder
+build_flags =
+    -I ../config${cdcFlag}
+    -D __PGMSPACE_H_
+    -D ${cfgMacro}${wifiFlag}
+`;
+  }
+  return "";
+}
+
+function generateUrdfXacro(spec) {
+  const geom = spec.geometry || {};
+  const wheelD = geom.wheel_diameter || 0.08;
+  const wheelR = wheelD / 2.0;
+  const trackW = geom.track_width || 0.22;
+  const wheelPosY = trackW / 2.0;
+
+  return `<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:property name="wheel_radius" value="${wheelR.toFixed(4)}" />
+  <xacro:property name="wheel_width" value="0.026" />
+  <xacro:property name="wheel_pos_x" value="0.0" />
+  <xacro:property name="wheel_pos_y" value="${wheelPosY.toFixed(4)}" />
+  <xacro:property name="wheel_pos_z" value="-0.010" />
+  <xacro:property name="wheel_mass" value="0.05" />
+
+  <xacro:property name="base_length" value="${(trackW * 1.2).toFixed(3)}" />
+  <xacro:property name="base_width" value="${(trackW * 0.9).toFixed(3)}" />
+  <xacro:property name="base_height" value="0.070" />
+  <xacro:property name="base_mass" value="1.2" />
+
+  <xacro:property name="laser_pose">
+    <origin xyz="0.05 0 0.08" rpy="0 0 0"/>
+  </xacro:property>
+</robot>
+`;
+}
+
+function generateWiringTable(spec) {
+  const mcu = spec.mcu;
+  const pins = spec.pins || {};
+  const driver = spec.motors?.driver_type || "GENERIC_2_IN";
+  const is4WD = spec.kinematics !== "DIFFERENTIAL_DRIVE";
+
+  const rows = [
+    `# 🔌 Wiring & Pinout Chart for ${spec.robot_name}`,
+    `**Microcontroller**: ${mcu} | **Kinematics**: ${spec.kinematics} | **Driver**: ${driver}`,
+    ``,
+    `| Function | MCU Pin (GPIO) | Target Peripheral / Signal | Wire Color / Notes |`,
+    `| :--- | :---: | :--- | :--- |`,
+    `| **Status LED** | \`GPIO ${pins.led}\` | Onboard or External LED | Status Blinker |`
+  ];
+
+  const numMotors = is4WD ? 4 : 2;
+  for (let i = 1; i <= numMotors; i++) {
+    const m = pins[`motor${i}`] || {};
+    if (driver === "BTS7960") {
+      rows.push(`| **Motor ${i} PWM_R** | \`GPIO ${m.pwm_r}\` | BTS7960 R_PWM | Forward PWM |`);
+      rows.push(`| **Motor ${i} PWM_L** | \`GPIO ${m.pwm_l}\` | BTS7960 L_PWM | Reverse PWM |`);
+      if (m.en !== undefined) rows.push(`| **Motor ${i} Enable** | \`GPIO ${m.en}\` | BTS7960 R_EN / L_EN | Enable Pin |`);
+    } else {
+      rows.push(`| **Motor ${i} PWM** | \`GPIO ${m.pwm}\` | Driver PWM / ENA | Speed Control |`);
+      rows.push(`| **Motor ${i} IN_A** | \`GPIO ${m.in_a}\` | Driver IN1 / DIR | Direction Line A |`);
+      rows.push(`| **Motor ${i} IN_B** | \`GPIO ${m.in_b}\` | Driver IN2 | Direction Line B |`);
+    }
+  }
+
+  const enc = pins.encoders || {};
+  for (let i = 1; i <= numMotors; i++) {
+    rows.push(`| **Encoder ${i} Phase A** | \`GPIO ${enc[`m${i}_a`]}\` | Wheel ${i} Encoder A | Hardware Interrupt |`);
+    rows.push(`| **Encoder ${i} Phase B** | \`GPIO ${enc[`m${i}_b`]}\` | Wheel ${i} Encoder B | Direction Read |`);
+  }
+
+  if (pins.i2c) {
+    rows.push(`| **I2C SDA** | \`GPIO ${pins.i2c.sda}\` | IMU / Mag / INA219 SDA | I2C Data Line (4.7kΩ Pullup) |`);
+    rows.push(`| **I2C SCL** | \`GPIO ${pins.i2c.scl}\` | IMU / Mag / INA219 SCL | I2C Clock Line (4.7kΩ Pullup) |`);
+  }
+
+  if (spec.sensors?.battery_monitor === "ADC_DIVIDER" && pins.battery_pin !== undefined) {
+    rows.push(`| **Battery Divider** | \`GPIO ${pins.battery_pin}\` | Voltage Divider Center | 30kΩ/7.5kΩ Divider to V_BAT |`);
+  }
+
+  if (spec.sensors?.sonar && pins.sonar) {
+    rows.push(`| **Sonar Trigger** | \`GPIO ${pins.sonar.trig}\` | HC-SR04 Trig | 10us Output Pulse |`);
+    rows.push(`| **Sonar Echo** | \`GPIO ${pins.sonar.echo}\` | HC-SR04 Echo | 5V->3.3V Voltage Divider Recommended |`);
+  }
+
+  return rows.join("\n");
+}
+
+// Render the Active Code Tab
+function renderActiveCode() {
+  const display = document.getElementById("code-display");
+  let code = "";
+
+  if (activeArtifact === "tab-code-header") {
+    code = generateCppHeader(currentSpec);
+    display.className = "language-cpp";
+  } else if (activeArtifact === "tab-code-pio") {
+    code = generatePlatformioEnv(currentSpec);
+    display.className = "language-ini";
+  } else if (activeArtifact === "tab-code-urdf") {
+    code = generateUrdfXacro(currentSpec);
+    display.className = "language-xml";
+  } else if (activeArtifact === "tab-code-wiring") {
+    code = generateWiringTable(currentSpec);
+    display.className = "language-markdown";
+  } else if (activeArtifact === "tab-code-deploy") {
+    code = generateDeployScript(currentSpec, readAutomationOptions());
+    display.className = "language-bash";
+  } else if (activeArtifact === "tab-code-json") {
+    code = JSON.stringify(currentSpec, null, 2);
+    display.className = "language-json";
+  }
+
+  display.innerText = code;
+}
+
+// Smart Auto-Assign Pinout Algorithm
+function autoAssignPins() {
+  const mcu = currentSpec.mcu;
+  const is4WD = currentSpec.kinematics !== "DIFFERENTIAL_DRIVE";
+  const driver = currentSpec.motors?.driver_type || "GENERIC_2_IN";
+
+  if (mcu === "PICO" || mcu === "PICO2" || mcu === "PICOW" || mcu === "PICO2W") {
+    document.getElementById("pin-led").value = (mcu === "PICOW" || mcu === "PICO2W") ? 32 : 25;
+    document.getElementById("pin-i2c-sda").value = 0;
+    document.getElementById("pin-i2c-scl").value = 1;
+    document.getElementById("pin-battery").value = 26;
+    document.getElementById("pin-sonar-trig").value = 22;
+    document.getElementById("pin-sonar-echo").value = 27;
+
+    document.getElementById("pin-m1-p1").value = 10;
+    document.getElementById("pin-m1-p2").value = 11;
+    document.getElementById("pin-m1-p3").value = 12;
+
+    document.getElementById("pin-m2-p1").value = 13;
+    document.getElementById("pin-m2-p2").value = 14;
+    document.getElementById("pin-m2-p3").value = 15;
+
+    document.getElementById("pin-enc-1a").value = 2;
+    document.getElementById("pin-enc-1b").value = 3;
+    document.getElementById("pin-enc-2a").value = 4;
+    document.getElementById("pin-enc-2b").value = 5;
+
+    if (is4WD) {
+      document.getElementById("pin-m3-p1").value = 16;
+      document.getElementById("pin-m3-p2").value = 17;
+      document.getElementById("pin-m3-p3").value = 18;
+      document.getElementById("pin-m4-p1").value = 19;
+      document.getElementById("pin-m4-p2").value = 20;
+      document.getElementById("pin-m4-p3").value = 21;
+      document.getElementById("pin-enc-3a").value = 6;
+      document.getElementById("pin-enc-3b").value = 7;
+      document.getElementById("pin-enc-4a").value = 8;
+      document.getElementById("pin-enc-4b").value = 9;
+    }
+  } else if (mcu === "ESP32" || mcu === "GENDRV") {
+    document.getElementById("pin-led").value = 2;
+    document.getElementById("pin-i2c-sda").value = 21;
+    document.getElementById("pin-i2c-scl").value = 22;
+    document.getElementById("pin-battery").value = 36;
+    document.getElementById("pin-sonar-trig").value = 5;
+    document.getElementById("pin-sonar-echo").value = 17;
+
+    document.getElementById("pin-m1-p1").value = 13;
+    document.getElementById("pin-m1-p2").value = 14;
+    document.getElementById("pin-m1-p3").value = 27;
+
+    document.getElementById("pin-m2-p1").value = 25;
+    document.getElementById("pin-m2-p2").value = 26;
+    document.getElementById("pin-m2-p3").value = 33;
+
+    document.getElementById("pin-enc-1a").value = 4;
+    document.getElementById("pin-enc-1b").value = 32;
+    document.getElementById("pin-enc-2a").value = 35;
+    document.getElementById("pin-enc-2b").value = 34;
+
+    if (is4WD) {
+      document.getElementById("pin-m3-p1").value = 18;
+      document.getElementById("pin-m3-p2").value = 19;
+      document.getElementById("pin-m3-p3").value = 23;
+      document.getElementById("pin-m4-p1").value = 15;
+      document.getElementById("pin-m4-p2").value = 16;
+      document.getElementById("pin-m4-p3").value = 17;
+      document.getElementById("pin-enc-1a").value = 34;
+      document.getElementById("pin-enc-1b").value = 35;
+      document.getElementById("pin-enc-2a").value = 36;
+      document.getElementById("pin-enc-2b").value = 39;
+      document.getElementById("pin-enc-3a").value = 4;
+      document.getElementById("pin-enc-3b").value = 32;
+      document.getElementById("pin-enc-4a").value = 5;
+      document.getElementById("pin-enc-4b").value = 12;
+    }
+  } else if (mcu === "ESP32S3") {
+    document.getElementById("pin-led").value = 48;
+    document.getElementById("pin-i2c-sda").value = 41;
+    document.getElementById("pin-i2c-scl").value = 42;
+    document.getElementById("pin-battery").value = 3;
+    document.getElementById("pin-sonar-trig").value = 47;
+    document.getElementById("pin-sonar-echo").value = 40;
+
+    document.getElementById("pin-m1-p1").value = 1;
+    document.getElementById("pin-m1-p2").value = 2;
+    document.getElementById("pin-m1-p3").value = 4;
+
+    document.getElementById("pin-m2-p1").value = 5;
+    document.getElementById("pin-m2-p2").value = 6;
+    document.getElementById("pin-m2-p3").value = 7;
+
+    document.getElementById("pin-enc-1a").value = 14;
+    document.getElementById("pin-enc-1b").value = 15;
+    document.getElementById("pin-enc-2a").value = 16;
+    document.getElementById("pin-enc-2b").value = 17;
+
+    if (is4WD) {
+      document.getElementById("pin-m3-p1").value = 8;
+      document.getElementById("pin-m3-p2").value = 9;
+      document.getElementById("pin-m3-p3").value = 10;
+      document.getElementById("pin-m4-p1").value = 11;
+      document.getElementById("pin-m4-p2").value = 12;
+      document.getElementById("pin-m4-p3").value = 13;
+      document.getElementById("pin-enc-3a").value = 18;
+      document.getElementById("pin-enc-3b").value = 21;
+      document.getElementById("pin-enc-4a").value = 38;
+      document.getElementById("pin-enc-4b").value = 39;
+    }
+  }
+
+  showToast("⚡ Conflict-free pins auto-allocated!");
+  recomputeAll();
+}
+
+// Copy Code to Clipboard
+function copyActiveCode() {
+  const code = document.getElementById("code-display").innerText;
+  navigator.clipboard.writeText(code).then(() => {
+    const btnText = document.getElementById("copy-btn-text");
+    btnText.innerText = "Copied!";
+    showToast("📋 Code copied to clipboard!");
+    setTimeout(() => { btnText.innerText = "Copy"; }, 2000);
+  }).catch(err => {
+    showToast("❌ Failed to copy: " + err);
+  });
+}
+
+// Download Active Artifact File
+function downloadActiveArtifact() {
+  let content = "";
+  let filename = "";
+  const name = currentSpec.robot_name || "robot";
+
+  if (activeArtifact === "tab-code-header") {
+    content = generateCppHeader(currentSpec);
+    filename = `${name}_config.h`;
+  } else if (activeArtifact === "tab-code-pio") {
+    content = generatePlatformioEnv(currentSpec);
+    filename = "platformio_section.ini";
+  } else if (activeArtifact === "tab-code-urdf") {
+    content = generateUrdfXacro(currentSpec);
+    filename = `${name}_properties.urdf.xacro`;
+  } else if (activeArtifact === "tab-code-wiring") {
+    content = generateWiringTable(currentSpec);
+    filename = `${name}_wiring_table.md`;
+  } else if (activeArtifact === "tab-code-deploy") {
+    content = generateDeployScript(currentSpec, readAutomationOptions());
+    filename = `deploy_${name}.sh`;
+  } else if (activeArtifact === "tab-code-json") {
+    content = JSON.stringify(currentSpec, null, 2);
+    filename = `${name}_spec.json`;
+  }
+
+  triggerDownload(filename, content, "text/plain");
+}
+
+// Export Spec JSON
+function exportSpecJson() {
+  const jsonStr = JSON.stringify(currentSpec, null, 2);
+  const filename = `${currentSpec.robot_name || "robot"}_spec.json`;
+  triggerDownload(filename, jsonStr, "application/json");
+  showToast("📥 Specification exported!");
+}
+
+// JSON Import File Handler (for saved spec JSON files)
+async function handleImportFile(e) {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = async (event) => {
+    try {
+      const content = event.target.result;
+      const imported = JSON.parse(content);
+      baseConfigSpec = JSON.parse(JSON.stringify(imported));
+      currentSpec = imported;
+      populateFormFromSpec(currentSpec);
+      recomputeAll();
+      showToast(`✅ Successfully imported '${imported.robot_name || file.name}'!`);
+    } catch (err) {
+      alert('Error importing JSON: ' + err.message);
+    }
+  };
+  reader.readAsText(file);
+}
+
+// ─── Board Config Selector (reads firmware/platformio.ini via server) ───────
+
+let boardList = [];
+
+async function openBoardSelector() {
+  const modal = document.getElementById('modal-board-select');
+  const sel = document.getElementById('board-select');
+  const info = document.getElementById('board-select-info');
+  const confirmBtn = document.getElementById('btn-board-confirm');
+
+  modal.style.display = 'flex';
+  sel.innerHTML = '<option value="">Loading…</option>';
+  confirmBtn.disabled = true;
+  info.textContent = '';
+
+  try {
+    const res = await fetch('/api/boards');
+    const data = await res.json();
+    boardList = (data.boards || []).filter(b => b.config_exists);
+
+    if (boardList.length === 0) {
+      sel.innerHTML = '<option value="">No board configs found</option>';
+      info.textContent = 'No *_config.h files found in config/custom/. Check your repository.';
+      return;
+    }
+
+    sel.innerHTML = '<option value="">— Select a board environment —</option>' +
+      boardList.map(b => {
+        const desc = (b.display_name && b.display_name !== b.env) ? ` — ${b.display_name}` : '';
+        return `<option value="${b.env}">${b.env}${desc}  [${b.transport}]</option>`;
+      }).join('');
+
+    sel.addEventListener('change', () => {
+      const chosen = boardList.find(b => b.env === sel.value);
+      if (chosen) {
+        const speed = chosen.monitor_speed ? ` · ${chosen.monitor_speed} baud` : '';
+        const wifi  = chosen.wifi ? ' · WiFi transport' : ' · Serial transport';
+        info.innerHTML = `<b>[env:${chosen.env}]</b>${chosen.display_name && chosen.display_name !== chosen.env ? ` · ${chosen.display_name}` : ''}${speed}${wifi}<br>
+          <span style="opacity:.7;">Config: <code>${chosen.config_file}</code></span>`;
+        confirmBtn.disabled = false;
+      } else {
+        info.textContent = '';
+        confirmBtn.disabled = true;
+      }
+    });
+  } catch (err) {
+    sel.innerHTML = '<option value="">Error loading boards</option>';
+    info.textContent = 'Could not reach /api/boards — is the server running?';
+  }
+}
+
+async function loadBoardConfig(envName) {
+  try {
+    showToast('⏳ Loading board configuration…');
+    const res = await fetch('/api/load_board_config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ env: envName })
+    });
+    const data = await res.json();
+    if (data.status === 'ok' && data.spec) {
+      baseConfigSpec = JSON.parse(JSON.stringify(data.spec));
+      currentSpec = data.spec;
+      populateFormFromSpec(currentSpec);
+      recomputeAll();
+      const board = data.board || {};
+      showToast(`✅ Loaded '${envName}' (${board.display_name || envName})`);
+    } else {
+      throw new Error(data.error || 'Failed to load board config');
+    }
+  } catch (err) {
+    alert('Error loading board config: ' + err.message);
+  }
+}
+
+// Trigger Client-Side File Download
+function triggerDownload(filename, text, mimeType) {
+  const blob = new Blob([text], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// Show Toast Notification
+function showToast(message) {
+  const toast = document.getElementById("toast");
+  toast.innerText = message;
+  toast.classList.add("show");
+  setTimeout(() => {
+    toast.classList.remove("show");
+  }, 2500);
+}
+
+
+// =============================================================================
+// Automation Hub, OS Detection, Deploy Script Generator & Web Serial Console
+// =============================================================================
+
+// Web Serial Global State
+let serialPort = null;
+let serialReader = null;
+let isSerialReading = false;
+
+// Robot Host SBC Environment Auto-Detection (Execution Destination)
+function syncRobotHostInfo(data) {
+  if (!data) return;
+
+  const node = data.node || "Robot Computer";
+  const arch = data.machine || "aarch64";
+  const distroId = (data.distro_id || "").toLowerCase();
+  const distroName = data.distro_name || data.os || "Linux";
+  const ports = data.serial_ports || [];
+  const rosDistros = data.installed_ros_distros || [];
+
+  // Update Header Badges
+  const headerIcon = document.getElementById("header-os-icon");
+  const headerText = document.getElementById("header-os-text");
+  if (headerIcon) headerIcon.innerText = "🤖";
+  if (headerText) headerText.innerText = `Robot Host: ${node} (${arch})`;
+
+  // Update Banner in Tab 5
+  const bannerIcon = document.getElementById("os-banner-icon");
+  const bannerText = document.getElementById("os-banner-detected-text");
+  const bannerArch = document.getElementById("os-banner-arch");
+  const bannerPorts = document.getElementById("os-banner-ports");
+  const bannerStatus = document.getElementById("os-banner-status");
+
+  if (bannerIcon) bannerIcon.innerText = "🤖";
+  if (bannerText) bannerText.innerText = `Target Robot Computer: ${node} (${distroName})`;
+  if (bannerArch) bannerArch.innerText = arch;
+  if (bannerPorts) {
+    bannerPorts.innerText = ports.length > 0 ? ports.join(", ") : "No USB serial MCUs detected (plug in Pico / ESP32)";
+    bannerPorts.style.color = ports.length > 0 ? "var(--success)" : "var(--text-dim)";
+  }
+  if (bannerStatus) {
+    bannerStatus.innerText = data.has_pio ? "PlatformIO Ready" : (isRunnerOnline ? "Runner Online" : "Disconnected");
+    bannerStatus.className = `badge-pill ${data.has_pio || isRunnerOnline ? "badge-ok" : "badge-warn"}`;
+  }
+
+  // Set Default Dropdowns if not manually touched
+  const osSelect = document.getElementById("auto-os-select");
+  if (osSelect && !osSelect.dataset.userModified) {
+    if (distroId.includes("ubuntu")) {
+      if (data.release && data.release.includes("26.04")) osSelect.value = "ubuntu_2604";
+      else if (data.release && data.release.includes("22.04")) osSelect.value = "ubuntu_2204";
+      else osSelect.value = "ubuntu_2404";
+    } else if (distroId.includes("debian")) {
+      osSelect.value = "debian";
+    } else if (distroId.includes("fedora") || distroId.includes("bluefin")) {
+      osSelect.value = "fedora";
+    }
+  }
+
+  const archSelect = document.getElementById("auto-arch-select");
+  if (archSelect && !archSelect.dataset.userModified) {
+    archSelect.value = arch.includes("arm") || arch.includes("aarch64") ? "aarch64" : "x86_64";
+  }
+
+  const rosSelect = document.getElementById("auto-ros-distro");
+  if (rosSelect && !rosSelect.dataset.userModified && rosDistros.length > 0) {
+    if (rosDistros.includes("jazzy")) rosSelect.value = "jazzy";
+    else if (rosDistros.includes("humble")) rosSelect.value = "humble";
+    else if (rosDistros.includes("lyrical")) rosSelect.value = "lyrical";
+    else if (rosDistros.includes("rolling")) rosSelect.value = "rolling";
+  }
+
+  // Auto-populate detected serial port into flash / agent controls with USB VID:PID & chip info
+  const chipsContainer = document.getElementById("flash-port-chips");
+  if (chipsContainer) {
+    const portDetails = data.port_details || [];
+    if (ports.length > 0) {
+      chipsContainer.innerHTML = `<span class="chips-label">Detected USB Devices:</span> ` + ports.map(p => {
+        const detail = portDetails.find(d => d.port === p) || {};
+        const isBootsel = !!detail.is_bootsel;
+        const isOk = detail.accessible !== false;
+        const vidPid = detail.vid && detail.pid ? `[${detail.vid}:${detail.pid}]` : "";
+        const chip = detail.chip || (detail.product ? detail.product : (isBootsel ? "RP2 Bootloader" : "USB Serial"));
+        const icon = isBootsel ? "⚡📦" : (isOk ? "⚡" : "⚠️");
+        const badgeClass = isBootsel ? "port-chip port-chip-bootsel" : (isOk ? "port-chip" : "port-chip port-chip-warn");
+        const title = `${p} ${vidPid} - ${chip} | Read/Write: ${isOk ? "Granted" : "Denied (dialout required)"}`;
+        return `<button type="button" class="${badgeClass}" data-port="${p}" title="${title}">
+          <span class="chip-icon">${icon}</span>
+          <span class="chip-port">${p}</span>
+          ${vidPid ? `<span class="chip-vidpid">${vidPid}</span>` : ""}
+          <span class="chip-desc">${chip}</span>
+          ${!isOk ? `<span class="chip-lock">[No RW Access]</span>` : ""}
+        </button>`;
+      }).join(" ");
+
+      chipsContainer.querySelectorAll(".port-chip").forEach(btn => {
+        btn.addEventListener("click", () => {
+          const p = btn.dataset.port;
+          const flashPortInput = document.getElementById("auto-flash-port");
+          if (flashPortInput) {
+            flashPortInput.value = p;
+            flashPortInput.dataset.autoManaged = "false";
+          }
+          const detail = (data.port_details || []).find(d => d.port === p);
+          const guessed = guessMcuFromUsbDetail(detail);
+          if (guessed) {
+            const mcuSelect = document.getElementById("cfg-mcu");
+            if (mcuSelect && mcuSelect.value !== guessed.mcu) {
+              mcuSelect.value = guessed.mcu;
+              mcuSelect.dispatchEvent(new Event("change"));
+            }
+            applyMcuRobotName(guessed.mcu);
+            showToast(`⚡ Selected ${p} (${guessed.chipName}) — Target MCU: ${guessed.mcu}`);
+          } else {
+            showToast(`🔌 Selected upload port: ${p}`);
+          }
+          updateAutomationPreviews();
+        });
+      });
+    } else {
+      chipsContainer.innerHTML = `<span class="chips-empty">No USB ports detected. You can type any serial path above.</span>`;
+    }
+  }
+
+  if (ports.length > 0) {
+    const flashPortInput = document.getElementById("auto-flash-port");
+    if (flashPortInput && (!flashPortInput.value || flashPortInput.value === "/dev/ttyACM0" || flashPortInput.dataset.autoManaged === "true")) {
+      flashPortInput.value = ports[0];
+    }
+    const multiInput = document.getElementById("auto-agent-multiserial-ports");
+    if (multiInput && (!multiInput.value || multiInput.dataset.autoManaged === "true")) {
+      multiInput.value = ports.join(" ");
+    }
+
+    // Hardware USB Auto-Detection & Bare Module Preset Adaptation
+    if (!window.hasAutoDetectedHardware && data.port_details && data.port_details.length > 0) {
+      window.hasAutoDetectedHardware = true;
+      const primaryDetail = data.port_details[0];
+      const guessed = guessMcuFromUsbDetail(primaryDetail);
+      if (guessed) {
+        // Load the all-pins-(-1) bare-module template so nothing is driven on a
+        // freshly plugged board, then stamp the detected MCU + a unique name.
+        loadPreset("bare");
+        const mcuSelect = document.getElementById("cfg-mcu");
+        if (mcuSelect) {
+          mcuSelect.value = guessed.mcu;
+          mcuSelect.dispatchEvent(new Event("change"));
+        }
+        applyMcuRobotName(guessed.mcu);
+        recomputeAll();
+        showToast(`⚡ Auto-detected Hardware: ${guessed.chipName} on ${ports[0]} (Bare Module Default Loaded — all pins N/C)`);
+      }
+    }
+  }
+
+  updateAutomationPreviews();
+}
+
+function detectClientOS() {
+  checkServerRunnerStatus();
+}
+
+// Read All Automation Configuration Options
+function readAutomationOptions() {
+  return {
+    os: document.getElementById("auto-os-select")?.value || "ubuntu_2404",
+    env: document.getElementById("auto-env-select")?.value || "native",
+    arch: document.getElementById("auto-arch-select")?.value || "x86_64",
+    installPio: document.getElementById("chk-install-pio")?.checked ?? true,
+    installUdev: document.getElementById("chk-install-udev")?.checked ?? true,
+    installDialout: document.getElementById("chk-install-dialout")?.checked ?? true,
+    installBuildTools: document.getElementById("chk-install-buildtools")?.checked ?? true,
+    rosDistro: document.getElementById("auto-ros-distro")?.value || "jazzy",
+    rosType: document.getElementById("auto-ros-type")?.value || "desktop",
+    buildMicrorosAgent: document.getElementById("chk-build-microros-agent")?.checked ?? true,
+    gitBranch: document.getElementById("auto-git-branch")?.value.trim() || `config/${currentSpec.robot_name || "robot"}`,
+    gitCommitMsg: document.getElementById("auto-git-commit-msg")?.value.trim() || `feat(config): add configuration for ${currentSpec.robot_name || "robot"}`,
+    mergeHeader: document.getElementById("chk-merge-header")?.checked ?? true,
+    mergePioFirmware: document.getElementById("chk-merge-pio-firmware")?.checked ?? true,
+    mergeUrdf: document.getElementById("chk-merge-urdf")?.checked ?? true,
+    autoCommit: document.getElementById("chk-auto-commit")?.checked ?? true,
+    flashTarget: document.getElementById("auto-flash-target")?.value || "firmware",
+    flashPort: (() => {
+      const otaOn = document.getElementById("cfg-ota-enable")?.checked;
+      const otaIp = (document.getElementById("cfg-ota-ip")?.value || "").trim();
+      if (otaOn && otaIp) return otaIp;   // espota target
+      return document.getElementById("auto-flash-port")?.value.trim() || "/dev/ttyACM0";
+    })(),
+    otaFlash: !!document.getElementById("cfg-ota-enable")?.checked &&
+              !!(document.getElementById("cfg-ota-ip")?.value || "").trim(),
+    otaPass: (document.getElementById("cfg-ota-password")?.value || "").trim()
+  };
+}
+
+// Update Dynamic Previews across Tab 5
+function updateAutomationPreviews() {
+  const opts = readAutomationOptions();
+  const spec = currentSpec;
+  const robotName = spec.robot_name || "scout_pico2";
+
+  // Dynamic Git Branch & Commit message if unset or auto-managed
+  const gitBranchInput = document.getElementById("auto-git-branch");
+  if (gitBranchInput && (!gitBranchInput.value || gitBranchInput.dataset.autoManaged === "true")) {
+    gitBranchInput.value = `config/${robotName}`;
+    gitBranchInput.dataset.autoManaged = "true";
+  }
+
+  const gitCommitInput = document.getElementById("auto-git-commit-msg");
+  if (gitCommitInput && (!gitCommitInput.value || gitCommitInput.dataset.autoManaged === "true")) {
+    gitCommitInput.value = `feat(config): add configuration for ${robotName}`;
+    gitCommitInput.dataset.autoManaged = "true";
+  }
+
+  // OTA mDNS hostname mirrors the robot name until the user edits it
+  const otaHostInput = document.getElementById("cfg-ota-hostname");
+  if (otaHostInput && (!otaHostInput.value || otaHostInput.dataset.autoManaged === "true")) {
+    otaHostInput.value = robotName;
+    otaHostInput.dataset.autoManaged = "true";
+  }
+
+  // Set default port based on MCU
+  const mcu = (spec.mcu || "PICO2").toUpperCase();
+  const portInput = document.getElementById("auto-flash-port");
+  if (portInput && (!portInput.value || portInput.dataset.autoManaged === "true")) {
+    if (mcu === "PICO" || mcu === "PICO2" || mcu === "ESP32S3") {
+      portInput.value = "/dev/ttyACM0";
+    } else {
+      portInput.value = "/dev/ttyUSB0";
+    }
+    portInput.dataset.autoManaged = "true";
+  }
+
+  // 1. Toolchain Preview
+  const toolCmdEl = document.getElementById("preview-tool-cmd");
+  if (toolCmdEl) {
+    toolCmdEl.innerText = getToolchainInstallCmd(opts);
+  }
+
+  // 2. ROS 2 Preview & Visibility
+  const rosDistroBox = document.getElementById("box-ros-cmd");
+  const rosTypeGroup = document.getElementById("group-ros-install-type");
+  const microrosGroup = document.getElementById("group-microros-agent");
+  const isRosActive = opts.rosDistro !== "none";
+
+  if (rosDistroBox) rosDistroBox.style.display = isRosActive ? "block" : "none";
+  if (rosTypeGroup) rosTypeGroup.style.display = isRosActive ? "flex" : "none";
+  if (microrosGroup) microrosGroup.style.display = isRosActive ? "grid" : "none";
+
+  const rosCmdEl = document.getElementById("preview-ros-cmd");
+  if (rosCmdEl && isRosActive) {
+    rosCmdEl.innerText = getRos2InstallCmd(opts);
+  }
+
+  // 3. Merge & Commit Preview
+  const mergeCmdEl = document.getElementById("preview-merge-cmd");
+  if (mergeCmdEl) {
+    mergeCmdEl.innerText = getMergeAndCommitCmd(spec, opts);
+  }
+
+  // 4. micro-ROS Agent Preview
+  const agentCmdEl = document.getElementById("preview-agent-cmd");
+  if (agentCmdEl) {
+    const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
+    const port = document.getElementById("auto-flash-port")?.value || (isESP32(spec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
+    const multiPorts = document.getElementById("auto-agent-multiserial-ports")?.value.trim() || "/dev/ttyACM0 /dev/ttyUSB0";
+    const baud = document.getElementById("auto-agent-baud")?.value || "921600";
+    const isWiFi = /WIFI|UDP/i.test(spec.transport || "");
+    if (isWiFi) {
+      agentCmdEl.innerText = `source /opt/ros/${distro}/setup.bash && [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"; ros2 run micro_ros_agent micro_ros_agent udp4 --port 8888`;
+    } else {
+      agentCmdEl.innerText = `# Single MCU:\nros2 run micro_ros_agent micro_ros_agent serial --dev ${port} -b ${baud}\n# Multi-MCU:\nros2 run micro_ros_agent micro_ros_agent multiserial --devs "${multiPorts}" -b ${baud}`;
+    }
+  }
+
+  // If Deploy Script tab is active, re-render code display
+  if (activeArtifact === "tab-code-deploy") {
+    renderActiveCode();
+  }
+}
+
+// Generate Toolchain Install Commands
+function getToolchainInstallCmd(opts) {
+  const lines = [];
+  const isDebianUbuntu = ["ubuntu_2404", "ubuntu_2604", "ubuntu_2204", "debian", "windows_wsl"].includes(opts.os);
+  const isMac = opts.os === "macos";
+  const isFedora = opts.os === "fedora";
+
+  if (isDebianUbuntu) {
+    lines.push("sudo dpkg --configure -a 2>/dev/null || true");
+    if (opts.installBuildTools) {
+      lines.push("sudo apt-get update && sudo apt-get install -y git cmake ninja-build python3-pip python3-venv udev");
+    }
+    if (opts.installPio) {
+      lines.push("curl -fsSL -o /tmp/get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py && python3 /tmp/get-platformio.py && export PATH=\"$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH\"");
+    }
+    if (opts.installUdev) {
+      lines.push("curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/system/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules > /dev/null");
+      lines.push("sudo udevadm control --reload-rules && sudo udevadm trigger");
+    }
+    if (opts.installDialout) {
+      lines.push("sudo usermod -a -G dialout,plugdev $USER || true");
+    }
+  } else if (isMac) {
+    if (opts.installBuildTools) lines.push("brew install git cmake ninja python3");
+    if (opts.installPio) lines.push("brew install platformio || pip3 install platformio");
+  } else if (isFedora) {
+    if (opts.installBuildTools) lines.push("sudo dnf install -y git cmake ninja-build python3-pip systemd-udev || true");
+    if (opts.installPio) lines.push("curl -fsSL -o /tmp/get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py && python3 /tmp/get-platformio.py && export PATH=\"$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH\"");
+    if (opts.installUdev) {
+      lines.push("curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/system/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules > /dev/null || true");
+      lines.push("sudo udevadm control --reload-rules && sudo udevadm trigger || true");
+    }
+    if (opts.installDialout) lines.push("sudo usermod -a -G dialout $USER 2>/dev/null || true");
+  }
+
+  return lines.length > 0 ? lines.join(" && \\\n") : "# No toolchain installations selected";
+}
+
+// Generate ROS 2 Install Commands
+function getRos2InstallCmd(opts) {
+  const distro = opts.rosDistro;
+  if (distro === "none") return "# ROS 2 Installation skipped (Standalone Firmware mode)";
+
+  const pkgName = opts.rosType === "desktop" ? `ros-${distro}-desktop` : `ros-${distro}-ros-base`;
+  const lines = [
+    `set -e`,
+    `sudo dpkg --configure -a 2>/dev/null || true`,
+    ``,
+    `# 1. Setup ROS 2 ${distro.toUpperCase()} Official Repository`,
+    `if command -v apt-get &>/dev/null; then`,
+    `    sudo apt-get update -qq && sudo apt-get install -y -qq software-properties-common curl gnupg`,
+    `    sudo add-apt-repository -y universe`,
+    `    sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg`,
+    `    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null`,
+    `    sudo apt-get update -qq && sudo apt-get install -y -qq ${pkgName} ros-${distro}-ros-workspace python3-catkin-pkg-modules python3-colcon-common-extensions python3-rosdep`,
+    `elif command -v distrobox &>/dev/null; then`,
+    `    distrobox create -n ${distro} -i docker.io/library/ubuntu:24.04 2>/dev/null || true`,
+    `    distrobox enter ${distro} -- bash -c "sudo apt-get update && sudo apt-get install -y ${pkgName} ros-${distro}-ros-workspace python3-catkin-pkg-modules python3-colcon-common-extensions python3-rosdep"`,
+    `else`,
+    `    echo "Package manager apt-get not found. Ensure ROS 2 ${distro} is installed on host/container."`,
+    `    exit 1`,
+    `fi`
+  ];
+
+  if (opts.buildMicrorosAgent) {
+    lines.push(
+      ``,
+      `# 2. Build micro-ROS Agent Workspace (micro-ROS-Agent + micro_ros_msgs)`,
+      `if [ -f "/opt/ros/${distro}/setup.bash" ]; then`,
+      `    source /opt/ros/${distro}/setup.bash`,
+      `    mkdir -p ~/uros_ws/src && cd ~/uros_ws`,
+      `    if [ ! -d "src/micro_ros_agent" ]; then`,
+      `        git clone -b ${distro} https://github.com/micro-ROS/micro-ROS-Agent.git src/micro_ros_agent || git clone -b rolling https://github.com/micro-ROS/micro-ROS-Agent.git src/micro_ros_agent`,
+      `    fi`,
+      `    if [ ! -d "src/micro_ros_msgs" ]; then`,
+      `        git clone -b ${distro} https://github.com/micro-ROS/micro_ros_msgs.git src/micro_ros_msgs || git clone -b rolling https://github.com/micro-ROS/micro_ros_msgs.git src/micro_ros_msgs`,
+      `    fi`,
+      `    colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3`,
+      `    grep -q "source /opt/ros/${distro}/setup.bash" ~/.bashrc || echo "source /opt/ros/${distro}/setup.bash" >> ~/.bashrc`,
+      `    grep -q "source \$HOME/uros_ws/install/setup.bash" ~/.bashrc || echo "source \$HOME/uros_ws/install/setup.bash" >> ~/.bashrc`,
+      `else`,
+      `    echo "❌ Error: ROS 2 setup not found at /opt/ros/${distro}/setup.bash"`,
+      `    exit 1`,
+      `fi`
+    );
+  }
+
+  return lines.join("\n");
+}
+
+// Generate Merge & Commit Commands
+function getMergeAndCommitCmd(spec, opts) {
+  const name = spec.robot_name || "my_robot";
+  const nameUpper = name.toUpperCase();
+  const branch = opts.gitBranch || `config/${name}`;
+  const commitMsg = opts.gitCommitMsg || `feat(config): add configuration for ${name}`;
+  const headerContent = generateCppHeader(spec);
+  const pioSection = generatePlatformioEnv(spec);
+  const urdfContent = generateUrdfXacro(spec);
+
+  const lines = [
+    `set -e`,
+    `# 1. Create Isolated Git Branch`,
+    `git checkout -b "${branch}" 2>/dev/null || git checkout "${branch}"`,
+    ``,
+    `# 2. Ingest Custom Header`,
+    `mkdir -p config/custom urdf`,
+    `cat << 'EOF_HEADER' > "config/custom/${name}_config.h"`,
+    `${headerContent}`,
+    `EOF_HEADER`,
+    ``,
+    `# Register in config/config.h`,
+    `if [ -f "config/config.h" ]; then`,
+    `    if ! grep -F -q "USE_${nameUpper}_CONFIG" config/config.h; then`,
+    `        sed -i '/\\/\\/ add user configurations above this line/i #ifdef USE_${nameUpper}_CONFIG\\n    #include "custom/${name}_config.h"\\n#endif\\n' config/config.h`,
+    `    fi`,
+    `fi`,
+    ``,
+    `# 3. Append PlatformIO Target Environment`,
+    `if [ -f "firmware/platformio.ini" ]; then`,
+    `    if ! grep -F -q "[env:${name}]" "firmware/platformio.ini"; then`,
+    `        echo "" >> "firmware/platformio.ini"`,
+    `        cat << 'EOF_PIO' >> "firmware/platformio.ini"`,
+    `${pioSection}`,
+    `EOF_PIO`,
+    `    fi`,
+    `fi`,
+    ``,
+    `# 4. Ingest URDF Description`,
+    `cat << 'EOF_URDF' > "urdf/${name}_properties.urdf.xacro"`,
+    `${urdfContent}`,
+    `EOF_URDF`,
+    ``,
+    `# 5. Stage & Create Git Commit`,
+    `git add config/ firmware/platformio.ini urdf/ 2>/dev/null || true`,
+    `if ! git diff --cached --quiet; then`,
+    `    git commit -m "${commitMsg}"`,
+    `else`,
+    `    echo "Configuration files already up to date on branch ${branch}."`,
+    `fi`
+  ];
+
+  return lines.join("\n");
+}
+
+// Full All-In-One Bash Deploy Script Generator
+function generateDeployScript(spec, opts) {
+  const name = spec.robot_name || "my_robot";
+  const nameUpper = name.toUpperCase();
+  const mcu = (spec.mcu || "PICO2").toUpperCase();
+  const branch = opts.gitBranch || `config/${name}`;
+  const commitMsg = opts.gitCommitMsg || `feat(config): add configuration for ${name}`;
+  const target = opts.flashTarget || "firmware";
+  const port = opts.flashPort || "/dev/ttyACM0";
+  const otaAuth = (opts.otaFlash && opts.otaPass) ? ` --upload-flags "--auth=${opts.otaPass}"` : "";
+  const headerContent = generateCppHeader(spec);
+  const wifiConfigContent = generateWifiConfig(spec);
+  const pioSection = generatePlatformioEnv(spec);
+  const urdfContent = generateUrdfXacro(spec);
+  // Escape a value for safe interpolation inside a double-quoted bash string
+  const shDq = (s) => String(s).replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/`/g, "\\`").replace(/\$/g, "\\$");
+  const commitMsgEsc = shDq(commitMsg);
+  const rosPkg = opts.rosType === "desktop" ? `ros-${opts.rosDistro}-desktop` : `ros-${opts.rosDistro}-ros-base`;
+
+  const script = `#!/usr/bin/env bash
+# =============================================================================
+# Automated Linorobot2 Setup, Merge, Build & Flash Script for '${name}'
+# Generated by Linorobot2 Robot Configuration Engine
+# Target MCU: ${mcu} | Kinematics: ${spec.kinematics} | Target: ${target}
+# =============================================================================
+
+set -e
+
+# ANSI Styling
+C_RESET='\\033[0m'
+C_CYAN='\\033[1;36m'
+C_GREEN='\\033[1;32m'
+C_YELLOW='\\033[1;33m'
+C_RED='\\033[1;31m'
+
+info()    { echo -e "\${C_CYAN}[INFO]\${C_RESET} \$*"; }
+success() { echo -e "\${C_GREEN}[SUCCESS]\${C_RESET} \$*"; }
+warn()    { echo -e "\${C_YELLOW}[WARN]\${C_RESET} \$*"; }
+err()     { echo -e "\${C_RED}[ERROR]\${C_RESET} \$*" >&2; }
+
+# Grant read/write on USB serial devices when no udev rule / 'dialout' group does.
+# Keeps flashing and the micro-ROS agent working on a fresh SBC without a reboot.
+ensure_serial_rw() {
+    local want="\$1" d
+    for d in /dev/ttyUSB* /dev/ttyACM*; do
+        [ -e "\$d" ] || continue
+        [ -w "\$d" ] && continue
+        warn "No write access to \$d (missing udev rule?) - running 'sudo chmod a+rw \$d'"
+        sudo chmod a+rw "\$d" 2>/dev/null || true
+    done
+    if [ -n "\$want" ] && [ "\$want" != "AUTO" ] && [ "\$want" != "BOOTSEL" ] && [ -e "\$want" ] && [ ! -w "\$want" ]; then
+        sudo chmod a+rw "\$want" 2>/dev/null || true
+    fi
+}
+
+# Cap build parallelism on low-memory hosts (Raspberry Pi 4/5 4 GB, etc.) so the
+# first libmicroros / micro-ROS-Agent compile does not OOM. 6 GB+ builds at full speed.
+_MEM_KB=\$(awk '/MemTotal/{print \$2}' /proc/meminfo 2>/dev/null || echo 8000000)
+if [ "\${_MEM_KB:-8000000}" -lt 6000000 ]; then
+    export MAKEFLAGS="-j2"
+    export PLATFORMIO_BUILD_JOBS=2
+    COLCON_JOBS="--parallel-workers 2"
+    info "Low memory (\$((_MEM_KB/1024)) MB) detected - capping builds at 2 parallel jobs to avoid OOM."
+else
+    COLCON_JOBS=""
+fi
+
+info "========================================================="
+info "  Linorobot2 Deployment Engine: ${name}"
+info "  Target MCU: ${mcu} | Mode: ${target}"
+info "========================================================="
+
+# -----------------------------------------------------------------------------
+# Phase 1: Toolchain & Dependency Verification
+# -----------------------------------------------------------------------------
+info "Step 1/9: Checking build toolchains and dependencies..."
+${opts.installBuildTools ? `if ! command -v pio &>/dev/null || ! command -v cmake &>/dev/null || ! command -v git &>/dev/null; then
+    if command -v apt-get &>/dev/null; then
+        info "First-time setup: installing missing build tools (apt-get update)..."
+        if [ "$EUID" -eq 0 ]; then
+            apt-get update -y
+            info "Installing build packages: git, cmake, ninja-build, python3-pip, python3-venv, udev..."
+            apt-get install -y git cmake ninja-build python3-pip python3-venv udev
+        elif sudo -n true 2>/dev/null || [ -t 0 ]; then
+            sudo apt-get update -y
+            info "Installing build packages: git, cmake, ninja-build, python3-pip, python3-venv, udev..."
+            sudo apt-get install -y git cmake ninja-build python3-pip python3-venv udev
+        else
+            warn "Running in non-interactive environment: attempting passwordless package install..."
+            sudo -n apt-get update -y 2>/dev/null || true
+            sudo -n apt-get install -y git cmake ninja-build python3-pip python3-venv udev 2>/dev/null || warn "Please ensure build dependencies are installed."
+        fi
+    elif command -v dnf &>/dev/null; then
+        info "Installing build packages via dnf..."
+        if [ "$EUID" -eq 0 ]; then
+            dnf install -y git cmake ninja-build python3-pip systemd-udev || true
+        else
+            sudo dnf install -y git cmake ninja-build python3-pip systemd-udev || true
+        fi
+    fi
+else
+    info "Build toolchains already installed (pio, cmake, git ready). Skipping redundant package updates."
+fi` : "# Build tools check skipped"}
+
+${opts.installPio ? `export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"
+if ! command -v pio &>/dev/null; then
+    info "Installing PlatformIO Core..."
+    if ! curl -fsSL -o /tmp/get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py; then
+        err "Could not download the PlatformIO installer (raw.githubusercontent.com unreachable)."
+        exit 1
+    fi
+    if ! python3 /tmp/get-platformio.py; then
+        err "PlatformIO Core installation failed."
+        exit 1
+    fi
+    export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"
+fi
+if ! command -v pio &>/dev/null; then
+    err "PlatformIO Core is still not on PATH after installation."
+    exit 1
+fi
+success "PlatformIO Core active: $(pio --version 2>/dev/null || echo 'Installed')"
+` : "# PlatformIO install skipped"}
+
+${opts.installUdev ? `if [ -d "/etc/udev/rules.d" ]; then
+    info "Installing PlatformIO hardware udev rules..."
+    curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/system/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules > /dev/null || true
+    sudo udevadm control --reload-rules && sudo udevadm trigger || true
+fi` : "# udev rules skipped"}
+
+${opts.installDialout ? `if command -v usermod &>/dev/null; then
+    sudo usermod -a -G dialout,plugdev "$USER" 2>/dev/null || true
+fi` : "# dialout group skipped"}
+
+# -----------------------------------------------------------------------------
+# Phase 2: Optional ROS 2 Distribution Setup
+# -----------------------------------------------------------------------------
+${opts.rosDistro !== "none" ? `info "Step 2: Verifying ROS 2 ${opts.rosDistro.toUpperCase()} environment..."
+if [ ! -d "/opt/ros/${opts.rosDistro}" ]; then
+    if command -v apt-get &>/dev/null; then
+        warn "ROS 2 ${opts.rosDistro} not found in /opt/ros/${opts.rosDistro}. Installing via apt..."
+        sudo apt-get update -qq || warn "apt-get update reported errors; continuing."
+        sudo apt-get install -y -qq curl gnupg software-properties-common || warn "Could not install apt prerequisites."
+        sudo add-apt-repository -y universe || warn "Could not enable the 'universe' repository."
+        if [ ! -f /usr/share/keyrings/ros-archive-keyring.gpg ]; then
+            sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg || warn "Could not download the ROS 2 archive key."
+        fi
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+        sudo apt-get update -qq || warn "apt-get update failed after adding the ROS 2 repository."
+        sudo apt-get install -y -qq ${rosPkg} || err "Failed to install ${rosPkg}."
+        sudo apt-get install -y -qq ros-${opts.rosDistro}-ros-workspace python3-catkin-pkg-modules python3-colcon-common-extensions python3-rosdep || warn "Some ROS 2 build helper packages are unavailable; continuing."
+    elif command -v distrobox &>/dev/null; then
+        info "Running on immutable/container host: ensuring distrobox container '${opts.rosDistro}' is configured..."
+        distrobox create -n ${opts.rosDistro} -i docker.io/library/ubuntu:24.04 2>/dev/null || true
+    else
+        warn "Package manager 'apt-get' not found on this host. Skipping apt install."
+    fi
+fi
+
+if [ ! -f "/opt/ros/${opts.rosDistro}/setup.bash" ]; then
+    err "ROS 2 ${opts.rosDistro} is not available at /opt/ros/${opts.rosDistro}/setup.bash."
+    err "Install it manually, or set ROS Distro to 'none' to build and flash firmware only."
+    exit 1
+fi
+success "ROS 2 ${opts.rosDistro} available at /opt/ros/${opts.rosDistro}"
+
+${opts.buildMicrorosAgent ? `UROS_AGENT_BIN="$HOME/uros_ws/install/micro_ros_agent/lib/micro_ros_agent/micro_ros_agent"
+# Rebuild if the agent binary is absent — colcon writes install/setup.bash even
+# when a package fails to compile, so that file alone is not proof of a build.
+if [ -d "/opt/ros/${opts.rosDistro}" ] && [ ! -x "$UROS_AGENT_BIN" ]; then
+    info "Building micro_ros_agent workspace at ~/uros_ws..."
+    if ! command -v colcon >/dev/null 2>&1; then
+        info "Installing colcon build tooling..."
+        if command -v apt-get &>/dev/null; then
+            sudo apt-get install -y -qq python3-colcon-common-extensions python3-rosdep || warn "Could not install colcon tooling via apt."
+        fi
+    fi
+    if ! command -v colcon >/dev/null 2>&1; then
+        err "colcon is required to build the micro-ROS agent but is not available."
+        err "Install 'python3-colcon-common-extensions', or set ROS Distro to 'none' to skip the agent build."
+        exit 1
+    fi
+    mkdir -p "$HOME/uros_ws/src"
+    pushd "$HOME/uros_ws" >/dev/null
+    # micro-ROS cuts a branch per ROS distro, but newer distros (e.g. lyrical)
+    # land in ROS before micro-ROS tags them — fall back to 'rolling', which
+    # builds fine against the current ROS headers.
+    uros_clone() {
+        local repo="\$1" dest="\$2"
+        git clone -b "${opts.rosDistro}" "\$repo" "\$dest" 2>/dev/null && return 0
+        warn "No '${opts.rosDistro}' branch for \$(basename \$repo .git); trying 'rolling'..."
+        git clone -b rolling "\$repo" "\$dest" 2>/dev/null && return 0
+        git clone "\$repo" "\$dest" 2>/dev/null && return 0
+        warn "Could not clone \$repo"
+        return 1
+    }
+    if [ ! -d "src/micro_ros_agent" ]; then
+        uros_clone https://github.com/micro-ROS/micro-ROS-Agent.git src/micro_ros_agent
+    fi
+    if [ ! -d "src/micro_ros_msgs" ]; then
+        uros_clone https://github.com/micro-ROS/micro_ros_msgs.git src/micro_ros_msgs
+    fi
+    if [ ! -d "src/micro_ros_agent" ] || [ ! -d "src/micro_ros_msgs" ]; then
+        popd >/dev/null
+        err "micro-ROS agent sources are missing; cannot build the agent workspace."
+        exit 1
+    fi
+    set +e
+    source "/opt/ros/${opts.rosDistro}/setup.bash"
+    colcon build --symlink-install \${COLCON_JOBS} --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+    COLCON_RC=$?
+    set -e
+    popd >/dev/null
+    if [ "\${COLCON_RC}" -ne 0 ] || [ ! -x "$UROS_AGENT_BIN" ]; then
+        err "Failed to build the micro-ROS agent workspace at $HOME/uros_ws."
+        err "micro-ROS-Agent may not yet support ROS 2 ${opts.rosDistro} (e.g. vendored spdlog vs the system libfmt on newer distros)."
+        err "The firmware build below is unaffected; run the agent from a supported distro or container."
+        exit 1
+    fi
+    success "micro-ROS agent workspace ready at $HOME/uros_ws"
+fi` : ""}
+` : `# ROS 2 Host setup skipped (Standalone Firmware mode)`}
+
+# -----------------------------------------------------------------------------
+# Phase 3: Git Branch Preparation
+# -----------------------------------------------------------------------------
+${opts.autoCommit ? `info "Step 3: Preparing Git branch '${branch}'..."
+if git rev-parse --is-inside-work-tree &>/dev/null; then
+    git checkout -b "${branch}" 2>/dev/null || git checkout "${branch}" || warn "Could not switch to branch '${branch}'; staying on the current branch."
+fi` : "# Git branch switch skipped (git automation disabled)"}
+
+# -----------------------------------------------------------------------------
+# Phase 4: Ingest Custom C++ Header
+# -----------------------------------------------------------------------------
+${opts.mergeHeader ? `info "Step 4: Merging C++ configuration header into config/custom/${name}_config.h..."
+mkdir -p config/custom
+
+cat << 'EOF_HEADER' > "config/custom/${name}_config.h"
+${headerContent}
+EOF_HEADER
+success "Generated config/custom/${name}_config.h"
+${wifiConfigContent ? `
+# WiFi credentials go to the git-ignored config/custom/wifi_config.h, never
+# into the tracked robot header. An existing file is left untouched.
+if [ ! -f "config/custom/wifi_config.h" ]; then
+    info "Writing config/custom/wifi_config.h (git-ignored — holds your WiFi credentials)..."
+    cat << 'EOF_WIFI_CFG' > "config/custom/wifi_config.h"
+${wifiConfigContent}
+EOF_WIFI_CFG
+    success "Wrote config/custom/wifi_config.h (not tracked by git)"
+else
+    info "Keeping existing config/custom/wifi_config.h (delete it to regenerate)"
+fi
+` : ""}
+# Register in config/config.h if not already present
+if [ -f "config/config.h" ]; then
+    if ! grep -F -q "USE_${nameUpper}_CONFIG" config/config.h; then
+        info "Registering USE_${nameUpper}_CONFIG in config/config.h..."
+        sed -i '/\\/\\/ add user configurations above this line/i #ifdef USE_${nameUpper}_CONFIG\\n    #include "custom/${name}_config.h"\\n#endif\\n' config/config.h
+        success "Registered in config/config.h"
+    else
+        info "USE_${nameUpper}_CONFIG already registered in config/config.h"
+    fi
+fi
+` : "# Header merge skipped"}
+
+# -----------------------------------------------------------------------------
+# Phase 5: Ingest PlatformIO Target Environment
+# (test_motors and test_sensors automatically inherit firmware/platformio.ini)
+# -----------------------------------------------------------------------------
+if [ -f "firmware/platformio.ini" ] && [ "${opts.mergePioFirmware ? "1" : "0"}" = "1" ]; then
+    if ! grep -F -q "[env:${name}]" "firmware/platformio.ini"; then
+        info "Appending [env:${name}] to firmware/platformio.ini..."
+        echo "" >> "firmware/platformio.ini"
+        cat << 'EOF_PIO' >> "firmware/platformio.ini"
+${pioSection}
+EOF_PIO
+        success "Updated firmware/platformio.ini (inherited by test_motors & test_sensors)"
+    else
+        info "[env:${name}] already exists in firmware/platformio.ini"
+    fi
+fi
+
+# -----------------------------------------------------------------------------
+# Phase 6: Ingest URDF Description
+# -----------------------------------------------------------------------------
+${opts.mergeUrdf ? `info "Step 6: Writing URDF description to urdf/${name}_properties.urdf.xacro..."
+mkdir -p urdf
+cat << 'EOF_URDF' > "urdf/${name}_properties.urdf.xacro"
+${urdfContent}
+EOF_URDF
+success "Generated urdf/${name}_properties.urdf.xacro"
+` : "# URDF generation skipped"}
+
+# -----------------------------------------------------------------------------
+# Phase 7: Stage and Commit Changes
+# -----------------------------------------------------------------------------
+${opts.autoCommit ? `if git rev-parse --is-inside-work-tree &>/dev/null; then
+    info "Step 7: Committing generated hardware configuration to Git..."
+    git add config/ firmware/platformio.ini urdf/ 2>/dev/null || true
+    if ! git diff --cached --quiet; then
+        if ! git config user.email >/dev/null 2>&1; then
+            warn "No git identity configured; setting a repository-local placeholder."
+            git config user.email "deploy@linorobot2.local" || true
+            git config user.name "Linorobot2 Deploy Engine" || true
+        fi
+        if git commit -m "${commitMsgEsc}"; then
+            success "Git commit created on branch '${branch}'"
+        else
+            warn "git commit failed; the generated configuration remains staged."
+        fi
+    else
+        info "No configuration changes to commit."
+    fi
+fi` : "# Git commit skipped"}
+
+# -----------------------------------------------------------------------------
+# Phase 8: Build and Flash Target Firmware
+# -----------------------------------------------------------------------------
+info "Step 8/9: Building target '${target}' for environment '[env:${name}]'..."
+info "💡 Note: First-time micro-ROS compilation builds IDL packages and may take 2-4 minutes on lower-spec SBCs (e.g. Raspberry Pi). Subsequent builds will be cached and fast."
+if [ -d "${target}" ]; then
+    pio run -d "${target}" -e "${name}"
+    success "Build SUCCEEDED for '${name}' in ${target}/"
+
+    if [ -n "${port}" ] && [ "${port}" != "AUTO" ]; then
+        ensure_serial_rw "${port}"
+        info "Releasing port '${port}' (closing active micro-ROS agents and serial monitors)..."
+        fuser -k "${port}" 2>/dev/null || true
+        pkill -f "micro_ros_agent.*${port}" 2>/dev/null || true
+        pkill -f "miniterm.*${port}" 2>/dev/null || true
+        pkill -f "screen.*${port}" 2>/dev/null || true
+        sleep 0.8
+
+        info "Uploading firmware to microcontroller on port '${port}'..."
+        pio run -d "${target}" -e "${name}" -t upload --upload-port "${port}"${otaAuth} || {
+            warn "Initial upload attempt exited. Retrying upload after resetting serial port..."
+            fuser -k "${port}" 2>/dev/null || true
+            sleep 1
+            pio run -d "${target}" -e "${name}" -t upload --upload-port "${port}"${otaAuth} || {
+                warn "Attempting fallback auto-upload protocol..."
+                pio run -d "${target}" -e "${name}" -t upload || {
+                    err "All upload attempts failed for port '${port}'."
+                    err "Check the cable, hold BOOT/RESET if the board requires it, and make sure no serial monitor holds the port."
+                    exit 1
+                }
+            }
+        }
+        success "Microcontroller flashing COMPLETE!"
+    fi
+else
+    warn "Target directory '${target}/' not found in current workspace."
+fi
+
+# -----------------------------------------------------------------------------
+# Phase 9: Start micro-ROS Agent & Discover Active ROS 2 Topics (for firmware)
+# -----------------------------------------------------------------------------
+if [ "${target}" = "firmware" ] && [ "${opts.rosDistro}" != "none" ]; then
+    info "Step 9/9: Launching micro-ROS Agent & discovering active ROS 2 topics..."
+    
+    # Source ROS 2 environment (setup chains may return non-zero; do not abort on them)
+    set +e
+    [ -f "/opt/ros/${opts.rosDistro}/setup.bash" ] && source "/opt/ros/${opts.rosDistro}/setup.bash"
+    [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"
+    set -e
+
+    # Terminate any existing micro_ros_agent on this port/protocol
+    pkill -f "micro_ros_agent.*${port}" 2>/dev/null || true
+    pkill -f "micro_ros_agent.*udp4" 2>/dev/null || true
+    sleep 0.5
+    ensure_serial_rw "${port}"
+
+    if ! ros2 pkg prefix micro_ros_agent >/dev/null 2>&1; then
+        err "micro_ros_agent is not on the ROS 2 graph — the agent workspace did not build for '${opts.rosDistro}'."
+        err "Firmware was compiled and flashed successfully; bridge it with an agent from a supported distro/container."
+        exit 1
+    fi
+
+    AGENT_LOG="/tmp/micro_ros_agent_${name}.log"
+    info "Starting micro-ROS agent in background (logging to \${AGENT_LOG})..."
+
+    # After a BOOTSEL / AUTO flash the board re-enumerates as a CDC device; the
+    # agent must target that, not the literal "BOOTSEL".
+    AGENT_DEV="${port}"
+    if [ "\${AGENT_DEV}" = "BOOTSEL" ] || [ "\${AGENT_DEV}" = "AUTO" ] || [ ! -e "\${AGENT_DEV}" ]; then
+        for _i in $(seq 1 10); do
+            AGENT_DEV=$(ls /dev/ttyACM* /dev/ttyUSB* 2>/dev/null | head -n1)
+            [ -n "\${AGENT_DEV}" ] && break
+            sleep 1
+        done
+        info "Post-flash serial device: \${AGENT_DEV:-<none found>}"
+    fi
+    ensure_serial_rw "\${AGENT_DEV}"
+
+    ${/WIFI|UDP/i.test(spec.transport || "") ? `
+    ros2 run micro_ros_agent micro_ros_agent udp4 --port 8888 > "\${AGENT_LOG}" 2>&1 &
+    AGENT_PID=$!
+    ` : `
+    ros2 run micro_ros_agent micro_ros_agent serial --dev "\${AGENT_DEV}" -b "${spec.baudrate || 921600}" > "\${AGENT_LOG}" 2>&1 &
+    AGENT_PID=$!
+    `}
+
+    info "Agent PID: \${AGENT_PID}. Waiting for session handshake from microcontroller..."
+    
+    # Poll for micro-ROS session establishment (up to 8 seconds)
+    CONNECTED=0
+    for i in $(seq 1 8); do
+        sleep 1
+        if grep -qi "session established" "\${AGENT_LOG}" 2>/dev/null || ros2 node list 2>/dev/null | grep -q "linorobot2"; then
+            CONNECTED=1
+            break
+        fi
+        echo -n "."
+    done
+    echo ""
+
+    if [ "\${CONNECTED}" -eq 1 ]; then
+        success "🎉 micro-ROS Agent connected successfully! Active ROS 2 Session Established."
+    else
+        info "micro-ROS Agent active in background. Querying active ROS 2 graph..."
+    fi
+
+    info "========================================================="
+    info "  Active ROS 2 Nodes on Robot Network:"
+    info "========================================================="
+    ros2 node list 2>/dev/null || echo "  (no nodes discovered yet)"
+    
+    info "========================================================="
+    info "  Active ROS 2 Topics & Message Types:"
+    info "========================================================="
+    ros2 topic list -t 2>/dev/null || echo "  (no topics discovered yet)"
+    info "========================================================="
+fi
+
+info "========================================================="
+success "All deployment steps completed successfully for '${name}'!"
+info "========================================================="
+`;
+
+  return script;
+}
+
+// -----------------------------------------------------------------------------
+// Web Serial API Implementation for Chrome / Edge Live Microcontroller Logs
+// -----------------------------------------------------------------------------
+async function toggleWebSerialConnection() {
+  if (serialPort) {
+    await disconnectWebSerial();
+  } else {
+    await connectWebSerial();
+  }
+}
+
+async function connectWebSerial() {
+  const terminalScreen = document.getElementById("serial-terminal-screen");
+  const statusPill = document.getElementById("serial-status-pill");
+  const statusText = document.getElementById("serial-status-text");
+  const btnConnect = document.getElementById("btn-serial-connect");
+  const btnText = document.getElementById("serial-btn-text");
+  const baudSelect = document.getElementById("serial-baud-select");
+  const inputBar = document.getElementById("serial-input-text");
+  const btnSend = document.getElementById("btn-serial-send");
+
+  if (!("serial" in navigator)) {
+    appendTerminalLine("❌ Web Serial API is not supported in this browser. Please use Chrome, Edge, or Opera over HTTPS/localhost.", "err");
+    alert("Web Serial API is not supported in this browser. Please open in Google Chrome or Microsoft Edge.");
+    return;
+  }
+
+  try {
+    const baudRate = parseInt(baudSelect?.value || "115200", 10);
+    appendTerminalLine(`🔌 Requesting serial port access (Baud: ${baudRate})...`, "dim");
+
+    serialPort = await navigator.serial.requestPort();
+    await serialPort.open({ baudRate: baudRate });
+
+    // Update UI Connected State
+    if (statusPill) statusPill.className = "serial-status-pill pill-connected";
+    if (statusText) statusText.innerText = `Connected (${baudRate} baud)`;
+    if (btnText) btnText.innerText = "Disconnect";
+    if (btnConnect) btnConnect.className = "btn btn-sm btn-secondary";
+    if (inputBar) inputBar.disabled = false;
+    if (btnSend) btnSend.disabled = false;
+
+    appendTerminalLine(`✅ Serial port connected at ${baudRate} baud. Streaming output:`, "dim");
+    showToast("🟢 Serial port connected!");
+
+    // Start background reader loop
+    readSerialStream();
+
+  } catch (err) {
+    appendTerminalLine(`❌ Connection failed: ${err.message}`, "err");
+    serialPort = null;
+    if (statusPill) statusPill.className = "serial-status-pill pill-disconnected";
+    if (statusText) statusText.innerText = "Disconnected";
+  }
+}
+
+async function disconnectWebSerial() {
+  const statusPill = document.getElementById("serial-status-pill");
+  const statusText = document.getElementById("serial-status-text");
+  const btnConnect = document.getElementById("btn-serial-connect");
+  const btnText = document.getElementById("serial-btn-text");
+  const inputBar = document.getElementById("serial-input-text");
+  const btnSend = document.getElementById("btn-serial-send");
+
+  isSerialReading = false;
+
+  try {
+    if (serialReader) {
+      await serialReader.cancel();
+      serialReader = null;
+    }
+    if (serialPort) {
+      await serialPort.close();
+      serialPort = null;
+    }
+  } catch (err) {
+    console.error("Error closing serial port:", err);
+  }
+
+  if (statusPill) statusPill.className = "serial-status-pill pill-disconnected";
+  if (statusText) statusText.innerText = "Disconnected";
+  if (btnText) btnText.innerText = "Connect Serial Port";
+  if (btnConnect) btnConnect.className = "btn btn-sm btn-accent";
+  if (inputBar) inputBar.disabled = true;
+  if (btnSend) btnSend.disabled = true;
+
+  appendTerminalLine("🔌 Serial port disconnected.", "dim");
+  showToast("🔌 Serial port disconnected.");
+}
+
+async function readSerialStream() {
+  isSerialReading = true;
+  const decoder = new TextDecoderStream();
+  const inputDone = serialPort.readable.pipeTo(decoder.writable);
+  const inputStream = decoder.readable;
+  serialReader = inputStream.getReader();
+
+  let lineBuffer = "";
+
+  try {
+    while (isSerialReading) {
+      const { value, done } = await serialReader.read();
+      if (done) break;
+      if (value) {
+        lineBuffer += value;
+        const lines = lineBuffer.split(/\r?\n/);
+        lineBuffer = lines.pop(); // Keep partial line in buffer
+
+        for (const line of lines) {
+          if (line.trim().length > 0) {
+            appendTerminalLine(line, "out");
+          }
+        }
+      }
+    }
+  } catch (err) {
+    if (isSerialReading) {
+      appendTerminalLine(`⚠️ Serial stream closed: ${err.message}`, "dim");
+    }
+  } finally {
+    if (serialReader) {
+      serialReader.releaseLock();
+    }
+  }
+}
+
+async function sendSerialCommand() {
+  const inputBar = document.getElementById("serial-input-text");
+  if (!inputBar || !inputBar.value || !serialPort || !serialPort.writable) return;
+
+  const textToSend = inputBar.value + "\n";
+  appendTerminalLine(`> ${inputBar.value}`, "in");
+  inputBar.value = "";
+
+  const encoder = new TextEncoder();
+  const writer = serialPort.writable.getWriter();
+  await writer.write(encoder.encode(textToSend));
+  writer.releaseLock();
+}
+
+function appendTerminalLine(text, type = "out") {
+  const screen = document.getElementById("serial-terminal-screen");
+  if (!screen) return;
+
+  const lineEl = document.createElement("div");
+  lineEl.className = `terminal-line terminal-${type}`;
+  lineEl.innerText = text;
+  screen.appendChild(lineEl);
+
+  const autoScroll = document.getElementById("chk-serial-autoscroll")?.checked ?? true;
+  if (autoScroll) {
+    screen.scrollTop = screen.scrollHeight;
+  }
+}
+
+function clearTerminalScreen() {
+  const screen = document.getElementById("serial-terminal-screen");
+  if (screen) {
+    screen.innerHTML = '<div class="terminal-line terminal-dim">[Terminal Cleared]</div>';
+  }
+}
+
+// Robust Direct Upload / Build Command Generator (module scope so the ADC
+// Calibration Studio's runHardwareAdcCalibration() can reuse it too).
+function getDirectUploadOrBuildCmd(target, isUpload = true) {
+  const spec = currentSpec;
+  const name = spec.robot_name || "scout_pico2";
+  const nameUpper = name.toUpperCase();
+  const opts = readAutomationOptions();
+  const rosDistro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
+  const otaOn = document.getElementById("cfg-ota-enable")?.checked;
+  const otaIp = (document.getElementById("cfg-ota-ip")?.value || "").trim();
+  const otaPass = (document.getElementById("cfg-ota-password")?.value || "").trim();
+  const port = (otaOn && otaIp) ? otaIp
+             : (document.getElementById("auto-flash-port")?.value.trim() || (isESP32(spec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0"));
+  const headerContent = generateCppHeader(spec);
+  const wifiConfigContent = generateWifiConfig(spec);
+  const pioSection = generatePlatformioEnv(spec);
+  const urdfContent = generateUrdfXacro(spec);
+  const targetDir = (target === "i2c_detect") ? "tools/i2c_detect" : target;
+  // test_motors/, test_acc/, test_sensors/ and adc_calibrate/ each carry a
+  // platformio.ini with `extra_configs = ../firmware/platformio.ini`, so they
+  // inherit [env:<robot>] and build with the user's exact config. (The legacy
+  // calibration/ project has its own fixed env list and is not used here.)
+  const buildEnv = name;
+
+  const lines = [
+    `set -e`,
+    `export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"`,
+    `export ROS_DISTRO=${rosDistro}`,
+    `[ "$(awk '/MemTotal/{print $2}' /proc/meminfo 2>/dev/null || echo 8000000)" -lt 6000000 ] && export PLATFORMIO_BUILD_JOBS=2 MAKEFLAGS="-j2" || true`,
+    `if [ -f "/opt/ros/${rosDistro}/setup.bash" ]; then source "/opt/ros/${rosDistro}/setup.bash"; fi`,
+    `if [ -f "$HOME/uros_ws/install/setup.bash" ]; then source "$HOME/uros_ws/install/setup.bash"; fi`,
+    ``,
+    `# 1. Ensure custom robot headers and urdf are synced`,
+    `mkdir -p config/custom urdf`,
+    `cat << 'EOF_HEADER' > "config/custom/${name}_config.h"`,
+    `${headerContent}`,
+    `EOF_HEADER`,
+    ...(wifiConfigContent ? [
+      `if [ ! -f "config/custom/wifi_config.h" ]; then`,
+      `    cat << 'EOF_WIFI_CFG' > "config/custom/wifi_config.h"   # git-ignored, holds WiFi credentials`,
+      `${wifiConfigContent}`,
+      `EOF_WIFI_CFG`,
+      `fi`,
+    ] : []),
+    ``,
+    `# 2. Ensure USE_${nameUpper}_CONFIG is registered in config/config.h`,
+    `if [ -f "config/config.h" ]; then`,
+    `    if ! grep -F -q "USE_${nameUpper}_CONFIG" config/config.h; then`,
+    `        sed -i '/\\/\\/ add user configurations above this line/i #ifdef USE_${nameUpper}_CONFIG\\n    #include "custom/${name}_config.h"\\n#endif\\n' config/config.h`,
+    `    fi`,
+    `fi`,
+    ``,
+    `# 3. Ensure [env:${name}] is defined in firmware/platformio.ini`,
+    `if [ -f "firmware/platformio.ini" ]; then`,
+    `    if ! grep -F -q "[env:${name}]" "firmware/platformio.ini"; then`,
+    `        echo "" >> "firmware/platformio.ini"`,
+    `        cat << 'EOF_PIO' >> "firmware/platformio.ini"`,
+    `${pioSection}`,
+    `EOF_PIO`,
+    `    fi`,
+    `fi`,
+    ``,
+    `# 4. Ingest URDF Description`,
+    `cat << 'EOF_URDF' > "urdf/${name}_properties.urdf.xacro"`,
+    `${urdfContent}`,
+    `EOF_URDF`,
+    ``,
+    `# 5. Compile & Upload via PlatformIO`
+  ];
+
+  if (isUpload) {
+    lines.push(`# 5. Stop serial micro-ROS agent & monitors to release shared USB port (WiFi agent kept running)`);
+    lines.push(`echo "Releasing USB port '${port}' (stopping serial micro-ROS agent and serial monitors)..."`);
+    // NOTE the "[m]" / "[s]" first-character classes: this whole script is passed
+    // to `bash -c` as one argument, so a plain `pkill -f "micro_ros_agent.*serial"`
+    // matches the running shell's OWN /proc/<pid>/cmdline and SIGTERMs the deploy
+    // (exit -15). The bracket makes the pattern text non-self-matching while it
+    // still matches a real `micro_ros_agent ... serial` process.
+    lines.push(`pkill -f "[m]icro_ros_agent.*serial" 2>/dev/null || true`);
+    lines.push(`pkill -f "[m]initerm" 2>/dev/null || true`);
+    lines.push(`pkill -f "[s]creen.*${port}" 2>/dev/null || true`);
+    if (port !== "AUTO" && port !== "BOOTSEL" && !(otaOn && otaIp)) {
+      lines.push(`[ -e "${port}" ] && fuser -k "${port}" 2>/dev/null || true`);
+      // Grant r/w when no udev rule / 'dialout' membership does.
+      lines.push(`for _d in /dev/ttyUSB* /dev/ttyACM*; do [ -e "$_d" ] && [ ! -w "$_d" ] && sudo chmod a+rw "$_d" 2>/dev/null || true; done`);
+    }
+    lines.push(`sleep 0.8`);
+    lines.push(``);
+    lines.push(`# 6. Flash Firmware onto Microcontroller`);
+    if (port === "AUTO" || port === "BOOTSEL") {
+      lines.push(`pio run -d ${targetDir} -e ${buildEnv} -t upload`);
+    } else if (otaOn && otaIp) {
+      const authFlag = otaPass ? ` --upload-flags "--auth=${otaPass}"` : "";
+      lines.push(`echo "OTA flashing ${buildEnv} over WiFi -> ${otaIp}"`);
+      lines.push(`pio run -d ${targetDir} -e ${buildEnv} -t upload --upload-port ${otaIp}${authFlag}`);
+    } else {
+      lines.push(`pio run -d ${targetDir} -e ${buildEnv} -t upload --upload-port ${port}`);
+    }
+  } else {
+    lines.push(`pio run -d ${targetDir} -e ${buildEnv}`);
+  }
+
+  return lines.join("\n");
+}
+
+
+// Initialize Automation Event Listeners
+function initAutomationEventListeners() {
+  // Top Quick Deploy Button
+  const btnQuickDeploy = document.getElementById("btn-quick-deploy");
+  if (btnQuickDeploy) {
+    btnQuickDeploy.addEventListener("click", () => {
+      const tabBtn = document.querySelector('[data-tab="tab-automation"]');
+      if (tabBtn) tabBtn.click();
+    });
+  }
+
+  // Re-detect OS Button
+  const btnRedetect = document.getElementById("btn-redetect-os");
+  if (btnRedetect) {
+    btnRedetect.addEventListener("click", () => {
+      detectClientOS();
+      showToast("🔍 OS re-detected!");
+    });
+  }
+
+  // Dynamic Automation Form Listeners
+  const autoInputs = [
+    "auto-os-select", "auto-env-select", "auto-arch-select",
+    "chk-install-pio", "chk-install-udev", "chk-install-dialout", "chk-install-buildtools",
+    "auto-ros-distro", "auto-ros-type", "chk-build-microros-agent",
+    "auto-git-branch", "auto-git-commit-msg",
+    "chk-merge-header", "chk-merge-pio-firmware", "chk-merge-urdf", "chk-auto-commit",
+    "auto-flash-target", "auto-flash-port"
+  ];
+
+  autoInputs.forEach(id => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.addEventListener("input", () => {
+        if (id === "auto-git-branch" || id === "auto-git-commit-msg" || id === "auto-flash-port") {
+          el.dataset.autoManaged = "false";
+        }
+        updateAutomationPreviews();
+      });
+      el.addEventListener("change", () => {
+        updateAutomationPreviews();
+      });
+    }
+  });
+
+  // Quick Copy Buttons
+  const btnCopyTool = document.getElementById("btn-copy-tool-cmd");
+  if (btnCopyTool) {
+    btnCopyTool.addEventListener("click", () => {
+      const cmd = document.getElementById("preview-tool-cmd")?.innerText || "";
+      navigator.clipboard.writeText(cmd).then(() => showToast("📋 Toolchain command copied!"));
+    });
+  }
+
+  const btnCopyRos = document.getElementById("btn-copy-ros-cmd");
+  if (btnCopyRos) {
+    btnCopyRos.addEventListener("click", () => {
+      const cmd = document.getElementById("preview-ros-cmd")?.innerText || "";
+      navigator.clipboard.writeText(cmd).then(() => showToast("📋 ROS 2 command copied!"));
+    });
+  }
+
+  const btnCopyMerge = document.getElementById("btn-copy-merge-cmd");
+  if (btnCopyMerge) {
+    btnCopyMerge.addEventListener("click", () => {
+      const cmd = document.getElementById("preview-merge-cmd")?.innerText || "";
+      navigator.clipboard.writeText(cmd).then(() => showToast("📋 Merge & Commit command copied!"));
+    });
+  }
+
+  const btnCopyBuild = document.getElementById("btn-copy-build-cmd");
+  if (btnCopyBuild) {
+    btnCopyBuild.addEventListener("click", () => {
+      const target = document.getElementById("auto-flash-target")?.value || "firmware";
+      const name = currentSpec.robot_name || "scout_pico2";
+      const cmd = `pio run -d ${target} -e ${name}`;
+      navigator.clipboard.writeText(cmd).then(() => showToast(`📋 Build command copied: ${cmd}`));
+    });
+  }
+
+  const btnCopyUpload = document.getElementById("btn-copy-upload-cmd");
+  if (btnCopyUpload) {
+    btnCopyUpload.addEventListener("click", () => {
+      const target = document.getElementById("auto-flash-target")?.value || "firmware";
+      const name = currentSpec.robot_name || "scout_pico2";
+      const port = document.getElementById("auto-flash-port")?.value.trim() || "/dev/ttyACM0";
+      const cmd = port === "AUTO" ? `pio run -d ${target} -e ${name} -t upload` : `pio run -d ${target} -e ${name} -t upload --upload-port ${port}`;
+      navigator.clipboard.writeText(cmd).then(() => showToast(`⚡ Upload command copied: ${cmd}`));
+    });
+  }
+
+  // Command Execution Buttons
+  const btnExecTool = document.getElementById("btn-exec-tool-cmd");
+  if (btnExecTool) {
+    btnExecTool.addEventListener("click", () => {
+      const cmd = document.getElementById("preview-tool-cmd")?.innerText || "";
+      executeCommandInTerminal(cmd, "Installing Build Toolchains & Permissions");
+    });
+  }
+
+  const btnExecRos = document.getElementById("btn-exec-ros-cmd");
+  if (btnExecRos) {
+    btnExecRos.addEventListener("click", () => {
+      const cmd = document.getElementById("preview-ros-cmd")?.innerText || "";
+      executeCommandInTerminal(cmd, "Installing ROS 2 Distribution & Packages");
+    });
+  }
+
+  // micro-ROS Agent Quick Actions
+  const btnCopyAgent = document.getElementById("btn-copy-agent-cmd");
+  if (btnCopyAgent) {
+    btnCopyAgent.addEventListener("click", () => {
+      const cmd = document.getElementById("preview-agent-cmd")?.innerText || "";
+      navigator.clipboard.writeText(cmd).then(() => showToast("📋 micro-ROS Agent command copied!"));
+    });
+  }
+
+  const btnExecAgentSerial = document.getElementById("btn-exec-agent-serial");
+  if (btnExecAgentSerial) {
+    btnExecAgentSerial.addEventListener("click", () => {
+      const opts = readAutomationOptions();
+      const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
+      const port = document.getElementById("auto-flash-port")?.value.trim() || "/dev/ttyUSB0";
+      const baud = document.getElementById("auto-agent-baud")?.value || "921600";
+      const cmd = `[ -e "${port}" ] && [ ! -w "${port}" ] && sudo chmod a+rw "${port}" 2>/dev/null || true; source /opt/ros/${distro}/setup.bash && [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"; ros2 run micro_ros_agent micro_ros_agent serial --dev ${port} -b ${baud}`;
+      executeCommandInTerminal(cmd, `Launching Single Serial micro-ROS Agent (${port} @ ${baud}) on Robot SBC`);
+    });
+  }
+
+  const btnExecAgentMultiSerial = document.getElementById("btn-exec-agent-multiserial");
+  if (btnExecAgentMultiSerial) {
+    btnExecAgentMultiSerial.addEventListener("click", () => {
+      const opts = readAutomationOptions();
+      const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
+      const multiPorts = document.getElementById("auto-agent-multiserial-ports")?.value.trim() || "/dev/ttyACM0 /dev/ttyUSB0";
+      const baud = document.getElementById("auto-agent-baud")?.value || "921600";
+      const cmd = `for _d in ${multiPorts}; do [ -e "$_d" ] && [ ! -w "$_d" ] && sudo chmod a+rw "$_d" 2>/dev/null || true; done; source /opt/ros/${distro}/setup.bash && [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"; ros2 run micro_ros_agent micro_ros_agent multiserial --devs "${multiPorts}" -b ${baud}`;
+      executeCommandInTerminal(cmd, `Launching Multi-Serial micro-ROS Agent (${multiPorts} @ ${baud}) on Robot SBC`);
+    });
+  }
+
+  const btnExecAgentUdp = document.getElementById("btn-exec-agent-udp");
+  if (btnExecAgentUdp) {
+    btnExecAgentUdp.addEventListener("click", () => {
+      const opts = readAutomationOptions();
+      const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
+      const cmd = `source /opt/ros/${distro}/setup.bash && [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"; ros2 run micro_ros_agent micro_ros_agent udp4 --port 8888`;
+      executeCommandInTerminal(cmd, `Launching UDP WiFi micro-ROS Agent (:8888) on Robot SBC`);
+    });
+  }
+
+  // Flash Port & Multi-Serial Input Event Listeners
+  const flashPortElem = document.getElementById("auto-flash-port");
+  if (flashPortElem) {
+    flashPortElem.addEventListener("input", () => {
+      flashPortElem.dataset.autoManaged = "false";
+      updateAutomationPreviews();
+    });
+  }
+
+  const multiPortsElem = document.getElementById("auto-agent-multiserial-ports");
+  if (multiPortsElem) {
+    multiPortsElem.addEventListener("input", () => {
+      multiPortsElem.dataset.autoManaged = "false";
+      updateAutomationPreviews();
+    });
+  }
+
+  const agentBaudElem = document.getElementById("auto-agent-baud");
+  if (agentBaudElem) {
+    agentBaudElem.addEventListener("change", () => {
+      updateAutomationPreviews();
+    });
+  }
+
+  const btnExecMerge = document.getElementById("btn-exec-merge-cmd");
+  if (btnExecMerge) {
+    btnExecMerge.addEventListener("click", () => {
+      const spec = currentSpec;
+      const opts = readAutomationOptions();
+      const name = spec.robot_name || "scout_pico2";
+      const cmd = getMergeAndCommitCmd(spec, opts);
+      executeCommandInTerminal(cmd, `Merging Headers & Committing '${name}'`);
+    });
+  }
+
+  const btnExecBuild = document.getElementById("btn-exec-build-cmd");
+  if (btnExecBuild) {
+    btnExecBuild.addEventListener("click", () => {
+      const target = document.getElementById("auto-flash-target")?.value || "firmware";
+      const name = currentSpec.robot_name || "scout_pico2";
+      const cmd = getDirectUploadOrBuildCmd(target, false);
+      executeCommandInTerminal(cmd, `Building ${target}/ for [env:${name}]`);
+    });
+  }
+
+  // Direct 1-Click Upload Buttons for test_sensors, test_motors, test_acc, adc_calibrate, firmware
+  const directTargets = [
+    { btnId: "btn-upload-sensors", target: "test_sensors", desc: "Sensor Diagnostics (I2C Scanner)" },
+    { btnId: "btn-upload-motors", target: "test_motors", desc: "Motor Diagnostics (CPR & Direction)" },
+    { btnId: "btn-upload-acc", target: "test_acc", desc: "Dynamic Acceleration Profiler" },
+    { btnId: "btn-upload-adc", target: "adc_calibrate", desc: "ESP32 ADC Calibration & Linearization" },
+    { btnId: "btn-upload-firmware", target: "firmware", desc: "Main Robot Firmware" }
+  ];
+
+  directTargets.forEach(({ btnId, target, desc }) => {
+    const btn = document.getElementById(btnId);
+    if (btn) {
+      btn.addEventListener("click", () => {
+        const targetSel = document.getElementById("auto-flash-target");
+        if (targetSel) targetSel.value = target;
+        updateAutomationPreviews();
+        const port = document.getElementById("auto-flash-port")?.value.trim() || (isESP32(currentSpec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
+        const cmd = getDirectUploadOrBuildCmd(target, true);
+        executeCommandInTerminal(cmd, `⚡ Uploading ${desc} (${target}/ -> ${port})`);
+      });
+    }
+  });
+
+  const btnExecUpload = document.getElementById("btn-exec-upload-cmd");
+  if (btnExecUpload) {
+    btnExecUpload.addEventListener("click", () => {
+      const target = document.getElementById("auto-flash-target")?.value || "firmware";
+      const port = document.getElementById("auto-flash-port")?.value.trim() || (isESP32(currentSpec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
+      const cmd = getDirectUploadOrBuildCmd(target, true);
+      executeCommandInTerminal(cmd, `Flashing Microcontroller (${target}/ -> ${port})`);
+    });
+  }
+
+  const btnExecDeploy = document.getElementById("btn-exec-deploy-script");
+  if (btnExecDeploy) {
+    btnExecDeploy.addEventListener("click", () => {
+      const spec = currentSpec;
+      const opts = readAutomationOptions();
+      const name = spec.robot_name || "scout_pico2";
+      const script = generateDeployScript(spec, opts);
+      const safeName = String(name).replace(/[^A-Za-z0-9._-]/g, "_");
+      const cmd = `cat << 'EOF_DEPLOY_SCRIPT_WRAPPER' > "deploy_${safeName}.sh"\n${script}\nEOF_DEPLOY_SCRIPT_WRAPPER\nchmod +x "deploy_${safeName}.sh" && bash "./deploy_${safeName}.sh"`;
+      executeCommandInTerminal(cmd, `Executing Full Deploy Lifecycle for '${name}'`);
+    });
+  }
+
+  const btnCancelExec = document.getElementById("btn-cancel-exec");
+  if (btnCancelExec) {
+    btnCancelExec.addEventListener("click", cancelRunningExecution);
+  }
+
+  const btnDownloadDeploy = document.getElementById("btn-download-deploy-script");
+  if (btnDownloadDeploy) {
+    btnDownloadDeploy.addEventListener("click", () => {
+      const script = generateDeployScript(currentSpec, readAutomationOptions());
+      const filename = `deploy_${currentSpec.robot_name || "robot"}.sh`;
+      triggerDownload(filename, script, "application/x-sh");
+      showToast(`📥 ${filename} downloaded!`);
+    });
+  }
+
+  // Stream SBC Serial Monitor
+  const btnSbcMonitor = document.getElementById("btn-sbc-monitor");
+  if (btnSbcMonitor) {
+    btnSbcMonitor.addEventListener("click", () => {
+      const port = document.getElementById("auto-flash-port")?.value.trim() || (isESP32(currentSpec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
+      const baud = document.getElementById("serial-baud-select")?.value || "921600";
+      const cmd = `python3 -u -c "import serial, sys, time; ser = serial.Serial('${port}', ${baud}, timeout=0.2); print('📡 Connected to ${port} @ ${baud} baud. Streaming live microcontroller output (test_sensors / telemetry)... Click ⏹️ Stop Process to disconnect.\\n', flush=True); [sys.stdout.write(l.decode('utf-8', errors='replace')) or sys.stdout.flush() for l in iter(ser.readline, b'')] || true"`;
+      executeCommandInTerminal(cmd, `📡 Streaming Serial Telemetry (${port} @ ${baud} baud)`);
+    });
+  }
+
+  // Web Serial Event Listeners (Client Browser USB)
+  const btnSerialConnect = document.getElementById("btn-serial-connect");
+  if (btnSerialConnect) {
+    btnSerialConnect.addEventListener("click", toggleWebSerialConnection);
+  }
+
+  const btnSerialClear = document.getElementById("btn-serial-clear");
+  if (btnSerialClear) {
+    btnSerialClear.addEventListener("click", clearTerminalScreen);
+  }
+
+  const btnSerialSend = document.getElementById("btn-serial-send");
+  if (btnSerialSend) {
+    btnSerialSend.addEventListener("click", sendSerialCommand);
+  }
+
+  const inputSerialText = document.getElementById("serial-input-text");
+  if (inputSerialText) {
+    inputSerialText.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        sendSerialCommand();
+      }
+    });
+  }
+}
+
+
+// =============================================================================
+// Live Command Execution API & Subprocess Controller
+// =============================================================================
+
+let isRunnerOnline = false;
+let currentExecController = null;
+
+// Check Server Runner API Status (GET /api/status)
+async function checkServerRunnerStatus() {
+  const pill = document.getElementById("runner-status-pill");
+  const text = document.getElementById("runner-status-text");
+
+  try {
+    const res = await fetch("/api/status", { cache: "no-cache" });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.status === "ok" && data.exec_supported) {
+        isRunnerOnline = true;
+        if (pill) pill.className = "runner-status-pill pill-online";
+        const distroLabel = data.distro_name || data.distro_id || data.os;
+        if (text) text.innerText = `Robot SBC: Online [${data.node || "host"}] (${data.machine || ""})`;
+
+        syncRobotHostInfo(data);
+        if (data.host_ip) applyHostIpDefaults(data.host_ip);
+        return;
+      }
+    }
+  } catch (e) {
+    // Runner offline
+  }
+
+  isRunnerOnline = false;
+  if (pill) pill.className = "runner-status-pill pill-offline";
+  if (text) text.innerText = "Robot SBC: Disconnected / Copy Mode";
+}
+
+// Seed the network-target IP fields with this host's LAN address (until the
+// user overrides them). Agent / Syslog / LiDAR all point back at the machine
+// running the Web UI by default.
+function applyHostIpDefaults(hostIp) {
+  ["cfg-agent-ip", "cfg-syslog-ip", "cfg-lidar-ip"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (!el || el.dataset.autoManaged === "false") return;
+    if (!el.value || el.value === "192.168.1.100") { el.value = hostIp; el.dataset.autoManaged = "true"; }
+  });
+}
+
+// Execute Command with Live Streaming Output in Terminal Console
+async function executeCommandInTerminal(command, title = "Executing Command") {
+  const terminalScreen = document.getElementById("serial-terminal-screen");
+  const btnCancel = document.getElementById("btn-cancel-exec");
+
+  // Scroll to terminal
+  const terminalEl = document.querySelector(".web-serial-console-card");
+  if (terminalEl) {
+    terminalEl.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }
+
+  if (!isRunnerOnline) {
+    await checkServerRunnerStatus();
+  }
+
+  if (!isRunnerOnline) {
+    appendTerminalLine(`\n=========================================================`, "dim");
+    appendTerminalLine(`🚀 ${title}`, "in");
+    appendTerminalLine(`=========================================================`, "dim");
+    appendTerminalLine(`$ ${command}`, "out");
+    appendTerminalLine(`ℹ️  Local Execution Runner is not active on this host/port.`, "dim");
+    appendTerminalLine(`👉 Run 'python3 server.py' in tools/robot_config_engine/web to enable 1-click execution!`, "in");
+    appendTerminalLine(`📋 Command copied to clipboard for manual terminal execution.`, "dim");
+
+    navigator.clipboard.writeText(command).then(() => {
+      showToast("📋 Command copied! (Start 'python3 server.py' for 1-click execution)");
+    });
+    return;
+  }
+
+  appendTerminalLine(`\n=========================================================`, "dim");
+  appendTerminalLine(`🚀 ${title}`, "in");
+  appendTerminalLine(`$ ${command}`, "dim");
+  appendTerminalLine(`=========================================================`, "dim");
+
+  if (btnCancel) btnCancel.style.display = "inline-flex";
+
+  // Update Hero Deploy Badge with Live Phase & Timer
+  const heroBadge = document.getElementById("hero-deploy-badge");
+  const heroStatusText = document.getElementById("hero-deploy-status-text");
+  const heroTimer = document.getElementById("hero-deploy-timer");
+  let deployStartTime = Date.now();
+  let deployTimerInterval = null;
+
+  // Generic "task running" indicator for every executeCommandInTerminal call
+  const execPill = document.getElementById("exec-progress-pill");
+  const execText = document.getElementById("exec-progress-text");
+  const execTimer = document.getElementById("exec-progress-timer");
+  const execTitle = title.replace(/^[^\w]+\s*/, "");
+  let execTimerInterval = null;
+  const setExecPhase = (p) => { if (execText) execText.textContent = p ? `${execTitle} · ${p}` : execTitle; };
+  if (execPill) {
+    execPill.style.display = "inline-flex";
+    execPill.className = "runner-status-pill pill-checking";
+    setExecPhase("");
+    if (execTimer) {
+      execTimer.textContent = "(0s)";
+      execTimerInterval = setInterval(() => {
+        const s = Math.floor((Date.now() - deployStartTime) / 1000);
+        execTimer.textContent = s < 60 ? `(${s}s)` : `(${Math.floor(s/60)}:${String(s%60).padStart(2,"0")})`;
+      }, 1000);
+    }
+  }
+
+  if (heroBadge && title.includes("Full Deploy")) {
+    heroBadge.className = "deploy-hero-badge deploying";
+    if (heroStatusText) heroStatusText.innerText = "Deploying...";
+    if (heroTimer) {
+      heroTimer.style.display = "inline";
+      heroTimer.innerText = "(0s)";
+      deployTimerInterval = setInterval(() => {
+        const sec = Math.floor((Date.now() - deployStartTime) / 1000);
+        heroTimer.innerText = `(${sec}s)`;
+      }, 1000);
+    }
+  }
+
+
+  try {
+    currentExecController = new AbortController();
+    const response = await fetch("/api/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ command: command }),
+      signal: currentExecController.signal
+    });
+
+    if (!response.ok) {
+      appendTerminalLine(`❌ Server error: HTTP ${response.status}`, "err");
+      if (btnCancel) btnCancel.style.display = "none";
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder("utf-8");
+
+    let buffer = "";
+    let adcStreamBuffer = "";
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (value) {
+        buffer += decoder.decode(value, { stream: true });
+        const events = buffer.split("\n\n");
+        buffer = events.pop(); // Keep incomplete event
+
+        for (const evt of events) {
+          if (!evt.trim()) continue;
+          const lines = evt.split("\n");
+          let eventType = "output";
+          let dataStr = "";
+
+          for (const line of lines) {
+            if (line.startsWith("event: ")) eventType = line.substring(7).trim();
+            if (line.startsWith("data: ")) dataStr = line.substring(6).trim();
+          }
+
+          if (dataStr) {
+            try {
+              const payload = JSON.parse(dataStr);
+              if ((eventType === "output" || eventType === "log" || eventType === "message") && (payload.line !== undefined || payload.text !== undefined || payload.data !== undefined)) {
+                const textLine = payload.line !== undefined ? payload.line : (payload.text !== undefined ? payload.text : payload.data);
+                appendTerminalLine(textLine, "out");
+
+                if (execPill) {
+                  const L = String(textLine);
+                  const step = L.match(/Step (\d)\/9/);
+                  if (step) setExecPhase(`step ${step[1]}/9`);
+                  else if (/apt-get|Installing |Reading package lists|Unpacking |Setting up /.test(L)) setExecPhase("installing packages");
+                  else if (/Cloning into|Receiving objects|Resolving deltas/.test(L)) setExecPhase("cloning sources");
+                  else if (/colcon build|Starting >>>|Finished <<</.test(L)) setExecPhase("building agent workspace");
+                  else if (/Compiling |Archiving |Indexing |Building \.pio/.test(L)) setExecPhase("compiling firmware");
+                  else if (/Linking \.pio|Retrieving maximum program size|Checking size/.test(L)) setExecPhase("linking");
+                  else if (/esptool|Writing at |Wrote \d+ bytes|Hash of data verified|Uploading \.pio|Hard resetting|picotool/.test(L)) setExecPhase("flashing MCU");
+                  else if (/Scanning I2C bus|Identified Hardware Matrix|Device ACK received/.test(L)) setExecPhase("scanning I2C bus");
+                  else if (/\[I2C_JSON\]/.test(L)) setExecPhase("sensors detected");
+                  else if (/micro_ros_agent|session established|Waiting for session handshake/.test(L)) setExecPhase("starting micro-ROS agent");
+                  else if (/Active ROS 2 Topics|ros2 topic list/.test(L)) setExecPhase("discovering ROS 2 topics");
+                  else if (/Test Linearity|Generating LUT|ADC_LUT/.test(L)) setExecPhase("calibrating ADC");
+                }
+
+                // Parse deployment phase for Hero Badge
+                if (heroStatusText && title.includes("Full Deploy")) {
+                  if (textLine.includes("Step 1")) heroStatusText.innerText = "1/9: Checking Tools";
+                  else if (textLine.includes("Step 2")) heroStatusText.innerText = "2/9: Verifying ROS 2";
+                  else if (textLine.includes("Step 4")) heroStatusText.innerText = "4/9: Ingesting C++ Header";
+                  else if (textLine.includes("Step 6")) heroStatusText.innerText = "6/9: Ingesting URDF";
+                  else if (textLine.includes("Step 8") || textLine.includes("Compiling")) heroStatusText.innerText = "8/9: Compiling Firmware (Please Wait...)";
+                  else if (textLine.includes("Uploading firmware") || textLine.includes("Writing at")) heroStatusText.innerText = "8/9: Flashing Microcontroller...";
+                  else if (textLine.includes("Step 9") || textLine.includes("Starting micro-ROS agent")) heroStatusText.innerText = "9/9: Launching Agent & Topics...";
+                  else if (textLine.includes("Deployment SUCCEEDED") || textLine.includes("ACTIVE TOPICS")) {
+                    heroBadge.className = "deploy-hero-badge succeeded";
+                    heroStatusText.innerText = "✅ Deployed (@ 50Hz)";
+                    if (deployTimerInterval) clearInterval(deployTimerInterval);
+                  }
+                }
+
+
+                // Live ADC Calibration Stream Parser
+                if (payload.line.includes("Test Linearity") || payload.line.includes("Generating LUT") || payload.line.includes("ADC_LUT")) {
+                  const statusText = document.getElementById("adc-status-text");
+                  if (statusText) {
+                    statusText.innerText = payload.line.trim();
+                    statusText.style.color = "#38bdf8";
+                  }
+                }
+
+                
+                // Live I2C Sensor Detection JSON Parser
+                if (textLine.includes("[I2C_JSON]")) {
+                  try {
+                    const jsonStr = textLine.substring(textLine.indexOf("[I2C_JSON]") + 10).trim();
+                    const i2cData = JSON.parse(jsonStr);
+                    if (i2cData.status === "ok") {
+                      handleI2cAutoDetectedSensors(i2cData);
+                    }
+                  } catch (err) {
+                    console.error("Failed to parse I2C_JSON:", err);
+                  }
+                }
+
+                adcStreamBuffer += payload.line + "\n";
+                if (adcStreamBuffer.includes("ADC_LUT[4096]") && adcStreamBuffer.split("ADC_LUT[4096]").pop().includes("};")) {
+                  try {
+                    // Anchor on the LUT declaration so earlier build-log braces /
+                    // numbers can't leak into the parsed array.
+                    const tail = adcStreamBuffer.substring(adcStreamBuffer.indexOf("ADC_LUT[4096]"));
+                    const startIdx = tail.indexOf("{");
+                    const endIdx = tail.indexOf("};");
+                    if (startIdx !== -1 && endIdx > startIdx) {
+                      const inner = tail.substring(startIdx + 1, endIdx);
+                      const parsedPoints = inner.split(/[\s,]+/).map(s => parseInt(s.trim(), 10)).filter(n => !isNaN(n));
+                      if (parsedPoints.length >= 4000) {
+                        currentAdcLut = parsedPoints.slice(0, 4096);
+                        while (currentAdcLut.length < 4096) currentAdcLut.push(4095);
+                        renderAdcChart(currentRawAdcCurve || currentAdcLut, currentAdcLut, null);
+                        const codeDisplay = document.getElementById("adc-lut-code-display");
+                        if (codeDisplay) codeDisplay.innerText = formatAdcLutArray(currentAdcLut);
+                        const btnMerge = document.getElementById("btn-adc-merge-lut");
+                        if (btnMerge) btnMerge.disabled = false;
+                        const statusText = document.getElementById("adc-status-text");
+                        if (statusText) {
+                          statusText.innerText = "🎉 Hardware ADC Calibration Complete! 4096 points captured.";
+                          statusText.style.color = "var(--success)";
+                        }
+                        showToast("🎉 Hardware ADC Calibration Complete! LUT captured.");
+                      }
+                    }
+                  } catch (e) {
+                    console.error("ADC parse error:", e);
+                  }
+                }
+              } else if (eventType === "done") {
+                const exitCode = payload.code !== undefined ? payload.code : (payload.exit_code !== undefined ? payload.exit_code : 0);
+                if (execPill) {
+                  if (execTimerInterval) { clearInterval(execTimerInterval); execTimerInterval = null; }
+                  if (execText) execText.textContent = exitCode === 0 ? `${execTitle} · done ✓` : `${execTitle} · exit ${exitCode} ✗`;
+                  execPill.className = exitCode === 0 ? "runner-status-pill pill-online" : "runner-status-pill pill-offline";
+                  setTimeout(() => { execPill.style.display = "none"; execPill.className = "runner-status-pill pill-checking"; }, 2500);
+                }
+                if (exitCode === 0) {
+                  appendTerminalLine(`\n✅ [SUCCESS] Command finished with exit code 0!`, "out");
+                  showToast("✅ Command executed successfully!");
+                } else {
+                  appendTerminalLine(`\n❌ [FAILED] Command exited with code ${exitCode}`, "err");
+                  showToast(`⚠️ Command exited with code ${exitCode}`);
+                }
+              } else if (eventType === "error") {
+                appendTerminalLine(`❌ [ERROR] ${payload.error}`, "err");
+              }
+            } catch (e) {
+              appendTerminalLine(dataStr, "out");
+            }
+          }
+        }
+      }
+    }
+  } catch (err) {
+    if (err.name === "AbortError") {
+      appendTerminalLine(`\n⏹️ Process aborted by user.`, "dim");
+      showToast("⏹️ Process stopped.");
+    } else {
+      appendTerminalLine(`\n❌ Execution failed: ${err.message}`, "err");
+    }
+  } finally {
+    if (btnCancel) btnCancel.style.display = "none";
+    if (typeof execTimerInterval !== "undefined" && execTimerInterval) clearInterval(execTimerInterval);
+    const _ep = document.getElementById("exec-progress-pill");
+    if (_ep && _ep.className.indexOf("pill-online") === -1 && _ep.className.indexOf("pill-offline") === -1) {
+      _ep.style.display = "none";
+    }
+    currentExecController = null;
+  }
+}
+
+// Abort running process via POST /api/kill
+async function cancelRunningExecution() {
+  if (currentExecController) {
+    currentExecController.abort();
+  }
+  try {
+    await fetch("/api/kill", { method: "POST" });
+  } catch (e) {}
+}
+
+// Formats 4096-entry ADC LUT into clean C++ header syntax (16 items per row)
+function formatAdcLutArray(lutData) {
+  if (typeof lutData === "string") return lutData;
+  if (!Array.isArray(lutData) || lutData.length === 0) {
+    return `const int16_t ADC_LUT[4096] = { /* insert adc_calibrate data here */ };`;
+  }
+  const rows = [];
+  for (let i = 0; i < lutData.length; i += 16) {
+    const slice = lutData.slice(i, i + 16);
+    rows.push("    " + slice.map(n => Math.round(n)).join(", ") + (i + 16 < lutData.length ? "," : ""));
+  }
+  return `const int16_t ADC_LUT[4096] = {\n${rows.join("\n")}\n};`;
+}
+
+// ==============================================================================
+// 🔋 ESP32 ADC Calibration Studio & LUT Linearizer
+// ==============================================================================
+let currentAdcLut = null;
+let currentRawAdcCurve = null;
+
+function initAdcCalibrationStudio() {
+  const canvas = document.getElementById("adc-chart-canvas");
+  const tooltip = document.getElementById("adc-chart-tooltip");
+  const btnRun = document.getElementById("btn-adc-run-cal");
+  const btnSim = document.getElementById("btn-adc-sim-cal");
+  const btnMerge = document.getElementById("btn-adc-merge-lut");
+  const btnCopy = document.getElementById("btn-copy-lut-code");
+
+  if (!canvas) return;
+
+  // Initialize with Theoretical / Empirical ESP32 Model
+  generateAdcModelLut(false);
+
+  if (btnSim) {
+    btnSim.addEventListener("click", () => {
+      generateAdcModelLut(true);
+    });
+  }
+
+  if (btnRun) {
+    btnRun.addEventListener("click", () => {
+      runHardwareAdcCalibration();
+    });
+  }
+
+  if (btnMerge) {
+    btnMerge.addEventListener("click", () => {
+      mergeAdcLutIntoConfig();
+    });
+  }
+
+  if (btnCopy) {
+    btnCopy.addEventListener("click", () => {
+      if (currentAdcLut) {
+        const code = formatAdcLutArray(currentAdcLut);
+        navigator.clipboard.writeText(code).then(() => {
+          showToast("📋 ADC_LUT[4096] array copied to clipboard!");
+        });
+      } else {
+        showToast("⚠️ No LUT table generated yet.");
+      }
+    });
+  }
+
+  // Interactive Hover / Tooltip on Canvas
+  canvas.addEventListener("mousemove", (e) => {
+    if (!currentRawAdcCurve || !currentAdcLut) return;
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const paddingLeft = 45;
+    const paddingRight = 15;
+    const chartWidth = rect.width - paddingLeft - paddingRight;
+
+    if (x >= paddingLeft && x <= paddingLeft + chartWidth) {
+      const ratio = (x - paddingLeft) / chartWidth;
+      const index = Math.min(4095, Math.max(0, Math.round(ratio * 4095)));
+      renderAdcChart(currentRawAdcCurve, currentAdcLut, index);
+
+      if (tooltip) {
+        const rawVal = currentRawAdcCurve[index];
+        const lutVal = currentAdcLut[index];
+        const vInput = (index * 3.3 / 4095).toFixed(3);
+        const vRaw = (rawVal * 3.3 / 4095).toFixed(3);
+        const vCal = (lutVal * 3.3 / 4095).toFixed(3);
+        const delta = lutVal - rawVal;
+
+        tooltip.style.display = "block";
+        tooltip.style.left = `${Math.min(rect.width - 180, Math.max(10, x - 70))}px`;
+        tooltip.style.top = `15px`;
+        tooltip.innerHTML = `
+          <div><strong>Input: ${index}</strong> (${vInput}V)</div>
+          <div style="color:#f43f5e;">Raw ADC: ${Math.round(rawVal)} (${vRaw}V)</div>
+          <div style="color:#10b981;">Linearized: ${Math.round(lutVal)} (${vCal}V)</div>
+          <div style="color:#a5b4fc;">Offset Δ: ${delta >= 0 ? "+" : ""}${Math.round(delta)} counts</div>
+        `;
+      }
+    } else {
+      if (tooltip) tooltip.style.display = "none";
+      renderAdcChart(currentRawAdcCurve, currentAdcLut, null);
+    }
+  });
+
+  canvas.addEventListener("mouseleave", () => {
+    if (tooltip) tooltip.style.display = "none";
+    if (currentRawAdcCurve && currentAdcLut) {
+      renderAdcChart(currentRawAdcCurve, currentAdcLut, null);
+    }
+  });
+
+  // Handle responsive window resize for canvas
+  window.addEventListener("resize", () => {
+    if (currentRawAdcCurve && currentAdcLut) {
+      renderAdcChart(currentRawAdcCurve, currentAdcLut, null);
+    }
+  });
+}
+
+// Generate Mathematical / Empirical ESP32 ADC Transfer Function & Inverted LUT
+function generateAdcModelLut(showToastMsg = true) {
+  const rawCurve = new Float32Array(4096);
+  const lut = new Int16Array(4096);
+
+  // ESP32 Non-linear ADC Simulation:
+  // 1. Deadband near 0V: 0 to ~140mV outputs 0
+  // 2. Non-linear knee at low voltage (140mV - 500mV)
+  // 3. Linear response from 500mV to ~2900mV
+  // 4. Saturation compression from 2900mV to 3300mV (maxes out around 3.15V)
+  for (let i = 0; i < 4096; i++) {
+    const v = i * (3.3 / 4095.0); // True Input Voltage (0 to 3.3V)
+    let rawAdc = 0;
+
+    if (v < 0.14) {
+      rawAdc = 0;
+    } else if (v < 0.50) {
+      const t = (v - 0.14) / (0.50 - 0.14);
+      rawAdc = 620 * (t * t * 0.7 + t * 0.3);
+    } else if (v <= 2.90) {
+      const t = (v - 0.50) / (2.90 - 0.50);
+      rawAdc = 620 + t * (3780 - 620);
+    } else {
+      const t = Math.min(1.0, (v - 2.90) / (3.15 - 2.90));
+      rawAdc = 3780 + Math.sin(t * Math.PI / 2) * (4095 - 3780);
+    }
+    rawCurve[i] = Math.min(4095, Math.max(0, rawAdc));
+  }
+
+  // Generate Inverted Lookup Table (LUT) to Linearize ADC readings:
+  // For each ADC reading y (0..4095), find input x such that rawCurve[x] == y
+  for (let adc = 0; adc < 4096; adc++) {
+    if (adc <= 0) {
+      lut[0] = 0;
+      continue;
+    }
+    if (adc >= 4095) {
+      lut[4095] = 4095;
+      continue;
+    }
+    let low = 0;
+    let high = 4095;
+    while (low < high) {
+      const mid = (low + high) >> 1;
+      if (rawCurve[mid] < adc) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    let corrected = low;
+    if (low > 0 && low < 4095) {
+      const y0 = rawCurve[low - 1];
+      const y1 = rawCurve[low];
+      if (y1 > y0) {
+        corrected = (low - 1) + (adc - y0) / (y1 - y0);
+      }
+    }
+    lut[adc] = Math.min(4095, Math.max(0, Math.round(corrected)));
+  }
+
+  currentRawAdcCurve = Array.from(rawCurve);
+  currentAdcLut = Array.from(lut);
+
+  // Update UI Elements
+  renderAdcChart(currentRawAdcCurve, currentAdcLut, null);
+
+  const codeDisplay = document.getElementById("adc-lut-code-display");
+  if (codeDisplay) {
+    codeDisplay.innerText = formatAdcLutArray(currentAdcLut);
+  }
+
+  const btnMerge = document.getElementById("btn-adc-merge-lut");
+  if (btnMerge) btnMerge.disabled = false;
+
+  const statusText = document.getElementById("adc-status-text");
+  if (statusText) {
+    statusText.innerText = "Model LUT generated. Ready to merge into robot configuration.";
+    statusText.style.color = "var(--success)";
+  }
+
+  if (showToastMsg) {
+    showToast("🧪 Model ADC LUT generated! Graph and 4096-point table ready.");
+  }
+}
+
+// Interactive High-Performance Canvas Renderer
+function renderAdcChart(rawData, lutData, hoveredIndex = null) {
+  const canvas = document.getElementById("adc-chart-canvas");
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  const dpr = window.devicePixelRatio || 1;
+  const rect = canvas.getBoundingClientRect();
+
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  ctx.scale(dpr, dpr);
+
+  const w = rect.width;
+  const h = rect.height;
+  const padLeft = 45;
+  const padBottom = 30;
+  const padTop = 15;
+  const padRight = 15;
+  const plotW = w - padLeft - padRight;
+  const plotH = h - padTop - padBottom;
+
+  // Clear background
+  ctx.fillStyle = "#090d16";
+  ctx.fillRect(0, 0, w, h);
+
+  // Draw Grid Lines & Axis Labels
+  ctx.lineWidth = 1;
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.07)";
+  ctx.fillStyle = "#64748b";
+  ctx.font = "10px Inter, -apple-system, sans-serif";
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+
+  const numGrid = 4;
+  for (let i = 0; i <= numGrid; i++) {
+    const yVal = (4095 / numGrid) * i;
+    const yPos = padTop + plotH - (i / numGrid) * plotH;
+    const volts = (yVal * 3.3 / 4095).toFixed(1);
+
+    ctx.beginPath();
+    ctx.moveTo(padLeft, yPos);
+    ctx.lineTo(padLeft + plotW, yPos);
+    ctx.stroke();
+
+    ctx.fillText(`${volts}V`, padLeft - 6, yPos);
+  }
+
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  for (let i = 0; i <= numGrid; i++) {
+    const xVal = (4095 / numGrid) * i;
+    const xPos = padLeft + (i / numGrid) * plotW;
+    const volts = (xVal * 3.3 / 4095).toFixed(1);
+
+    ctx.beginPath();
+    ctx.moveTo(xPos, padTop);
+    ctx.lineTo(xPos, padTop + plotH);
+    ctx.stroke();
+
+    ctx.fillText(`${volts}V`, xPos, padTop + plotH + 6);
+  }
+
+  // 1. Plot Ideal Reference Line (Cyan Dashed)
+  ctx.save();
+  ctx.strokeStyle = "rgba(56, 189, 248, 0.4)";
+  ctx.lineWidth = 1.5;
+  ctx.setLineDash([4, 4]);
+  ctx.beginPath();
+  ctx.moveTo(padLeft, padTop + plotH);
+  ctx.lineTo(padLeft + plotW, padTop);
+  ctx.stroke();
+  ctx.restore();
+
+  // 2. Plot Raw Non-Linear Curve (Rose/Coral)
+  if (rawData && rawData.length > 0) {
+    ctx.save();
+    ctx.strokeStyle = "#f43f5e";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    const step = Math.max(1, Math.floor(rawData.length / plotW));
+    for (let i = 0; i < rawData.length; i += step) {
+      const xPos = padLeft + (i / 4095) * plotW;
+      const yPos = padTop + plotH - (rawData[i] / 4095) * plotH;
+      if (i === 0) ctx.moveTo(xPos, yPos);
+      else ctx.lineTo(xPos, yPos);
+    }
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // 3. Plot Calibrated Output Curve (Neon Emerald Green)
+  if (lutData && rawData && lutData.length > 0) {
+    ctx.save();
+    ctx.strokeStyle = "#10b981";
+    ctx.lineWidth = 2.5;
+    ctx.beginPath();
+    const step = Math.max(1, Math.floor(lutData.length / plotW));
+    for (let i = 0; i < lutData.length; i += step) {
+      const rawVal = Math.round(rawData[i]);
+      const calVal = (rawVal >= 0 && rawVal < lutData.length) ? lutData[rawVal] : rawVal;
+      const xPos = padLeft + (i / 4095) * plotW;
+      const yPos = padTop + plotH - (calVal / 4095) * plotH;
+      if (i === 0) ctx.moveTo(xPos, yPos);
+      else ctx.lineTo(xPos, yPos);
+    }
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // 4. Draw Crosshair & Indicators on Hover
+  if (hoveredIndex !== null && hoveredIndex >= 0 && hoveredIndex < 4096) {
+    const xPos = padLeft + (hoveredIndex / 4095) * plotW;
+    const rawVal = rawData ? rawData[hoveredIndex] : hoveredIndex;
+    const rawYPos = padTop + plotH - (rawVal / 4095) * plotH;
+    const calVal = (lutData && Math.round(rawVal) < lutData.length) ? lutData[Math.round(rawVal)] : hoveredIndex;
+    const calYPos = padTop + plotH - (calVal / 4095) * plotH;
+
+    // Vertical Crosshair
+    ctx.strokeStyle = "rgba(165, 180, 252, 0.5)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(xPos, padTop);
+    ctx.lineTo(xPos, padTop + plotH);
+    ctx.stroke();
+
+    // Raw Point Dot
+    ctx.fillStyle = "#f43f5e";
+    ctx.beginPath();
+    ctx.arc(xPos, rawYPos, 4.5, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Calibrated Point Dot
+    ctx.fillStyle = "#10b981";
+    ctx.beginPath();
+    ctx.arc(xPos, calYPos, 5, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = "#ffffff";
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+  }
+}
+
+// Live Hardware ADC Calibration Runner
+function runHardwareAdcCalibration() {
+  const spec = currentSpec;
+  const port = document.getElementById("auto-flash-port")?.value.trim() || (isESP32(spec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
+  const baud = spec.baudrate || spec.telemetry?.baudrate || ((spec.mcu || "").toUpperCase() === "GENDRV" ? 1500000 : 921600);
+  const uploadCmd = getDirectUploadOrBuildCmd("adc_calibrate", true);
+
+  // adc_calibrate sweeps the DAC, prints `const int16_t ADC_LUT[4096] = {...};`
+  // once (~1-3 min after reset), then idles. The upload command alone never
+  // reads the port back, so append a short serial reader — the parser in
+  // executeCommandInTerminal() picks the LUT block out of the stream. Staged to
+  // a file (quoted heredoc) to sidestep python -c newline/quote escaping.
+  const monScript = [
+    `cat > /tmp/lr_adc_monitor.py << 'EOF_ADC_MON'`,
+    `import serial, sys, time`,
+    `s = serial.Serial('${port}', ${baud}, timeout=2)`,
+    `time.sleep(0.5); t = time.time(); seen = False`,
+    `while time.time() - t < 360:`,
+    `    l = s.readline().decode('utf-8', errors='ignore').rstrip()`,
+    `    if not l: continue`,
+    `    print(l); sys.stdout.flush()`,
+    `    if 'ADC_LUT[4096]' in l: seen = True`,
+    `    if seen and l.strip().endswith('};'): break`,
+    `s.close()`,
+    `EOF_ADC_MON`,
+    `~/.platformio/penv/bin/python /tmp/lr_adc_monitor.py`
+  ].join("\n");
+  const cmd = `${uploadCmd}\necho "--- adc_calibrate flashed; capturing LUT over serial (${port} @ ${baud} baud, up to 6 min) ---"\n${monScript}`;
+
+  const statusText = document.getElementById("adc-status-text");
+  if (statusText) {
+    statusText.innerText = `Compiling & Uploading adc_calibrate to ${port}...`;
+    statusText.style.color = "#38bdf8";
+  }
+
+  executeCommandInTerminal(cmd, `⚡ Uploading & Running ADC Calibration (${port})`);
+}
+
+// Merge Generated ADC LUT Table into Robot Configuration
+function mergeAdcLutIntoConfig() {
+  if (!currentAdcLut || currentAdcLut.length === 0) {
+    showToast("⚠️ No LUT table generated to merge.");
+    return;
+  }
+
+  currentSpec.adc_lut = Array.from(currentAdcLut);
+  if (!currentSpec.sensors) currentSpec.sensors = {};
+  currentSpec.sensors.battery_monitor = "ADC_DIVIDER";
+  currentSpec.sensors.adc_lut = Array.from(currentAdcLut);
+
+  // Re-generate C++ Headers and update previews
+  updateAutomationPreviews();
+  renderActiveCode();
+
+  const name = currentSpec.robot_name || "robot";
+  showToast(`✅ ADC LUT successfully merged into '${name}_config.h'!`);
+
+  const statusText = document.getElementById("adc-status-text");
+  if (statusText) {
+    statusText.innerText = `✅ ADC_LUT successfully merged into config/custom/${name}_config.h`;
+    statusText.style.color = "var(--success)";
+  }
+}
+
+
+
+// Global Existing Config Base State
+let baseConfigSpec = null;
+let existingConfigsList = [];
+
+// Fetch available existing configs from server
+async function loadExistingConfigsList() {
+  const sel = document.getElementById('existing-config-select');
+  if (!sel) return;
+  try {
+    const res = await fetch('/api/configs');
+    if (!res.ok) return;
+    const data = await res.json();
+    existingConfigsList = data.configs || [];
+    sel.innerHTML = '<option value="">Select Existing Config...</option>';
+    existingConfigsList.forEach(c => {
+      const opt = document.createElement('option');
+      opt.value = c.filename;
+      opt.innerText = `${c.filename} (${c.mcu} | ${c.kinematics})`;
+      sel.appendChild(opt);
+    });
+  } catch (e) {
+    console.log('Configs API not available:', e);
+  }
+}
+
+// Load selected existing configuration into form for modification
+async function loadExistingConfig(filename) {
+  if (!filename) return;
+  const cfg = existingConfigsList.find(c => c.filename === filename);
+  if (!cfg) return;
+  try {
+    const res = await fetch('/api/parse', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: cfg.content, is_json: false })
+    });
+    const data = await res.json();
+    if (data.status === 'ok' && data.spec) {
+      baseConfigSpec = JSON.parse(JSON.stringify(data.spec));
+      currentSpec = data.spec;
+      populateFormFromSpec(currentSpec);
+      recomputeAll();
+      showToast(`📂 Loaded '${filename}'! You can now modify and merge settings.`);
+    }
+  } catch (e) {
+    showToast(`⚠️ Failed to parse ${filename}: ` + e.message);
+  }
+}
+
+// Merge modified UI form settings into base configuration
+async function mergeCurrentConfig() {
+  readFormIntoSpec();
+  try {
+    const res = await fetch('/api/merge', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        base_spec: baseConfigSpec || currentSpec,
+        override_spec: currentSpec
+      })
+    });
+    const data = await res.json();
+    if (data.status === 'ok') {
+      currentSpec = data.merged_spec;
+      const count = data.changes ? data.changes.length : 0;
+      updateAutomationPreviews();
+      renderActiveCode();
+      showToast(`🔄 Merged ${count} updated setting(s) successfully!`);
+    }
+  } catch (e) {
+    showToast('⚠️ Merge error: ' + e.message);
+  }
+}
+
+// Save merged configuration directly to config/custom/
+async function saveConfigToFirmware() {
+  readFormIntoSpec();
+  const name = currentSpec.robot_name || 'robot';
+  const filename = `${name}_config.h`;
+  const headerCode = generateCppConfigHeader(currentSpec);
+  try {
+    const res = await fetch('/api/save', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        filename: filename,
+        header: headerCode,
+        wifi_config: generateWifiConfig(currentSpec),
+        spec: currentSpec
+      })
+    });
+    const data = await res.json();
+    if (data.status === 'saved') {
+      showToast(`💾 Saved to config/custom/${filename}!` +
+        (data.wifi_config_written ? ` WiFi keys → git-ignored wifi_config.h.` : ``));
+    }
+  } catch (e) {
+    showToast('⚠️ Save error: ' + e.message);
+  }
+}
+
+
+  // Existing Config & Merge Handlers
+  loadExistingConfigsList();
+  initSyslogControls();
+  const btnLoadCfg = document.getElementById("btn-load-config");
+  if (btnLoadCfg) {
+    btnLoadCfg.addEventListener("click", () => {
+      const sel = document.getElementById("existing-config-select");
+      if (sel && sel.value) loadExistingConfig(sel.value);
+      else showToast("Select an existing config first");
+    });
+  }
+  const btnMergeCfg = document.getElementById("btn-merge-config");
+  if (btnMergeCfg) btnMergeCfg.addEventListener("click", mergeCurrentConfig);
+  const btnSaveCfg = document.getElementById("btn-save-config");
+  if (btnSaveCfg) btnSaveCfg.addEventListener("click", saveConfigToFirmware);
+
+
+// =============================================================================
+// Live ROS 2 Topic Streamer, Hz Table & Inspector
+// =============================================================================
+let activeRos2EventSource = null;
+let activeRos2StreamMode = null; // 'echo' or 'hz'
+let selectedRos2Topic = "/odom/unfiltered";
+
+async function fetchRos2Topics() {
+  try {
+    const res = await fetch("/api/ros2/topics");
+    if (!res.ok) return;
+    const data = await res.json();
+    if (data.status === "ok" && Array.isArray(data.topics) && data.topics.length > 0) {
+      renderRos2TopicTable(data.topics);
+      updateRos2Dropdown(data.topics);
+      const graphStatus = document.getElementById("ros2-graph-status");
+      if (graphStatus) {
+        graphStatus.textContent = `● ${data.topics.length} Topics Active`;
+        graphStatus.className = "badge-pill badge-ok";
+      }
+    }
+  } catch (err) {
+    console.warn("fetchRos2Topics error:", err);
+  }
+}
+
+function updateRos2Dropdown(topics) {
+  const select = document.getElementById("ros2-topic-select");
+  if (!select) return;
+  const cur = select.value;
+  select.innerHTML = "";
+  topics.forEach(t => {
+    const opt = document.createElement("option");
+    opt.value = t.topic;
+    opt.textContent = `${t.topic} (${t.type.split("/").pop()})`;
+    select.appendChild(opt);
+  });
+  if (topics.some(t => t.topic === selectedRos2Topic)) {
+    select.value = selectedRos2Topic;
+  } else if (topics.some(t => t.topic === cur)) {
+    select.value = cur;
+  }
+}
+
+function renderRos2TopicTable(topics) {
+  const tbody = document.getElementById("ros2-topic-table-body");
+  if (!tbody) return;
+  tbody.innerHTML = "";
+
+  topics.forEach(t => {
+    const isSelected = (t.topic === selectedRos2Topic);
+    const tr = document.createElement("tr");
+    tr.className = "topic-row" + (isSelected ? " active" : "");
+    tr.setAttribute("data-topic", t.topic);
+
+    let icon = "📡";
+    if (t.topic.includes("odom")) icon = "🏎️";
+    else if (t.topic.includes("imu")) icon = "🧭";
+    else if (t.topic.includes("bat")) icon = "🔋";
+    else if (t.topic.includes("cmd")) icon = "🎮";
+
+    let hzClass = "topic-hz-badge";
+    if (t.hz.includes("1.0") || t.hz.includes("Event")) hzClass += " hz-low";
+    if (t.hz.includes("Sub")) hzClass += " hz-sub";
+
+    tr.innerHTML = `
+      <td style="text-align: center;"><input type="radio" name="topic-select-radio" value="${t.topic}" ${isSelected ? "checked" : ""}></td>
+      <td><span class="topic-table-name font-mono">${icon} ${t.topic}</span></td>
+      <td><span class="topic-table-type font-mono text-muted">${t.type}</span></td>
+      <td style="text-align: center;"><span class="${hzClass}" id="hz-cell-${t.topic.replace(/[^a-zA-Z0-9]/g, '_')}">${t.hz}</span></td>
+      <td style="text-align: center;"><span class="badge-pill ${t.status === 'active' ? 'badge-ok' : 'badge-info'}">${t.status === 'active' ? 'Active' : 'Sub'}</span></td>
+      <td style="text-align: right;">
+        <button type="button" class="btn btn-xs btn-accent btn-table-stream" data-topic="${t.topic}">▶️ Stream</button>
+        ${t.status === 'active' ? `<button type="button" class="btn btn-xs btn-ghost btn-table-hz" data-topic="${t.topic}">⚡ Hz</button>` : ''}
+      </td>
+    `;
+
+    // Row Click selects topic & starts live display
+    tr.addEventListener("click", (e) => {
+      if (e.target.tagName === "BUTTON") return;
+      selectTopicAndDisplay(t.topic);
+    });
+
+    const btnStream = tr.querySelector(".btn-table-stream");
+    if (btnStream) {
+      btnStream.addEventListener("click", (e) => {
+        e.stopPropagation();
+        selectTopicAndDisplay(t.topic, "echo");
+      });
+    }
+
+    const btnHz = tr.querySelector(".btn-table-hz");
+    if (btnHz) {
+      btnHz.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        selectTopicAndDisplay(t.topic, "hz");
+      });
+    }
+
+    tbody.appendChild(tr);
+  });
+}
+
+function selectTopicAndDisplay(topic, mode = "echo") {
+  selectedRos2Topic = topic;
+
+  // Update table selection state
+  document.querySelectorAll("#ros2-topic-table tbody tr").forEach(r => {
+    if (r.getAttribute("data-topic") === topic) {
+      r.classList.add("active");
+      const rad = r.querySelector("input[type='radio']");
+      if (rad) rad.checked = true;
+    } else {
+      r.classList.remove("active");
+    }
+  });
+
+  // Update dropdown
+  const select = document.getElementById("ros2-topic-select");
+  if (select && select.value !== topic) {
+    select.value = topic;
+  }
+
+  // Update HUD
+  const hudTopic = document.getElementById("hud-topic-name");
+  if (hudTopic) hudTopic.textContent = topic;
+
+  startRos2Stream(topic, mode);
+}
+
+async function measureAllTopicHz() {
+  const tbody = document.getElementById("ros2-topic-table-body");
+  if (!tbody) return;
+  const rows = tbody.querySelectorAll("tr.topic-row");
+  for (const row of rows) {
+    const topic = row.getAttribute("data-topic");
+    if (!topic || topic.includes("cmd_vel")) continue;
+    const badge = row.querySelector(".topic-hz-badge");
+    if (badge) {
+      badge.textContent = "Measuring...";
+      badge.style.opacity = "0.6";
+    }
+    try {
+      const res = await fetch(`/api/ros2/hz_single?topic=${encodeURIComponent(topic)}`);
+      const data = await res.json();
+      if (data.status === "ok" && data.hz && badge) {
+        badge.textContent = data.hz;
+        badge.style.opacity = "1.0";
+      }
+    } catch (e) {
+      if (badge) badge.style.opacity = "1.0";
+    }
+  }
+}
+
+function stopRos2Stream() {
+  if (activeRos2EventSource) {
+    activeRos2EventSource.close();
+    activeRos2EventSource = null;
+  }
+  activeRos2StreamMode = null;
+  const echoBtn = document.getElementById("btn-ros2-echo");
+  if (echoBtn) {
+    const icon = document.getElementById("ros2-echo-icon");
+    const text = document.getElementById("ros2-echo-text");
+    if (icon) icon.textContent = "📡";
+    if (text) text.textContent = "Stream Topic";
+    echoBtn.className = "btn btn-sm btn-accent";
+  }
+  const cancelBtn = document.getElementById("btn-cancel-exec");
+  if (cancelBtn) cancelBtn.style.display = "none";
+}
+
+function startRos2Stream(topic, mode = "echo") {
+  stopRos2Stream();
+
+  const screen = document.getElementById("serial-terminal-screen");
+  if (screen) {
+    screen.innerHTML = `<div class="terminal-line terminal-info">📡 Connecting to live ROS 2 topic stream: <strong>${topic}</strong> (mode: ${mode})...</div>`;
+  }
+
+  const hudTopic = document.getElementById("hud-topic-name");
+  if (hudTopic) hudTopic.textContent = topic;
+
+  const echoBtn = document.getElementById("btn-ros2-echo");
+  if (echoBtn) {
+    const icon = document.getElementById("ros2-echo-icon");
+    const text = document.getElementById("ros2-echo-text");
+    if (icon) icon.textContent = "⏹️";
+    if (text) text.textContent = "Stop Stream";
+    echoBtn.className = "btn btn-sm btn-danger";
+  }
+  const cancelBtn = document.getElementById("btn-cancel-exec");
+  if (cancelBtn) {
+    cancelBtn.style.display = "inline-flex";
+    cancelBtn.onclick = stopRos2Stream;
+  }
+
+  activeRos2StreamMode = mode;
+  const url = `/api/ros2/stream?topic=${encodeURIComponent(topic)}&mode=${encodeURIComponent(mode)}`;
+  activeRos2EventSource = new EventSource(url);
+
+  activeRos2EventSource.onmessage = function(e) {
+    try {
+      const data = JSON.parse(e.data);
+      if (data.type === "line" || data.type === "start") {
+        const text = data.text;
+        appendTerminalLine(text);
+
+        // Parse metrics for Live HUD
+        if (text.includes("average rate:")) {
+          const m = text.match(/average rate:\s*([0-9.]+)/);
+          if (m) {
+            const hzVal = document.getElementById("hud-topic-hz");
+            if (hzVal) hzVal.textContent = `${parseFloat(m[1]).toFixed(1)} Hz`;
+            const cellBadge = document.getElementById(`hz-cell-${topic.replace(/[^a-zA-Z0-9]/g, '_')}`);
+            if (cellBadge) cellBadge.textContent = `${parseFloat(m[1]).toFixed(1)} Hz`;
+          }
+        }
+        if (text.includes("linear:") || text.includes("x:")) {
+          const m = text.match(/x:\s*([0-9.-]+)/);
+          if (m && Math.abs(parseFloat(m[1])) > 0.0001) {
+            const v1 = document.getElementById("hud-topic-val1");
+            if (v1) v1.textContent = `${parseFloat(m[1]).toFixed(3)} m/s`;
+          }
+        }
+        if (text.includes("angular:") || text.includes("z:")) {
+          const m = text.match(/z:\s*([0-9.-]+)/);
+          if (m && Math.abs(parseFloat(m[1])) > 0.0001) {
+            const v2 = document.getElementById("hud-topic-val2");
+            if (v2) v2.textContent = `${parseFloat(m[1]).toFixed(3)} rad/s`;
+          }
+        }
+        if (text.includes("voltage:")) {
+          const m = text.match(/voltage:\s*([0-9.]+)/);
+          if (m) {
+            const v1 = document.getElementById("hud-topic-val1");
+            if (v1) v1.textContent = `${parseFloat(m[1]).toFixed(2)} V`;
+          }
+        }
+      } else if (data.type === "error") {
+        appendTerminalLine(`[ERROR] ${data.text}`, "err");
+      }
+    } catch (err) {
+      appendTerminalLine(e.data, "dim");
+    }
+  };
+
+  activeRos2EventSource.onerror = function() {
+    appendTerminalLine("[INFO] ROS 2 topic stream ended.", "info");
+    stopRos2Stream();
+  };
+}
+
+function initRos2TopicInspector() {
+  const echoBtn = document.getElementById("btn-ros2-echo");
+  const hzBtn = document.getElementById("btn-ros2-hz");
+  const refreshBtn = document.getElementById("btn-ros2-refresh");
+  const inspRefreshBtn = document.getElementById("btn-ros2-inspector-refresh");
+  const measureAllBtn = document.getElementById("btn-measure-all-hz");
+  const topicSelect = document.getElementById("ros2-topic-select");
+
+  if (echoBtn) {
+    echoBtn.addEventListener("click", () => {
+      if (activeRos2EventSource) {
+        stopRos2Stream();
+      } else {
+        const t = topicSelect ? topicSelect.value : selectedRos2Topic;
+        selectTopicAndDisplay(t, "echo");
+      }
+    });
+  }
+  if (hzBtn) {
+    hzBtn.addEventListener("click", () => {
+      const t = topicSelect ? topicSelect.value : selectedRos2Topic;
+      selectTopicAndDisplay(t, "hz");
+    });
+  }
+  if (refreshBtn) refreshBtn.addEventListener("click", fetchRos2Topics);
+  if (inspRefreshBtn) inspRefreshBtn.addEventListener("click", fetchRos2Topics);
+  if (measureAllBtn) measureAllBtn.addEventListener("click", measureAllTopicHz);
+
+  if (topicSelect) {
+    topicSelect.addEventListener("change", () => {
+      selectTopicAndDisplay(topicSelect.value, activeRos2StreamMode || "echo");
+    });
+  }
+
+  fetchRos2Topics();
+  setInterval(fetchRos2Topics, 10000);
+}
+
+// -----------------------------------------------------------------------------
+// AI I2C Sensor Auto-Detection & Auto-Configuration Handler
+// -----------------------------------------------------------------------------
+function handleI2cAutoDetectedSensors(data) {
+  console.log("Auto-detected I2C Hardware:", data);
+  const _b = document.getElementById("btn-auto-detect-i2c");
+  if (_b) { _b.disabled = false; if (_b.dataset._t) _b.textContent = _b.dataset._t; }
+  const resultsDiv = document.getElementById("i2c-detect-results");
+  let summaryParts = [];
+
+  // 1. Auto-select IMU driver
+  const imuSelect = document.getElementById("cfg-imu");
+  if (imuSelect) {
+    if (data.imu && data.imu !== "NONE") {
+      for (let opt of imuSelect.options) {
+        if (opt.value.toUpperCase().includes(data.imu.toUpperCase())) {
+          imuSelect.value = opt.value;
+          summaryParts.push(`IMU: <strong>${data.imu}</strong>`);
+          break;
+        }
+      }
+    } else {
+      imuSelect.value = "FAKE";
+    }
+    imuSelect.dispatchEvent(new Event("change"));
+  }
+
+  // 2. Auto-select Magnetometer driver
+  const magSelect = document.getElementById("cfg-mag");
+  if (magSelect) {
+    if (data.mag && data.mag !== "NONE") {
+      for (let opt of magSelect.options) {
+        if (opt.value.toUpperCase().includes(data.mag.toUpperCase())) {
+          magSelect.value = opt.value;
+          summaryParts.push(`MAG: <strong>${data.mag}</strong>`);
+          break;
+        }
+      }
+    } else {
+      magSelect.value = "NONE";
+    }
+    magSelect.dispatchEvent(new Event("change"));
+  }
+
+  // 3. Auto-configure Current / Power Monitor
+  const batSelect = document.getElementById("cfg-battery");
+  if (batSelect) {
+    if (data.current && data.current.includes("INA219")) {
+      batSelect.value = "INA219";
+      summaryParts.push(`Power: <strong>INA219</strong>`);
+    }
+    batSelect.dispatchEvent(new Event("change"));
+  }
+
+  // Update UI results box
+  if (resultsDiv) {
+    resultsDiv.style.display = "block";
+    if (summaryParts.length > 0) {
+      resultsDiv.innerHTML = `✅ <span style="color:#34d399;">Auto-Configured Drivers:</span> ${summaryParts.join(" | ")} <span class="badge-pill badge-ok ml-2">Drivers Applied</span>`;
+    } else {
+      resultsDiv.innerHTML = `ℹ️ <span style="color:#94a3b8;">No physical I2C chips detected. Configured to Bare Module mode (Fake IMU/MAG).</span>`;
+    }
+  }
+
+  // Regenerate configuration headers & code
+  if (typeof updateGeneratedCode === "function") {
+    updateGeneratedCode();
+  }
+
+  const toastMsg = summaryParts.length > 0
+    ? `🎉 Auto-Detected: ${summaryParts.join(", ")}! Drivers configured.`
+    : `ℹ️ Bus scanned: No I2C chips detected (Bare Module Mode preserved).`;
+  showToast(toastMsg);
+}
+
+function runI2cSensorAutoDetect() {
+  const mcu = (document.getElementById("cfg-mcu")?.value || "GENDRV").toUpperCase();
+  // tools/i2c_detect/platformio.ini envs: gendrv, esp32, esp32s3, pico, pico2
+  // tools/i2c_detect always runs at 921600 (its own BAUDRATE default / [env]
+  // monitor_speed) — NOT the 1.5 Mbaud the GenDrv micro-ROS firmware uses.
+  let envName = "esp32", baud = 921600;
+  if (mcu.includes("GENDRV")) { envName = "gendrv"; }
+  else if (mcu.includes("PICO2")) envName = "pico2";
+  else if (mcu.includes("PICO"))  envName = "pico";
+  else if (mcu.includes("S3"))    envName = "esp32s3";
+  else if (mcu.includes("S2"))    envName = "esp32";   // no s2 env; override pins carry it
+  const distro = mcu.includes("GENDRV") ? "gendrv" : envName;
+
+  const portSelect = document.getElementById("auto-flash-port");
+  const port = (portSelect && portSelect.value) ? portSelect.value.trim()
+             : (envName === "gendrv" || envName === "esp32" || envName === "esp32s3" ? "/dev/ttyUSB0" : "/dev/ttyACM0");
+  const uploadFlag = (port && !port.includes("BOOTSEL")) ? ` --upload-port ${port}` : "";
+
+  // Scan the pins currently set in the Pinout matrix (not whatever the tracked
+  // board header happens to define). Passed as build flags the tools/i2c_detect
+  // firmware honours ahead of BOARD_INIT.
+  const sda = parseInt(document.getElementById("pin-i2c-sda")?.value, 10);
+  const scl = parseInt(document.getElementById("pin-i2c-scl")?.value, 10);
+  const havePins = Number.isInteger(sda) && Number.isInteger(scl) && sda >= 0 && scl >= 0;
+  const pfx = havePins ? `PLATFORMIO_BUILD_FLAGS="-D I2C_SDA_OVERRIDE=${sda} -D I2C_SCL_OVERRIDE=${scl}" ` : "";
+  const pinNote = havePins ? ` on SDA ${sda} / SCL ${scl}` : "";
+
+  // i2c_detect resets on port open, then boots (~1.5 s) and prints the scan +
+  // the [I2C_JSON] line, repeating every 5 s. Read up to 20 s, stop at the
+  // first JSON (or the "no devices" line).
+  const monitorPy = "import serial, sys, time; s = serial.Serial('" + port + "', " + baud + ", timeout=2); t = time.time();\nwhile time.time() - t < 20:\n  l = s.readline().decode('utf-8', errors='ignore').strip()\n  if not l: continue\n  print(l); sys.stdout.flush()\n  if '[I2C_JSON]' in l or 'No I2C devices detected' in l: break\ns.close()";
+  const rd = document.getElementById("i2c-detect-results");
+  if (rd) rd.innerHTML = `<span style="color:#38bdf8;">⏳ Building & flashing tools/i2c_detect${pinNote}, then scanning the bus… (first build ~30–90 s)</span>`;
+  const btn = document.getElementById("btn-auto-detect-i2c");
+  if (btn) { btn.disabled = true; btn.dataset._t = btn.textContent; btn.textContent = "⏳ Scanning…"; setTimeout(() => { btn.disabled = false; if (btn.dataset._t) btn.textContent = btn.dataset._t; }, 150000); }
+  const rwFix = `for _d in /dev/ttyUSB* /dev/ttyACM*; do [ -e "$_d" ] && [ ! -w "$_d" ] && sudo chmod a+rw "$_d" 2>/dev/null || true; done`;
+  const cmd = `${rwFix} && cd tools/i2c_detect && ${pfx}pio run -e ${envName} -t upload${uploadFlag} && ~/.platformio/penv/bin/python -c "${monitorPy}"`;
+  executeCommandInTerminal(cmd, `🔍 AI Auto-Detecting I2C Sensors (${envName}${pinNote} -> ${port})`);
+}
+
+
+// =============================================================================
+// 📡 Live UDP Syslog Server & Streamer Management
+// =============================================================================
+let activeSyslogEventSource = null;
+let isSyslogRunning = false;
+
+async function checkSyslogStatus() {
+  try {
+    const res = await fetch('/api/syslog/status');
+    if (!res.ok) return;
+    const data = await res.json();
+    updateSyslogUIState(data);
+    if (data.running && !activeSyslogEventSource) {
+      connectSyslogStream();
+    }
+  } catch (e) {
+    // server might be offline or reloading
+  }
+}
+
+function updateSyslogUIState(data) {
+  isSyslogRunning = !!data.running;
+  const badge = document.getElementById('syslog-status-badge');
+  const badgeText = document.getElementById('syslog-status-text');
+  const btnStart = document.getElementById('btn-syslog-start');
+  const btnStop = document.getElementById('btn-syslog-stop');
+  const tab5Text = document.getElementById('tab5-syslog-text');
+  const tab5Btn = document.getElementById('btn-tab5-launch-syslog');
+  const statFile = document.getElementById('syslog-stat-file');
+  const statPackets = document.getElementById('syslog-stat-packets');
+  const statClient = document.getElementById('syslog-stat-client');
+  const portInput = document.getElementById('cfg-syslog-port');
+
+  if (portInput && data.port) {
+    portInput.value = data.port;
+  }
+
+  if (badge && badgeText) {
+    if (data.running) {
+      badge.className = 'syslog-status-badge running';
+      badgeText.textContent = `Syslog: UDP :${data.port}`;
+    } else {
+      badge.className = 'syslog-status-badge stopped';
+      badgeText.textContent = 'Syslog: Offline';
+    }
+  }
+
+  if (btnStart && btnStop) {
+    if (data.running) {
+      btnStart.style.display = 'none';
+      btnStop.style.display = 'inline-flex';
+    } else {
+      btnStart.style.display = 'inline-flex';
+      btnStop.style.display = 'none';
+    }
+  }
+
+  if (tab5Text) {
+    tab5Text.textContent = data.running ? `Syslog: :${data.port}` : 'Syslog Server';
+  }
+  if (tab5Btn) {
+    if (data.running) {
+      tab5Btn.classList.add('btn-accent');
+      tab5Btn.classList.remove('btn-ghost');
+    } else {
+      tab5Btn.classList.remove('btn-accent');
+      tab5Btn.classList.add('btn-ghost');
+    }
+  }
+
+  if (statFile && data.logfile) statFile.textContent = data.logfile;
+  if (statPackets && typeof data.packets === 'number') statPackets.textContent = data.packets;
+  if (statClient && data.last_sender) statClient.textContent = data.last_sender;
+  const otaIp = document.getElementById('cfg-ota-ip');
+  if (otaIp && !otaIp.value && data.last_sender) otaIp.value = data.last_sender;
+}
+
+async function startSyslogServer(requestedPort) {
+  const portInput = document.getElementById('cfg-syslog-port');
+  const port = requestedPort || (portInput ? parseInt(portInput.value) || 514 : 514);
+  try {
+    const res = await fetch('/api/syslog/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ port: port })
+    });
+    const data = await res.json();
+    if (data.status === 'running' || data.status === 'already_running') {
+      updateSyslogUIState(data);
+      const ipEl = document.getElementById('cfg-syslog-ip');
+      if (ipEl && data.host_ip) ipEl.value = data.host_ip;
+      const portEl = document.getElementById('cfg-syslog-port');
+      if (portEl && data.port) portEl.value = data.port;   // reflect the bound port in the config
+      if (data.host_ip) showToast(`📡 Syslog target set to ${data.host_ip}:${data.port}`);
+      recomputeAll();
+      connectSyslogStream();
+      const fallbackNote = data.fallback ? ` (fell back to :${data.port})` : '';
+      showToast(`🟢 Syslog Server listening on UDP port ${data.port}${fallbackNote}!`);
+      
+      // Append notification to terminal
+      const terminalScreen = document.getElementById('serial-terminal-screen');
+      if (terminalScreen) {
+        const lineEl = document.createElement('div');
+        lineEl.className = 'terminal-line terminal-in';
+        lineEl.textContent = `[SYSLOG SERVER] Listening on UDP 0.0.0.0:${data.port} | Saving to ${data.logfile}`;
+        terminalScreen.appendChild(lineEl);
+        terminalScreen.scrollTop = terminalScreen.scrollHeight;
+      }
+    } else {
+      showToast(`⚠️ Failed to start syslog: ${data.error || 'Unknown error'}`);
+    }
+  } catch (e) {
+    showToast(`⚠️ Syslog start error: ${e.message}`);
+  }
+}
+
+async function stopSyslogServer() {
+  try {
+    const res = await fetch('/api/syslog/stop', { method: 'POST' });
+    const data = await res.json();
+    updateSyslogUIState(data);
+    if (activeSyslogEventSource) {
+      activeSyslogEventSource.close();
+      activeSyslogEventSource = null;
+    }
+    showToast(`⏹️ Syslog Server stopped. Total packets: ${data.packets || 0}`);
+    const terminalScreen = document.getElementById('serial-terminal-screen');
+    if (terminalScreen) {
+      const lineEl = document.createElement('div');
+      lineEl.className = 'terminal-line terminal-dim';
+      lineEl.textContent = `[SYSLOG SERVER] Stopped (Captured ${data.packets || 0} packets).`;
+      terminalScreen.appendChild(lineEl);
+      terminalScreen.scrollTop = terminalScreen.scrollHeight;
+    }
+  } catch (e) {
+    showToast(`⚠️ Syslog stop error: ${e.message}`);
+  }
+}
+
+function connectSyslogStream() {
+  if (activeSyslogEventSource) {
+    activeSyslogEventSource.close();
+  }
+  activeSyslogEventSource = new EventSource('/api/syslog/stream');
+  
+  activeSyslogEventSource.addEventListener('status', (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      updateSyslogUIState(data);
+    } catch (_) {}
+  });
+
+  activeSyslogEventSource.addEventListener('syslog', (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      const statPackets = document.getElementById('syslog-stat-packets');
+      const statClient = document.getElementById('syslog-stat-client');
+      if (statPackets) {
+        const cur = parseInt(statPackets.textContent) || 0;
+        statPackets.textContent = cur + 1;
+      }
+      if (statClient) statClient.textContent = data.sender;
+
+      const chkStream = document.getElementById('chk-stream-syslog-terminal');
+      if (!chkStream || chkStream.checked) {
+        const terminalScreen = document.getElementById('serial-terminal-screen');
+        if (terminalScreen) {
+          const lineEl = document.createElement('div');
+          lineEl.className = 'terminal-line terminal-syslog';
+          const timePart = data.time ? data.time.split(' ')[1] || data.time : '';
+          const escapedMsg = (data.message || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+          lineEl.innerHTML = `<span class="badge-syslog">SYSLOG</span> <span class="syslog-time">${timePart}</span> <span class="syslog-sender">[${data.sender}]</span> <span class="syslog-msg">${escapedMsg}</span>`;
+          terminalScreen.appendChild(lineEl);
+          
+          const chkAutoScroll = document.getElementById('chk-serial-autoscroll');
+          if (!chkAutoScroll || chkAutoScroll.checked) {
+            terminalScreen.scrollTop = terminalScreen.scrollHeight;
+          }
+        }
+      }
+    } catch (_) {}
+  });
+
+  activeSyslogEventSource.onerror = () => {
+    // will auto-reconnect
+  };
+}
+
+async function viewSyslogFiles() {
+  try {
+    const res = await fetch('/api/syslog/logs?tail=30');
+    if (!res.ok) return;
+    const data = await res.json();
+    const terminalScreen = document.getElementById('serial-terminal-screen');
+    if (terminalScreen) {
+      const lineEl = document.createElement('div');
+      lineEl.className = 'terminal-line terminal-in';
+      lineEl.textContent = `=== 📂 Syslog Files in logs/ (${data.files.length} files) ===`;
+      terminalScreen.appendChild(lineEl);
+      for (const f of data.files) {
+        const fEl = document.createElement('div');
+        fEl.className = 'terminal-line terminal-out';
+        fEl.textContent = `  - ${f.name} (${f.size} bytes)`;
+        terminalScreen.appendChild(fEl);
+      }
+      if (data.lines && data.lines.length > 0) {
+        const hEl = document.createElement('div');
+        hEl.className = 'terminal-line terminal-in';
+        hEl.textContent = `--- Tail of ${data.current_file} ---`;
+        terminalScreen.appendChild(hEl);
+        for (const l of data.lines) {
+          const lEl = document.createElement('div');
+          lEl.className = 'terminal-line terminal-syslog';
+          lEl.textContent = `  ${l}`;
+          terminalScreen.appendChild(lEl);
+        }
+      }
+      terminalScreen.scrollTop = terminalScreen.scrollHeight;
+    }
+    showToast(`📂 Found ${data.files.length} log files in logs/`);
+  } catch (e) {
+    showToast(`⚠️ Could not list logs: ${e.message}`);
+  }
+}
+
+function initSyslogControls() {
+  const btnStart = document.getElementById('btn-syslog-start');
+  if (btnStart) btnStart.addEventListener('click', () => startSyslogServer());
+
+  const btnStop = document.getElementById('btn-syslog-stop');
+  if (btnStop) btnStop.addEventListener('click', () => stopSyslogServer());
+
+  const btnTab5 = document.getElementById('btn-tab5-launch-syslog');
+  if (btnTab5) {
+    btnTab5.addEventListener('click', () => {
+      if (isSyslogRunning) stopSyslogServer();
+      else startSyslogServer();
+    });
+  }
+
+  const btnViewLogs = document.getElementById('btn-syslog-view-logs');
+  if (btnViewLogs) btnViewLogs.addEventListener('click', () => viewSyslogFiles());
+
+  checkSyslogStatus();
+}

--- a/tools/robot_config_engine/web/app.js
+++ b/tools/robot_config_engine/web/app.js
@@ -228,7 +228,6 @@ const PRESETS = {
       battery_nominal_voltage: 11.1,
       battery_min_voltage: 9.0,
       battery_max_voltage: 12.6,
-      battery_dip: 0.98,
       sonar: true
     },
     pins: {
@@ -591,6 +590,13 @@ function initEventListeners() {
   });
   const otaHostEl = document.getElementById("cfg-ota-hostname");
   if (otaHostEl) otaHostEl.addEventListener("input", () => { otaHostEl.dataset.autoManaged = "false"; });
+  // Typing in a covariance field marks it user-owned so a later sensor change
+  // won't overwrite it with the datasheet default.
+  ["cfg-cov-accel", "cfg-cov-gyro", "cfg-cov-ori", "cfg-cov-mag", "cfg-cov-env",
+   "cfg-cov-pose", "cfg-cov-twist"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) el.addEventListener("input", () => { delete el.dataset.autoCov; });
+  });
   // show/hide password toggles
   [["cfg-wifi-pass-show", "cfg-wifi-pass"], ["cfg-ota-password-show", "cfg-ota-password"]].forEach(([chk, fld]) => {
     const c = document.getElementById(chk), f = document.getElementById(fld);
@@ -688,6 +694,11 @@ function normalizeSpecToFormShape(spec) {
         typeof s.sonar_echo === "number" && s.sonar_echo >= 0) {
       s.sonar = true;
     }
+    // Environmental barometer: parser emits env_type / use_bmp280
+    if (s.env == null) {
+      if (s.env_type) s.env = String(s.env_type).toUpperCase();
+      else if (s.use_bmp280) s.env = "BMP280";
+    }
     // Battery numeric fields use different names in the parser
     if (s.battery_capacity == null && s.battery_cap != null)            s.battery_capacity = s.battery_cap;
     if (s.battery_min_voltage == null && s.battery_min != null)         s.battery_min_voltage = s.battery_min;
@@ -761,11 +772,12 @@ function populateFormFromSpec(spec) {
   if (document.getElementById("cfg-bat-nom")) document.getElementById("cfg-bat-nom").value = spec.sensors?.battery_nominal_voltage || 11.1;
   if (document.getElementById("cfg-bat-min")) document.getElementById("cfg-bat-min").value = spec.sensors?.battery_min_voltage || 9.0;
   if (document.getElementById("cfg-bat-max")) document.getElementById("cfg-bat-max").value = spec.sensors?.battery_max_voltage || 12.6;
-  if (document.getElementById("cfg-bat-dip")) document.getElementById("cfg-bat-dip").value = spec.sensors?.battery_dip || 0.98;
+  if (document.getElementById("cfg-bat-dip")) document.getElementById("cfg-bat-dip").value = spec.sensors?.battery_dip ?? "";
   if (document.getElementById("cfg-bat-r1")) document.getElementById("cfg-bat-r1").value = spec.sensors?.battery_r1 || 30000;
   if (document.getElementById("cfg-bat-r2")) document.getElementById("cfg-bat-r2").value = spec.sensors?.battery_r2 || 7500;
   if (document.getElementById("cfg-bat-cap-val")) document.getElementById("cfg-bat-cap-val").value = spec.sensors?.battery_adc_cap || 1000;
   document.getElementById("cfg-sonar").value = spec.sensors?.sonar ? "true" : "false";
+  if (document.getElementById("cfg-env")) document.getElementById("cfg-env").value = spec.sensors?.env || "NONE";
 
   // Dual-Core
   if (document.getElementById("cfg-dual-core")) {
@@ -868,6 +880,7 @@ function populateFormFromSpec(spec) {
   setNum("cfg-cov-mag", covScalar(tune.mag_cov));
   setNum("cfg-cov-pose", covList(tune.pose_cov));
   setNum("cfg-cov-twist", covList(tune.twist_cov));
+  setNum("cfg-cov-env", covList(tune.env_cov));
   setPinVal("pin-battery", p.battery_pin);
   setPinVal("pin-sonar-trig", p.sonar?.trig);
   setPinVal("pin-sonar-echo", p.sonar?.echo);
@@ -887,6 +900,9 @@ function populateFormFromSpec(spec) {
 
 
   updateDynamicUIState();
+  // Fill datasheet covariance defaults for the loaded IMU/mag/barometer, but
+  // only into fields the imported spec left blank (explicit values are kept).
+  applySensorCovDefaults();
 }
 
 function setPinVal(id, val) {
@@ -954,11 +970,12 @@ function readSpecFromForm() {
       battery_nominal_voltage: getFloat("cfg-bat-nom", 11.1),
       battery_min_voltage: getFloat("cfg-bat-min", 9.0),
       battery_max_voltage: getFloat("cfg-bat-max", 12.6),
-      battery_dip: getFloat("cfg-bat-dip", 0.98),
+      battery_dip: getFloatOrNull("cfg-bat-dip"),   // blank = disabled (no BATTERY_DIP emitted)
       battery_r1: getFloat("cfg-bat-r1", 30000.0),
       battery_r2: getFloat("cfg-bat-r2", 7500.0),
       battery_adc_cap: getFloat("cfg-bat-cap-val", 1000.0),
-      sonar: document.getElementById("cfg-sonar").value === "true"
+      sonar: document.getElementById("cfg-sonar").value === "true",
+      env: document.getElementById("cfg-env")?.value || "NONE"
     },
     imu_tuning: (() => {
       const bx = getFloatOrNull("cfg-mag-bias-x"), by = getFloatOrNull("cfg-mag-bias-y"), bz = getFloatOrNull("cfg-mag-bias-z");
@@ -984,6 +1001,10 @@ function readSpecFromForm() {
       const pc = covField("cfg-cov-pose"), tc = covField("cfg-cov-twist");
       if (pc !== null) t.pose_cov = pc;
       if (tc !== null) t.twist_cov = tc;
+      // ENV_COV: BMP280 FluidPressure/Temperature/RelativeHumidity .variance
+      // { pressure Pa^2, temperature C^2, humidity (0..1)^2 } — scalar or 3-list.
+      const evc = covField("cfg-cov-env");
+      if (evc !== null) t.env_cov = evc;
       return t;
     })(),
     baudrate: document.getElementById("cfg-baudrate") ? parseInt(document.getElementById("cfg-baudrate").value, 10) : 921600,
@@ -1104,8 +1125,62 @@ function readSpecFromForm() {
 }
 
 // Handle Form Changes
+// Datasheet-derived default measurement variances. Auto-filled into the
+// Covariance Overrides when a sensor is enabled, so the generated header
+// ships realistic ACCEL/GYRO/ORI/MAG/ENV_COV instead of the firmware's
+// generic 1e-5 fallback. variance ≈ (noise_density · √(~100 Hz bandwidth))².
+// A value the user types is never overwritten (see applySensorCovDefaults).
+const SENSOR_COV_DEFAULTS = {
+  imu: {   // { accel: (m/s²)² , gyro: (rad/s)² , ori?: rad² (fused output only) }
+    BNO085:   { accel: 2.2e-4, gyro: 1.5e-6, ori: 4e-3 },
+    LSM6DSOX: { accel: 4.7e-5, gyro: 4.4e-7 },
+    ICM20948: { accel: 5.1e-4, gyro: 6.9e-6 },
+    QMI8658:  { accel: 8e-5,   gyro: 2e-6 },
+    MPU9250:  { accel: 9e-4,   gyro: 3e-6 },
+    MPU9150:  { accel: 1.5e-3, gyro: 3e-6 },
+    MPU6050:  { accel: 1.5e-3, gyro: 3e-6 },
+    GY85:     { accel: 1.8e-3, gyro: 4.4e-5 },
+  },
+  mag: {   // Tesla²
+    AK09918:  2.3e-14, ICM20948: 2.3e-14,
+    QMC5883L: 4e-14,   HMC5883L: 4e-14,
+    AK8963:   9e-14,   AK8975:   9e-14,
+  },
+  env: {   // [ pressure Pa² (σ≈1.7 Pa, IIR-x4) , temperature °C² (±0.5°C accuracy) , humidity (0..1)² (±3% RH) ]
+    BMP280: [3, 0.25, 0],
+    BME280: [3, 0.25, 9e-4],
+  },
+};
+
+// Fill the ACCEL/GYRO/ORI/MAG/ENV_COV fields from SENSOR_COV_DEFAULTS for the
+// currently-selected IMU / magnetometer / barometer. Only touches a field that
+// is empty or that we filled ourselves (data-auto-cov); a user-typed value —
+// or one being typed right now — is left alone. Clearing a sensor back to
+// NONE/FAKE also clears its auto-filled covariance.
+function applySensorCovDefaults() {
+  const setAuto = (id, val) => {
+    const el = document.getElementById(id);
+    if (!el || document.activeElement === el) return;
+    const userTyped = (el.value || "").trim() !== "" && el.dataset.autoCov !== "1";
+    if (userTyped) return;
+    if (val == null || val === "") {
+      if (el.dataset.autoCov === "1") { el.value = ""; delete el.dataset.autoCov; }
+      return;
+    }
+    el.value = Array.isArray(val) ? val.join(", ") : String(val);
+    el.dataset.autoCov = "1";
+  };
+  const d = SENSOR_COV_DEFAULTS.imu[document.getElementById("cfg-imu")?.value];
+  setAuto("cfg-cov-accel", d ? d.accel : null);
+  setAuto("cfg-cov-gyro",  d ? d.gyro  : null);
+  setAuto("cfg-cov-ori",   d && d.ori != null ? d.ori : null);
+  setAuto("cfg-cov-mag", SENSOR_COV_DEFAULTS.mag[document.getElementById("cfg-mag")?.value] ?? null);
+  setAuto("cfg-cov-env", SENSOR_COV_DEFAULTS.env[document.getElementById("cfg-env")?.value] ?? null);
+}
+
 function handleInputChange() {
   updateDynamicUIState();
+  applySensorCovDefaults();
   recomputeAll();
 }
 
@@ -1673,6 +1748,7 @@ function generateCppHeader(spec) {
   covLine("MAG_COV", tune.mag_cov);
   covLine("POSE_COV", tune.pose_cov, 6);
   covLine("TWIST_COV", tune.twist_cov, 6);
+  covLine("ENV_COV", tune.env_cov, 3);   // { pressure, temperature, humidity } variance
 
   if (sensors.battery_monitor === "ADC_DIVIDER") {
     const numFmt = (x) => { const f = Number(x); return Number.isInteger(f) ? String(f) : String(f).replace(/0+$/,"").replace(/\.$/,""); };
@@ -1702,6 +1778,12 @@ function generateCppHeader(spec) {
     lines.push(`#define USE_INA219`);
   }
 
+  // Environmental barometer — BMP280 & BME280 share the macro; the driver
+  // reads the chip id at runtime and only publishes /humidity for a BME280.
+  if (sensors.env && sensors.env !== "NONE") {
+    lines.push(`#define USE_BMP280`);
+  }
+
   if (sensors.sonar && pins.sonar) {
     lines.push(
       `#define USE_SONAR`,
@@ -1718,7 +1800,8 @@ function generateCppHeader(spec) {
   const i2c = pins.i2c || {};
   const i2cUsed = (sensors.imu && sensors.imu !== "FAKE" && sensors.imu !== "FAKE_IMU" && sensors.imu !== "NONE")
                || (sensors.mag && sensors.mag !== "NONE")
-               || sensors.battery_monitor === "INA219";
+               || sensors.battery_monitor === "INA219"
+               || (sensors.env && sensors.env !== "NONE");
   const sda = i2c.sda, scl = i2c.scl;
   if (i2cUsed && sda !== undefined && scl !== undefined && sda >= 0 && scl >= 0) {
     lines.push(``, `// I2C Bus`, `#define SDA_PIN ${sda}`, `#define SCL_PIN ${scl}`);
@@ -2696,6 +2779,111 @@ function getToolchainInstallCmd(opts) {
   return lines.length > 0 ? lines.join(" && \\\n") : "# No toolchain installations selected";
 }
 
+// Idempotent shell snippet that GUARANTEES a working `pio` on PATH, installing
+// PlatformIO Core (and the few OS packages its installer needs) the first time.
+// Standalone actions — I2C auto-detect, ADC calibrate — otherwise just run a bare
+// `pio ...` and die with "command not found" (exit 127) on a fresh SBC / distrobox
+// that has never run a Full Deploy. Mirrors Phase 1 of generateDeployScript.
+// Meant to be the first lines of a command passed to executeCommandInTerminal().
+function ensurePioToolchainSnippet() {
+  return [
+    `export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"`,
+    `_pio_ok() { command -v pio >/dev/null 2>&1 && pio --version >/dev/null 2>&1; }`,
+    `if ! _pio_ok; then`,
+    `  echo ">>> PlatformIO not found - installing build toolchain (first run only, ~1-2 min)..."`,
+    `  if command -v pio >/dev/null 2>&1; then echo ">>> (removing a broken PlatformIO venv)"; rm -rf "$HOME/.platformio/penv"; hash -r; fi`,
+    `  if ! python3 -c "import venv, ensurepip" >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then`,
+    `    if command -v apt-get >/dev/null 2>&1; then`,
+    `      (sudo -n apt-get update -y 2>/dev/null || sudo apt-get update -y) || true`,
+    `      sudo -n apt-get install -y python3 python3-venv python3-pip curl git 2>/dev/null || sudo apt-get install -y python3 python3-venv python3-pip curl git || true`,
+    `    elif command -v dnf >/dev/null 2>&1; then`,
+    `      (sudo -n dnf install -y python3 python3-pip curl git 2>/dev/null || sudo dnf install -y python3 python3-pip curl git) || true`,
+    `    else`,
+    `      echo ">>> WARN: no apt-get/dnf - assuming python3+curl already present"`,
+    `    fi`,
+    `  fi`,
+    `  curl -fsSL -o /tmp/get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py || { echo "ERROR: cannot download the PlatformIO installer (network?)"; exit 1; }`,
+    `  python3 /tmp/get-platformio.py || { echo "ERROR: PlatformIO Core installation failed"; exit 1; }`,
+    `  export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"; hash -r`,
+    `fi`,
+    `_pio_ok || { echo "ERROR: PlatformIO Core still not working ('pio --version' fails)"; exit 1; }`,
+    `echo ">>> PlatformIO ready: $(pio --version 2>/dev/null || echo installed)"`,
+  ].join("\n");
+}
+
+// micro-ROS agent launch with graceful degradation:
+//   native `ros2 run micro_ros_agent`  (from /opt/ros or ~/uros_ws)
+//   -> apt `ros-<distro>-micro-ros-agent`  (if the ROS 2 apt repo is present)
+//   -> docker / podman `microros/micro-ros-agent:<distro>`  (-> :rolling tag)
+//   -> clear error pointing at the "Install ROS 2" button.
+// mode: "serial" | "multiserial" | "udp".
+function microRosAgentCmd(mode, opt) {
+  const distro   = opt.distro || "jazzy";
+  const baud     = opt.baud || 921600;
+  const udpPort  = opt.udpPort || 8888;
+  const port     = (opt.port || "/dev/ttyUSB0").trim();
+  const ports    = (opt.ports || "/dev/ttyACM0 /dev/ttyUSB0").trim();
+
+  let agentArgs, deviceFlags, permPorts;
+  if (mode === "multiserial") {
+    agentArgs = `multiserial --devs "${ports}" -b ${baud}`;
+    deviceFlags = ports.split(/\s+/).filter(Boolean).map(d => `--device ${d}`).join(" ");
+    permPorts = ports;
+  } else if (mode === "udp") {
+    agentArgs = `udp4 --port ${udpPort}`;
+    deviceFlags = "";
+    permPorts = "";
+  } else { // serial
+    agentArgs = `serial --dev ${port} -b ${baud}`;
+    deviceFlags = `--device ${port}`;
+    permPorts = port;
+  }
+
+  const argsEcho = agentArgs.replace(/"/g, '\\"');   // safe inside a "…" echo
+  return [
+    `DISTRO="${distro}"`,
+    permPorts
+      ? `for _d in ${permPorts}; do [ -e "$_d" ] && [ ! -w "$_d" ] && sudo chmod a+rw "$_d" 2>/dev/null || true; done`
+      : `# udp transport - no serial port to free`,
+    ``,
+    `# 1. Native ROS 2 agent (from /opt/ros/<distro> or ~/uros_ws)`,
+    `if [ -f "/opt/ros/$DISTRO/setup.bash" ]; then`,
+    `  source "/opt/ros/$DISTRO/setup.bash"`,
+    `  [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"`,
+    `  if ros2 pkg prefix micro_ros_agent >/dev/null 2>&1; then`,
+    `    echo ">>> micro-ROS agent: native 'ros2 run' (ROS 2 $DISTRO)"`,
+    `    exec ros2 run micro_ros_agent micro_ros_agent ${agentArgs}`,
+    `  fi`,
+    `  if command -v apt-get >/dev/null 2>&1; then`,
+    `    echo ">>> micro_ros_agent package missing - trying apt install ros-$DISTRO-micro-ros-agent ..."`,
+    `    if sudo -n apt-get install -y "ros-$DISTRO-micro-ros-agent" 2>/dev/null || sudo apt-get install -y "ros-$DISTRO-micro-ros-agent"; then`,
+    `      source "/opt/ros/$DISTRO/setup.bash"`,
+    `      if ros2 pkg prefix micro_ros_agent >/dev/null 2>&1; then`,
+    `        echo ">>> micro-ROS agent: native 'ros2 run' (apt-installed)"`,
+    `        exec ros2 run micro_ros_agent micro_ros_agent ${agentArgs}`,
+    `      fi`,
+    `    fi`,
+    `  fi`,
+    `fi`,
+    ``,
+    `# 2. Docker / Podman fallback`,
+    `_DK=""`,
+    `command -v docker >/dev/null 2>&1 && _DK=docker`,
+    `[ -z "$_DK" ] && command -v podman >/dev/null 2>&1 && _DK=podman`,
+    `if [ -n "$_DK" ]; then`,
+    `  IMG="microros/micro-ros-agent:$DISTRO"`,
+    `  echo ">>> no native ROS 2 agent - falling back to: $_DK run $IMG"`,
+    `  $_DK pull "$IMG" 2>/dev/null || { echo ">>> no '$DISTRO' tag on Docker Hub - trying ':rolling'"; IMG="microros/micro-ros-agent:rolling"; $_DK pull "$IMG" 2>/dev/null || true; }`,
+    `  exec $_DK run --rm --net=host --name "uros_agent_${mode}" ${deviceFlags} "$IMG" ${agentArgs}`,
+    `fi`,
+    ``,
+    `echo "ERROR: no micro-ROS agent available (no ROS 2 $DISTRO, no docker/podman)."`,
+    `echo "  fix: click 'Install ROS 2 Distribution & Packages' above, or install Docker, then retry."`,
+    `echo "  manual: docker run --rm --net=host ${deviceFlags} microros/micro-ros-agent:$DISTRO ${argsEcho}"`,
+    `exit 1`,
+  ].join("\n");
+}
+
 // Generate ROS 2 Install Commands
 function getRos2InstallCmd(opts) {
   const distro = opts.rosDistro;
@@ -3508,6 +3696,10 @@ function getDirectUploadOrBuildCmd(target, isUpload = true) {
     `set -e`,
     `export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"`,
     `export ROS_DISTRO=${rosDistro}`,
+    ``,
+    `echo "=== [1/2] Build tools (PlatformIO) ==============================="`,
+    ensurePioToolchainSnippet(),   // first-run bootstrap so a bare SBC/box doesn't exit 127
+    `echo "=== [2/2] ${isUpload ? "Building & flashing" : "Building"} ${target} ==============="`,
     `[ "$(awk '/MemTotal/{print $2}' /proc/meminfo 2>/dev/null || echo 8000000)" -lt 6000000 ] && export PLATFORMIO_BUILD_JOBS=2 MAKEFLAGS="-j2" || true`,
     `if [ -f "/opt/ros/${rosDistro}/setup.bash" ]; then source "/opt/ros/${rosDistro}/setup.bash"; fi`,
     `if [ -f "$HOME/uros_ws/install/setup.bash" ]; then source "$HOME/uros_ws/install/setup.bash"; fi`,
@@ -3583,6 +3775,25 @@ function getDirectUploadOrBuildCmd(target, isUpload = true) {
   }
 
   return lines.join("\n");
+}
+
+// After flashing a diagnostic sketch (test_sensors / test_motors / test_acc),
+// append a read-only serial monitor so its output streams into the console.
+// Dependency-free (stty + cat, like the "Stream SBC Serial" button); runs until
+// the user hits Stop. No-op for BOOTSEL / AUTO ports or non-diagnostic targets.
+function withSerialMonitor(cmd, target, port) {
+  const streamable = ["test_sensors", "test_motors", "test_acc"];
+  if (!streamable.includes(target)) return cmd;
+  if (!port || port.includes("BOOTSEL") || port.includes("AUTO")) return cmd;
+  const baud = firmwareBaud();
+  return cmd + [
+    ``,
+    `echo`,
+    `echo "=== Serial monitor: ${port} @ ${baud} — press ⏹ Stop to end ==="`,
+    `sleep 1`,
+    `stty -F "${port}" ${baud} raw -echo 2>/dev/null || true`,
+    `exec cat "${port}"`,
+  ].join("\n");
 }
 
 
@@ -3702,7 +3913,7 @@ function initAutomationEventListeners() {
       const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
       const port = document.getElementById("auto-flash-port")?.value.trim() || "/dev/ttyUSB0";
       const baud = firmwareBaud();
-      const cmd = `[ -e "${port}" ] && [ ! -w "${port}" ] && sudo chmod a+rw "${port}" 2>/dev/null || true; source /opt/ros/${distro}/setup.bash && [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"; ros2 run micro_ros_agent micro_ros_agent serial --dev ${port} -b ${baud}`;
+      const cmd = microRosAgentCmd("serial", { distro, port, baud });
       executeCommandInTerminal(cmd, `Launching Single Serial micro-ROS Agent (${port} @ ${baud}) on Robot SBC`);
     });
   }
@@ -3714,7 +3925,7 @@ function initAutomationEventListeners() {
       const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
       const multiPorts = document.getElementById("auto-agent-multiserial-ports")?.value.trim() || "/dev/ttyACM0 /dev/ttyUSB0";
       const baud = firmwareBaud();
-      const cmd = `for _d in ${multiPorts}; do [ -e "$_d" ] && [ ! -w "$_d" ] && sudo chmod a+rw "$_d" 2>/dev/null || true; done; source /opt/ros/${distro}/setup.bash && [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"; ros2 run micro_ros_agent micro_ros_agent multiserial --devs "${multiPorts}" -b ${baud}`;
+      const cmd = microRosAgentCmd("multiserial", { distro, ports: multiPorts, baud });
       executeCommandInTerminal(cmd, `Launching Multi-Serial micro-ROS Agent (${multiPorts} @ ${baud}) on Robot SBC`);
     });
   }
@@ -3724,7 +3935,7 @@ function initAutomationEventListeners() {
     btnExecAgentUdp.addEventListener("click", () => {
       const opts = readAutomationOptions();
       const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
-      const cmd = `source /opt/ros/${distro}/setup.bash && [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"; ros2 run micro_ros_agent micro_ros_agent udp4 --port 8888`;
+      const cmd = microRosAgentCmd("udp", { distro, udpPort: 8888 });
       executeCommandInTerminal(cmd, `Launching UDP WiFi micro-ROS Agent (:8888) on Robot SBC`);
     });
   }
@@ -3784,7 +3995,7 @@ function initAutomationEventListeners() {
         if (targetSel) targetSel.value = target;
         updateAutomationPreviews();
         const port = document.getElementById("auto-flash-port")?.value.trim() || (isESP32(currentSpec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
-        const cmd = getDirectUploadOrBuildCmd(target, true);
+        const cmd = withSerialMonitor(getDirectUploadOrBuildCmd(target, true), target, port);
         executeCommandInTerminal(cmd, `⚡ Uploading ${desc} (${target}/ -> ${port})`);
       });
     }
@@ -3795,7 +4006,7 @@ function initAutomationEventListeners() {
     btnExecUpload.addEventListener("click", () => {
       const target = document.getElementById("auto-flash-target")?.value || "firmware";
       const port = document.getElementById("auto-flash-port")?.value.trim() || (isESP32(currentSpec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
-      const cmd = getDirectUploadOrBuildCmd(target, true);
+      const cmd = withSerialMonitor(getDirectUploadOrBuildCmd(target, true), target, port);
       executeCommandInTerminal(cmd, `Flashing Microcontroller (${target}/ -> ${port})`);
     });
   }
@@ -3854,6 +4065,24 @@ function initAutomationEventListeners() {
   const btnSerialConnect = document.getElementById("btn-serial-connect");
   if (btnSerialConnect) {
     btnSerialConnect.addEventListener("click", toggleWebSerialConnection);
+  }
+
+  // Web Serial is Chromium-only (and needs HTTPS or localhost). On a browser
+  // without it, grey out Connect / the command input / Send so it's clear the
+  // in-browser serial console isn't available here.
+  if (!("serial" in navigator)) {
+    const why = "In-browser serial needs Chrome / Edge / Opera over HTTPS or localhost";
+    [["btn-serial-connect", "serial-btn-text", "Serial N/A"],
+     ["btn-serial-send", null, null],
+     ["serial-input-text", null, null]].forEach(([id, txtId, txt]) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      el.disabled = true;
+      el.classList.add("is-disabled");
+      el.title = why;
+      if (txtId && txt) { const t = document.getElementById(txtId); if (t) t.textContent = txt; }
+      if (id === "serial-input-text") el.placeholder = why;
+    });
   }
 
 
@@ -3925,6 +4154,17 @@ function applyHostIpDefaults(hostIp) {
   });
 }
 
+// Bring the live terminal on-screen: activate the Automation tab (the console
+// lives there) and scroll the console card into view. Used by the ROS 2 topic
+// stream / Hz buttons, which sit further up the same tab, so their output
+// otherwise lands out of sight.
+function jumpToTerminal() {
+  const autoTab = document.querySelector('[data-tab="tab-automation"]');
+  if (autoTab && !autoTab.classList.contains("active")) autoTab.click();
+  const card = document.querySelector(".web-serial-console-card");
+  if (card) card.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
 // Execute Command with Live Streaming Output in Terminal Console
 async function executeCommandInTerminal(command, title = "Executing Command") {
   const terminalScreen = document.getElementById("serial-terminal-screen");
@@ -3934,10 +4174,36 @@ async function executeCommandInTerminal(command, title = "Executing Command") {
   // grows O(n) in memory and O(n^2) in CPU over a long build log.
   const _isAdcCal = /\badc_calibrate\b/.test(command);
 
-  // Scroll to terminal
+  // Surface the live terminal: the console lives on the Automation tab, so a
+  // command fired from any other tab (I2C auto-detect, ADC calibrate, branch
+  // switch, …) would otherwise stream out of sight. Activate that tab, then
+  // scroll its console into view. No-op when already there. Remember where the
+  // user was so we can hop back when the command finishes (see finally block).
+  const _origTabBtn = document.querySelector(".nav-tab.active");
+  const _origScrollY = window.scrollY;
+  const _autoTabBtn = document.querySelector('[data-tab="tab-automation"]');
+  let _switchedTab = false;
+  if (_autoTabBtn && !_autoTabBtn.classList.contains("active")) {
+    _autoTabBtn.click();
+    _switchedTab = true;
+  }
+  const _restoreOrigTab = () => {
+    // only if we moved them AND they're still sitting on Automation (didn't
+    // navigate away themselves mid-run)
+    if (_switchedTab && _origTabBtn && _autoTabBtn && _autoTabBtn.classList.contains("active")) {
+      _origTabBtn.click();
+      // ...and back to the scroll position they launched from (the trigger
+      // button is often at the top of its tab; scrollIntoView had jumped us
+      // down to the console).
+      window.scrollTo({ top: _origScrollY, behavior: "auto" });
+    }
+  };
   const terminalEl = document.querySelector(".web-serial-console-card");
   if (terminalEl) {
-    terminalEl.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    // block:"start" (not "nearest") — the console sits well below the flash /
+    // build buttons on the Automation tab, so "nearest" left it at the very
+    // bottom edge, mostly clipped.
+    terminalEl.scrollIntoView({ behavior: "smooth", block: "start" });
   }
 
   if (!isRunnerOnline) {
@@ -3956,6 +4222,7 @@ async function executeCommandInTerminal(command, title = "Executing Command") {
     navigator.clipboard.writeText(command).then(() => {
       showToast("📋 Command copied! (Start 'python3 server.py' for 1-click execution)");
     });
+    _restoreOrigTab();
     return;
   }
 
@@ -4030,6 +4297,8 @@ async function executeCommandInTerminal(command, title = "Executing Command") {
 
     let buffer = "";
     let adcStreamBuffer = "";
+    let _sseDone = false;   // set on the `event: done` line — the socket may be
+                            // kept alive, so we can't rely on the stream closing
     while (true) {
       const { value, done } = await reader.read();
       if (done) break;
@@ -4059,7 +4328,10 @@ async function executeCommandInTerminal(command, title = "Executing Command") {
                 if (execPill) {
                   const L = String(textLine);
                   const step = L.match(/Step (\d)\/9/);
+                  const phaseBanner = L.match(/^=== \[\d\/\d\]\s+(.+?)\s+=+\s*$/);
                   if (step) setExecPhase(`step ${step[1]}/9`);
+                  else if (phaseBanner) setExecPhase(phaseBanner[1].replace(/\s*\(.*$/, "").toLowerCase());
+                  else if (/PlatformIO not found|installing build toolchain|get-platformio|Installing PlatformIO Core/.test(L)) setExecPhase("installing build tools");
                   else if (/apt-get|Installing |Reading package lists|Unpacking |Setting up /.test(L)) setExecPhase("installing packages");
                   else if (/Cloning into|Receiving objects|Resolving deltas/.test(L)) setExecPhase("cloning sources");
                   else if (/colcon build|Starting >>>|Finished <<</.test(L)) setExecPhase("building agent workspace");
@@ -4159,6 +4431,8 @@ async function executeCommandInTerminal(command, title = "Executing Command") {
                   appendTerminalLine(`\n❌ [FAILED] Command exited with code ${exitCode}`, "err");
                   showToast(`⚠️ Command exited with code ${exitCode}`);
                 }
+                _sseDone = true;   // stop reading; hop back to the launching tab now
+                _restoreOrigTab();
               } else if (eventType === "error") {
                 appendTerminalLine(`❌ [ERROR] ${payload.error}`, "err");
               }
@@ -4168,6 +4442,7 @@ async function executeCommandInTerminal(command, title = "Executing Command") {
           }
         }
       }
+      if (_sseDone) { try { await reader.cancel(); } catch (_) {} break; }
     }
   } catch (err) {
     if (err.name === "AbortError") {
@@ -4199,6 +4474,8 @@ async function executeCommandInTerminal(command, title = "Executing Command") {
       _ep.style.display = "none";
     }
     currentExecController = null;
+    // Action done — return the user to the tab they launched it from.
+    _restoreOrigTab();
   }
 }
 
@@ -4582,6 +4859,7 @@ function runHardwareAdcCalibration() {
     `    if seen and l.strip().endswith('};'): break`,
     `s.close()`,
     `EOF_ADC_MON`,
+    `~/.platformio/penv/bin/python -c 'import serial' 2>/dev/null || ~/.platformio/penv/bin/python -m pip install -q pyserial 2>/dev/null || true`,
     `~/.platformio/penv/bin/python /tmp/lr_adc_monitor.py`
   ].join("\n");
   const cmd = `${uploadCmd}\necho "--- adc_calibrate flashed; capturing LUT over serial (${port} @ ${baud} baud, up to 6 min) ---"\n${monScript}`;
@@ -4875,26 +5153,28 @@ function selectTopicAndDisplay(topic, mode = "echo") {
 async function measureAllTopicHz() {
   const tbody = document.getElementById("ros2-topic-table-body");
   if (!tbody) return;
-  const rows = tbody.querySelectorAll("tr.topic-row");
-  for (const row of rows) {
+  const rows = [...tbody.querySelectorAll("tr.topic-row")];
+  // 7 s window so a 1 Hz topic (/battery, /pressure, /temperature, …) is
+  // averaged over ~7 samples instead of 2. Run every row in parallel so the
+  // total wait is ~7 s regardless of how many topics there are.
+  await Promise.all(rows.map(async (row) => {
     const topic = row.getAttribute("data-topic");
-    if (!topic || topic.includes("cmd_vel")) continue;
+    if (!topic || topic.includes("cmd_vel")) return;
     const badge = row.querySelector(".topic-hz-badge");
-    if (badge) {
-      badge.textContent = "Measuring...";
-      badge.style.opacity = "0.6";
-    }
+    if (badge) { badge.textContent = "Measuring…"; badge.style.opacity = "0.6"; }
     try {
-      const res = await fetch(`/api/ros2/hz_single?topic=${encodeURIComponent(topic)}`);
+      const res = await fetch(`/api/ros2/hz_single?topic=${encodeURIComponent(topic)}&secs=7`);
       const data = await res.json();
       if (data.status === "ok" && data.hz && badge) {
         badge.textContent = data.hz;
+        badge.style.opacity = "1.0";
+      } else if (badge) {
         badge.style.opacity = "1.0";
       }
     } catch (e) {
       if (badge) badge.style.opacity = "1.0";
     }
-  }
+  }));
 }
 
 function stopRos2Stream() {
@@ -4917,6 +5197,10 @@ function stopRos2Stream() {
 
 function startRos2Stream(topic, mode = "echo") {
   stopRos2Stream();
+
+  // Surface the console so the streamed messages are actually visible (the
+  // topic table / Hz buttons are higher up the same tab).
+  jumpToTerminal();
 
   const screen = document.getElementById("serial-terminal-screen");
   if (screen) {
@@ -5088,6 +5372,21 @@ function handleI2cAutoDetectedSensors(data) {
     batSelect.dispatchEvent(new Event("change"));
   }
 
+  // 4. Auto-configure Environmental barometer (env category — BMP280 / BME280)
+  const envSelect = document.getElementById("cfg-env");
+  if (envSelect) {
+    const envDev = (data.devices || []).find((d) => d.category === "env");
+    if (envDev) {
+      const model = String(envDev.model || "BMP280").toUpperCase();
+      for (let opt of envSelect.options) {
+        if (opt.value.toUpperCase() === model) { envSelect.value = opt.value; break; }
+      }
+      if (envSelect.value === "NONE") envSelect.value = "BMP280";
+      summaryParts.push(`Env: <strong>${envSelect.value}</strong>`);
+      envSelect.dispatchEvent(new Event("change"));
+    }
+  }
+
   // Update UI results box
   if (resultsDiv) {
     resultsDiv.style.display = "block";
@@ -5141,12 +5440,37 @@ function runI2cSensorAutoDetect() {
   // first JSON (or the "no devices" line).
   const monitorPy = "import serial, sys, time; s = serial.Serial('" + port + "', " + baud + ", timeout=2); t = time.time();\nwhile time.time() - t < 20:\n  l = s.readline().decode('utf-8', errors='ignore').strip()\n  if not l: continue\n  print(l); sys.stdout.flush()\n  if '[I2C_JSON]' in l or 'No I2C devices detected' in l: break\ns.close()";
   const rd = document.getElementById("i2c-detect-results");
-  if (rd) rd.innerHTML = `<span style="color:#38bdf8;">⏳ Building & flashing tools/i2c_detect${pinNote}, then scanning the bus… (first build ~30–90 s)</span>`;
+  if (rd) {
+    rd.style.display = "block";
+    rd.innerHTML = `<span style="color:#38bdf8;">⏳ Watch the <strong>Automation &amp; Flash</strong> tab terminal — installs tools (first run only) → builds &amp; flashes <code>tools/i2c_detect</code>${pinNote} → scans the bus. Returns here when done.</span>`;
+  }
   const btn = document.getElementById("btn-auto-detect-i2c");
-  if (btn) { btn.disabled = true; btn.dataset._t = btn.textContent; btn.textContent = "⏳ Scanning…"; setTimeout(() => { btn.disabled = false; if (btn.dataset._t) btn.textContent = btn.dataset._t; }, 150000); }
+  let _btnRestore = null;
+  if (btn) {
+    btn.disabled = true; btn.dataset._t = btn.textContent; btn.textContent = "⏳ Scanning…";
+    _btnRestore = () => { btn.disabled = false; if (btn.dataset._t) btn.textContent = btn.dataset._t; };
+    setTimeout(() => { if (btn.disabled) _btnRestore(); }, 360000);
+  }
+  // (executeCommandInTerminal activates the Automation tab so this streams on-screen.)
   const rwFix = `for _d in /dev/ttyUSB* /dev/ttyACM*; do [ -e "$_d" ] && [ ! -w "$_d" ] && sudo chmod a+rw "$_d" 2>/dev/null || true; done`;
-  const cmd = `${rwFix} && cd tools/i2c_detect && ${pfx}pio run -e ${envName} -t upload${uploadFlag} && ~/.platformio/penv/bin/python -c "${monitorPy}"`;
-  executeCommandInTerminal(cmd, `🔍 AI Auto-Detecting I2C Sensors (${envName}${pinNote} -> ${port})`);
+  // Guarantee the pyserial the mini-monitor below imports (penv python has pip).
+  const ensurePyserial = `~/.platformio/penv/bin/python -c 'import serial' 2>/dev/null || ~/.platformio/penv/bin/python -m pip install -q pyserial 2>/dev/null || python3 -m pip install -q --user pyserial 2>/dev/null || true`;
+  // Explicit phase banners so the streamed terminal output reads as
+  // installing tools -> building/flashing -> scanning.
+  const cmd = [
+    `set -e`,
+    rwFix,
+    `echo; echo "=== [1/3] Build tools (PlatformIO) ================================"`,
+    ensurePioToolchainSnippet(),          // installs PlatformIO on first use (no more exit 127)
+    ensurePyserial,
+    `echo; echo "=== [2/3] Building & flashing i2c_detect firmware (${envName}) ===="`,
+    `cd tools/i2c_detect`,
+    `${pfx}pio run -e ${envName} -t upload${uploadFlag}`,
+    `echo; echo "=== [3/3] Scanning the I2C bus${pinNote} ========================="`,
+    `~/.platformio/penv/bin/python -c "${monitorPy}"`,
+  ].join("\n");
+  const p = executeCommandInTerminal(cmd, `🔍 AI Auto-Detecting I2C Sensors (${envName}${pinNote} -> ${port})`);
+  if (p && typeof p.finally === "function" && _btnRestore) p.finally(_btnRestore);
 }
 
 

--- a/tools/robot_config_engine/web/app.js
+++ b/tools/robot_config_engine/web/app.js
@@ -358,8 +358,8 @@ const PRESETS = {
     },
     pins: {
       led: -1,
-      motor1: { pwm_r: 25, pwm_l: 17, en: 21 },
-      motor2: { pwm_r: 26, pwm_l: 23, en: 22 },
+      motor1: { in_a: 17, in_b: 21 },
+      motor2: { in_a: 23, in_b: 22 },
       encoders: { m1_a: 34, m1_b: 35, m2_a: 16, m2_b: 27 },
       i2c: { sda: 32, scl: 33 },
       battery_pin: -1,
@@ -396,8 +396,116 @@ document.addEventListener("DOMContentLoaded", () => {
   loadPreset("bare");
   detectClientOS();
   checkServerRunnerStatus();
+  initGitVersionBadge();
   handleUrlParams();
 });
+
+// Mirror the Robot SBC's current git branch into the Tab 5 merge/commit
+// branch field until the user edits it. "Run Merge & Commit" then checks that
+// branch out (creating it if new).
+function applyCurrentBranch(branch) {
+  const el = document.getElementById("auto-git-branch");
+  if (!el || !branch || branch === "(detached)") return;
+  if (el.dataset.autoManaged === "false") return;
+  el.value = branch;
+  el.dataset.autoManaged = "true";
+}
+
+// =============================================================================
+// Header Git Version Badge — shows the 8-char commit the web server booted on;
+// click to reveal the branch, remotes and last 10 commits (GET /api/gitinfo).
+// =============================================================================
+function initGitVersionBadge() {
+  const badge = document.getElementById("git-version-badge");
+  const text = document.getElementById("git-version-text");
+  const popover = document.getElementById("git-version-popover");
+  if (!badge || !text || !popover) return;
+
+  const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
+  ));
+
+  let loaded = null;
+
+  const render = (info) => {
+    const remotes = (info.remotes || []).map((r) => `
+      <div class="gv-line">
+        <span class="gv-remote-name">${esc(r.name)}</span>
+        <span class="gv-val">${esc(r.url)}</span>
+      </div>`).join("") || `<div class="gv-line"><span class="gv-val">(no remotes)</span></div>`;
+
+    const commits = (info.commits || []).map((c) => `
+      <li>
+        <div><span class="gv-hash">${esc(c.hash)}</span> <span class="gv-subject">${esc(c.subject)}</span></div>
+        <div class="gv-meta">${esc(c.author)} · ${esc(c.date)} (${esc(c.reldate)})</div>
+      </li>`).join("") || `<li><span class="gv-meta">(no commit history)</span></li>`;
+
+    const movedNote = info.moved_since_start
+      ? `<div class="gv-note">⚠ HEAD is now at <code>${esc(info.version)}</code> — the server is still running the <code>${esc(info.version_at_start)}</code> build. Restart server.py to pick up the new code.</div>`
+      : "";
+    const dirtyNote = info.dirty
+      ? `<div class="gv-note">Working tree has uncommitted changes.</div>`
+      : "";
+
+    popover.innerHTML = `
+      <h4>Version</h4>
+      <div class="gv-line"><span class="gv-key">server @</span><span class="gv-val">${esc(info.version_at_start)}</span></div>
+      <div class="gv-line"><span class="gv-key">branch</span><span class="gv-val">${esc(info.branch)}</span></div>
+      <h4>Remotes</h4>
+      ${remotes}
+      <h4>Last 10 commits</h4>
+      <ol class="gv-commits">${commits}</ol>
+      ${movedNote}
+      ${dirtyNote}`;
+  };
+
+  const load = async () => {
+    try {
+      const res = await fetch("/api/gitinfo", { cache: "no-cache" });
+      if (!res.ok) return null;
+      return await res.json();
+    } catch (e) {
+      return null;
+    }
+  };
+
+  const closePopover = () => {
+    popover.hidden = true;
+    badge.setAttribute("aria-expanded", "false");
+  };
+
+  const openPopover = async () => {
+    // Always re-fetch: the branch and recent commits change during a session
+    // whenever a robot-config Full Deploy writes a config commit / branch.
+    const fresh = await load();
+    if (fresh) { loaded = fresh; render(loaded); applyCurrentBranch(fresh.branch); }
+    if (!loaded) return;
+    popover.hidden = false;
+    badge.setAttribute("aria-expanded", "true");
+  };
+
+  badge.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (popover.hidden) openPopover();
+    else closePopover();
+  });
+  document.addEventListener("click", (e) => {
+    if (!popover.hidden && !popover.contains(e.target) && e.target !== badge) closePopover();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && !popover.hidden) closePopover();
+  });
+
+  // Prime the badge label at startup.
+  load().then((info) => {
+    if (!info) { text.textContent = "no-git"; return; }
+    loaded = info;
+    render(info);
+    text.textContent = info.version_at_start || "unknown";
+    if (info.dirty || info.moved_since_start) badge.classList.add("is-dirty");
+    applyCurrentBranch(info.branch);
+  });
+}
 
 // URL Query Parameter Handling (e.g. ?preset=mech_esp32&tab=tab-drive&artifact=tab-code-pio)
 function handleUrlParams() {
@@ -455,6 +563,25 @@ function initEventListeners() {
   document.getElementById("preset-select").addEventListener("change", (e) => {
     loadPreset(e.target.value);
   });
+
+  // Header "= name" button: point the branch field at the robot name and
+  // switch the Robot SBC to that branch (creating it if new).
+  const btnBranchToName = document.getElementById("btn-branch-to-name");
+  if (btnBranchToName) {
+    btnBranchToName.addEventListener("click", () => {
+      const name = (currentSpec.robot_name
+        || document.getElementById("cfg-robot-name")?.value || "robot").trim();
+      const el = document.getElementById("auto-git-branch");
+      if (el) { el.value = name; el.dataset.autoManaged = "false"; updateAutomationPreviews(); }
+      const cmd = [
+        `set -e`,
+        `if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then echo "Not a git repository."; exit 1; fi`,
+        `git checkout -b "${name}" 2>/dev/null || git checkout "${name}"`,
+        `echo "Now on branch: $(git rev-parse --abbrev-ref HEAD)"`,
+      ].join("\n");
+      executeCommandInTerminal(cmd, `Switching to Git branch '${name}'`);
+    });
+  }
 
   // Dynamic Input Form Listeners
   const allInputs = document.querySelectorAll(".form-input, .form-select, input[type='checkbox']");
@@ -662,21 +789,24 @@ function populateFormFromSpec(spec) {
   document.getElementById("pin-led").value = p.led !== undefined ? p.led : 25;
 
   const dt = spec.motors?.driver_type || "GENERIC_2_IN";
-  setPinVal("pin-m1-p1", dt === "BTS7960" ? p.motor1?.pwm_r : p.motor1?.pwm);
-  setPinVal("pin-m1-p2", dt === "BTS7960" ? p.motor1?.pwm_l : (dt === "GENERIC_1_IN" ? p.motor1?.dir : p.motor1?.in_a));
-  setPinVal("pin-m1-p3", dt === "BTS7960" ? p.motor1?.en : p.motor1?.in_b);
-
-  setPinVal("pin-m2-p1", dt === "BTS7960" ? p.motor2?.pwm_r : p.motor2?.pwm);
-  setPinVal("pin-m2-p2", dt === "BTS7960" ? p.motor2?.pwm_l : (dt === "GENERIC_1_IN" ? p.motor2?.dir : p.motor2?.in_a));
-  setPinVal("pin-m2-p3", dt === "BTS7960" ? p.motor2?.en : p.motor2?.in_b);
-
-  setPinVal("pin-m3-p1", dt === "BTS7960" ? p.motor3?.pwm_r : p.motor3?.pwm);
-  setPinVal("pin-m3-p2", dt === "BTS7960" ? p.motor3?.pwm_l : (dt === "GENERIC_1_IN" ? p.motor3?.dir : p.motor3?.in_a));
-  setPinVal("pin-m3-p3", dt === "BTS7960" ? p.motor3?.en : p.motor3?.in_b);
-
-  setPinVal("pin-m4-p1", dt === "BTS7960" ? p.motor4?.pwm_r : p.motor4?.pwm);
-  setPinVal("pin-m4-p2", dt === "BTS7960" ? p.motor4?.pwm_l : (dt === "GENERIC_1_IN" ? p.motor4?.dir : p.motor4?.in_a));
-  setPinVal("pin-m4-p3", dt === "BTS7960" ? p.motor4?.en : p.motor4?.in_b);
+  const _pick = (...v) => v.find((x) => x !== undefined && x !== null);
+  for (let i = 1; i <= 4; i++) {
+    const m = p[`motor${i}`] || {};
+    let p1, p2, p3;
+    if (dt === "BTS7960") {
+      // Two outputs: RPWM (IN_A) and LPWM (IN_B). Accept legacy pwm_r/pwm_l/en.
+      p1 = _pick(m.in_a, m.pwm_l, m.pwm_r, m.pwm);
+      p2 = _pick(m.in_b, m.en);
+      p3 = undefined;
+    } else if (dt === "GENERIC_1_IN") {
+      p1 = m.pwm; p2 = _pick(m.dir, m.in_a); p3 = m.in_b;
+    } else {
+      p1 = m.pwm; p2 = m.in_a; p3 = m.in_b;
+    }
+    setPinVal(`pin-m${i}-p1`, p1);
+    setPinVal(`pin-m${i}-p2`, p2);
+    setPinVal(`pin-m${i}-p3`, p3);
+  }
 
   const enc = p.encoders || {};
   setPinVal("pin-enc-1a", enc.m1_a);
@@ -737,10 +867,8 @@ function populateFormFromSpec(spec) {
   setPinVal("pin-sonar-echo", p.sonar?.echo);
 
   const robotName = spec.robot_name || "my_robot";
-  const gitBranchInput = document.getElementById("auto-git-branch");
-  if (gitBranchInput && gitBranchInput.dataset.autoManaged !== "false") {
-    gitBranchInput.value = `config/${robotName}`;
-  }
+  // The git branch field mirrors the Robot SBC's current branch (populated
+  // from /api/gitinfo), not the robot name — leave it to applyCurrentBranch().
   const gitCommitInput = document.getElementById("auto-git-commit-msg");
   if (gitCommitInput && gitCommitInput.dataset.autoManaged !== "false") {
     gitCommitInput.value = `feat(config): add configuration for ${robotName}`;
@@ -902,7 +1030,8 @@ function readSpecFromForm() {
     const p3 = getInt(`${prefix}-p3`);
 
     if (driverType === "BTS7960") {
-      return { pwm_r: p1, pwm_l: p2, en: p3 };
+      // Two outputs only: p1 = RPWM (MOTORx_IN_A), p2 = LPWM (MOTORx_IN_B).
+      return { in_a: p1, in_b: p2 };
     } else if (driverType === "GENERIC_2_IN") {
       return { pwm: p1, in_a: p2, in_b: p3 };
     } else if (driverType === "GENERIC_1_IN") {
@@ -1002,17 +1131,36 @@ function updateDynamicUIState() {
   document.getElementById("box-sonar-trig").style.display = sonarActive ? "flex" : "none";
   document.getElementById("box-sonar-echo").style.display = sonarActive ? "flex" : "none";
 
-  // Motor Headers based on Driver Type
+  // Motor pin matrix: header + how many of the 3 pin columns the driver
+  // actually uses. Columns beyond that are hidden, and any blank value in
+  // them is parked at -1 ("no connection") so it never reads as GPIO 0.
+  // A value the user has typed into a hidden column is left untouched.
   const headerEl = document.getElementById("motor-pin-headers");
   const invTh = `<th title="Invert this motor's spin direction">Invert</th>`;
+  let pinTh, activePins;
   if (driverType === "BTS7960") {
-    headerEl.innerHTML = `<th>Motor</th><th>PWM (n/c)</th><th>IN_A / PWM 1</th><th>IN_B / PWM 2</th>` + invTh;
+    pinTh = `<th>RPWM &rarr; IN_A</th><th>LPWM &rarr; IN_B</th>`;
+    activePins = 2;
   } else if (driverType === "GENERIC_2_IN") {
-    headerEl.innerHTML = `<th>Motor</th><th>PWM (Speed)</th><th>IN_A (Dir 1)</th><th>IN_B (Dir 2)</th>` + invTh;
+    pinTh = `<th>PWM (Speed)</th><th>IN_A (Dir 1)</th><th>IN_B (Dir 2)</th>`;
+    activePins = 3;
   } else if (driverType === "GENERIC_1_IN") {
-    headerEl.innerHTML = `<th>Motor</th><th>PWM (Speed)</th><th>DIR (Direction)</th><th>--</th>` + invTh;
-  } else {
-    headerEl.innerHTML = `<th>Motor</th><th>PWM Signal</th><th>--</th><th>--</th>` + invTh;
+    pinTh = `<th>PWM (Speed)</th><th>DIR (Direction)</th>`;
+    activePins = 2;
+  } else { // ESC
+    pinTh = `<th>PWM Signal</th>`;
+    activePins = 1;
+  }
+  headerEl.innerHTML = `<th>Motor</th>` + pinTh + invTh;
+  for (let i = 1; i <= 4; i++) {
+    for (let c = 1; c <= 3; c++) {
+      const el = document.getElementById(`pin-m${i}-p${c}`);
+      if (!el) continue;
+      const used = c <= activePins;
+      const cell = el.closest("td");
+      if (cell) cell.style.display = used ? "" : "none";
+      if (!used && el.value.trim() === "") el.value = "-1";
+    }
   }
 
   // HUD Tag
@@ -1120,9 +1268,8 @@ function validateRobotSpec(spec) {
   for (let i = 1; i <= numMotors; i++) {
     const m = pins[`motor${i}`] || {};
     if (driverType === "BTS7960") {
-      registerPin(m.pwm_r, `Motor ${i} PWM_R`, true);
-      registerPin(m.pwm_l, `Motor ${i} PWM_L`, true);
-      registerPin(m.en, `Motor ${i} Enable`, true);
+      registerPin(m.in_a !== undefined ? m.in_a : m.pwm_l, `Motor ${i} RPWM (IN_A)`, true);
+      registerPin(m.in_b !== undefined ? m.in_b : m.en, `Motor ${i} LPWM (IN_B)`, true);
     } else if (driverType === "GENERIC_2_IN") {
       registerPin(m.pwm, `Motor ${i} PWM`, true);
       registerPin(m.in_a, `Motor ${i} IN_A`, true);
@@ -1425,10 +1572,11 @@ function generateCppHeader(spec) {
   for (let i = 1; i <= 4; i++) {
     const m = pins[`motor${i}`] || {};
     if (driver === "BTS7960") {
-      // MOTORx_PWM = RPWM (unused placeholder), IN_A = LPWM, IN_B = EN
-      lines.push(`  #define MOTOR${i}_PWM ${pinVal(m.pwm_r !== undefined ? m.pwm_r : m.pwm)} //DON'T TOUCH THIS! This is just a placeholder`);
-      lines.push(`  #define MOTOR${i}_IN_A ${pinVal(m.pwm_l !== undefined ? m.pwm_l : m.in_a)}`);
-      lines.push(`  #define MOTOR${i}_IN_B ${pinVal(m.en !== undefined ? m.en : m.in_b)}`);
+      // BTS7960 uses two outputs only: IN_A = RPWM, IN_B = LPWM.
+      // MOTORx_PWM is an unused arg in the driver class -> fixed placeholder.
+      lines.push(`  #define MOTOR${i}_PWM -1 //DON'T TOUCH THIS! This is just a placeholder`);
+      lines.push(`  #define MOTOR${i}_IN_A ${pinVal(m.in_a !== undefined ? m.in_a : m.pwm_l)}`);
+      lines.push(`  #define MOTOR${i}_IN_B ${pinVal(m.in_b !== undefined ? m.in_b : m.en)}`);
     } else if (driver === "GENERIC_1_IN") {
       lines.push(`  #define MOTOR${i}_PWM ${pinVal(m.pwm)}`);
       lines.push(`  #define MOTOR${i}_IN_A ${pinVal(m.dir !== undefined ? m.dir : m.in_a)}`);
@@ -1524,16 +1672,6 @@ function generateCppHeader(spec) {
   if (i2cUsed && sda !== undefined && scl !== undefined && sda >= 0 && scl >= 0) {
     lines.push(``, `// I2C Bus`, `#define SDA_PIN ${sda}`, `#define SCL_PIN ${scl}`);
     const bi = [`#define BOARD_INIT { \\`];
-    if (driver === "BTS7960") {
-      for (let i = 1; i <= (is4WD ? 4 : 2); i++) {
-        const mm = pins[`motor${i}`] || {};
-        const pwm = mm.pwm_r !== undefined ? mm.pwm_r : mm.pwm;
-        if (pwm !== undefined && pwm >= 0) {
-          bi.push(`    pinMode(MOTOR${i}_PWM, OUTPUT); \\`);
-          bi.push(`    digitalWrite(MOTOR${i}_PWM, HIGH); \\`);
-        }
-      }
-    }
     bi.push(`    Wire.begin(SDA_PIN, SCL_PIN); \\`);
     bi.push(`    Wire.setClock(400000); \\`);
     bi.push(`}`);
@@ -1812,9 +1950,10 @@ function generateWiringTable(spec) {
   for (let i = 1; i <= numMotors; i++) {
     const m = pins[`motor${i}`] || {};
     if (driver === "BTS7960") {
-      rows.push(`| **Motor ${i} PWM_R** | \`GPIO ${m.pwm_r}\` | BTS7960 R_PWM | Forward PWM |`);
-      rows.push(`| **Motor ${i} PWM_L** | \`GPIO ${m.pwm_l}\` | BTS7960 L_PWM | Reverse PWM |`);
-      if (m.en !== undefined) rows.push(`| **Motor ${i} Enable** | \`GPIO ${m.en}\` | BTS7960 R_EN / L_EN | Enable Pin |`);
+      const inA = m.in_a !== undefined ? m.in_a : m.pwm_l;
+      const inB = m.in_b !== undefined ? m.in_b : m.en;
+      rows.push(`| **Motor ${i} RPWM** | \`GPIO ${inA}\` | BTS7960 RPWM -> MOTOR${i}_IN_A | Forward PWM |`);
+      rows.push(`| **Motor ${i} LPWM** | \`GPIO ${inB}\` | BTS7960 LPWM -> MOTOR${i}_IN_B | Reverse PWM |`);
     } else {
       rows.push(`| **Motor ${i} PWM** | \`GPIO ${m.pwm}\` | Driver PWM / ENA | Speed Control |`);
       rows.push(`| **Motor ${i} IN_A** | \`GPIO ${m.in_a}\` | Driver IN1 / DIR | Direction Line A |`);
@@ -2333,7 +2472,7 @@ function readAutomationOptions() {
     rosDistro: document.getElementById("auto-ros-distro")?.value || "jazzy",
     rosType: document.getElementById("auto-ros-type")?.value || "desktop",
     buildMicrorosAgent: document.getElementById("chk-build-microros-agent")?.checked ?? true,
-    gitBranch: document.getElementById("auto-git-branch")?.value.trim() || `config/${currentSpec.robot_name || "robot"}`,
+    gitBranch: document.getElementById("auto-git-branch")?.value.trim() || "",
     gitCommitMsg: document.getElementById("auto-git-commit-msg")?.value.trim() || `feat(config): add configuration for ${currentSpec.robot_name || "robot"}`,
     mergeHeader: document.getElementById("chk-merge-header")?.checked ?? true,
     mergePioFirmware: document.getElementById("chk-merge-pio-firmware")?.checked ?? true,
@@ -2358,13 +2497,8 @@ function updateAutomationPreviews() {
   const spec = currentSpec;
   const robotName = spec.robot_name || "scout_pico2";
 
-  // Dynamic Git Branch & Commit message if unset or auto-managed
-  const gitBranchInput = document.getElementById("auto-git-branch");
-  if (gitBranchInput && (!gitBranchInput.value || gitBranchInput.dataset.autoManaged === "true")) {
-    gitBranchInput.value = `config/${robotName}`;
-    gitBranchInput.dataset.autoManaged = "true";
-  }
-
+  // The git branch field tracks the Robot SBC's current branch (see
+  // applyCurrentBranch), not the robot name — do not overwrite it here.
   const gitCommitInput = document.getElementById("auto-git-commit-msg");
   if (gitCommitInput && (!gitCommitInput.value || gitCommitInput.dataset.autoManaged === "true")) {
     gitCommitInput.value = `feat(config): add configuration for ${robotName}`;
@@ -2532,7 +2666,7 @@ function getRos2InstallCmd(opts) {
 function getMergeAndCommitCmd(spec, opts) {
   const name = spec.robot_name || "my_robot";
   const nameUpper = name.toUpperCase();
-  const branch = opts.gitBranch || `config/${name}`;
+  const branch = (opts.gitBranch || "").trim();
   const commitMsg = opts.gitCommitMsg || `feat(config): add configuration for ${name}`;
   const headerContent = generateCppHeader(spec);
   const pioSection = generatePlatformioEnv(spec);
@@ -2540,9 +2674,13 @@ function getMergeAndCommitCmd(spec, opts) {
 
   const lines = [
     `set -e`,
-    `# 1. Create Isolated Git Branch`,
-    `git checkout -b "${branch}" 2>/dev/null || git checkout "${branch}"`,
-    ``,
+    ...(branch ? [
+      `# 1. Switch to (or create) the target branch`,
+      `if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then`,
+      `    git checkout -b "${branch}" 2>/dev/null || git checkout "${branch}"`,
+      `fi`,
+      ``,
+    ] : []),
     `# 2. Ingest Custom Header`,
     `mkdir -p config/custom urdf`,
     `cat << 'EOF_HEADER' > "config/custom/${name}_config.h"`,
@@ -2576,7 +2714,7 @@ function getMergeAndCommitCmd(spec, opts) {
     `if ! git diff --cached --quiet; then`,
     `    git commit -m "${commitMsg}"`,
     `else`,
-    `    echo "Configuration files already up to date on branch ${branch}."`,
+    `    echo "Configuration files already up to date on branch $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')."`,
     `fi`
   ];
 
@@ -2588,7 +2726,6 @@ function generateDeployScript(spec, opts) {
   const name = spec.robot_name || "my_robot";
   const nameUpper = name.toUpperCase();
   const mcu = (spec.mcu || "PICO2").toUpperCase();
-  const branch = opts.gitBranch || `config/${name}`;
   const commitMsg = opts.gitCommitMsg || `feat(config): add configuration for ${name}`;
   const target = opts.flashTarget || "firmware";
   const port = opts.flashPort || "/dev/ttyACM0";
@@ -2807,12 +2944,12 @@ fi` : ""}
 ` : `# ROS 2 Host setup skipped (Standalone Firmware mode)`}
 
 # -----------------------------------------------------------------------------
-# Phase 3: Git Branch Preparation
+# Phase 3: Git Branch
 # -----------------------------------------------------------------------------
-${opts.autoCommit ? `info "Step 3: Preparing Git branch '${branch}'..."
-if git rev-parse --is-inside-work-tree &>/dev/null; then
-    git checkout -b "${branch}" 2>/dev/null || git checkout "${branch}" || warn "Could not switch to branch '${branch}'; staying on the current branch."
-fi` : "# Git branch switch skipped (git automation disabled)"}
+# Full Deploy runs on whatever branch is checked out. To land the config on a
+# different branch, set it in the studio's "Git Branch Name" field and use
+# "Run Merge & Commit" (which checks that branch out first).
+${`if git rev-parse --is-inside-work-tree &>/dev/null; then info "Working on Git branch '$(git rev-parse --abbrev-ref HEAD)'."; fi`}
 
 # -----------------------------------------------------------------------------
 # Phase 4: Ingest Custom C++ Header
@@ -2890,7 +3027,7 @@ ${opts.autoCommit ? `if git rev-parse --is-inside-work-tree &>/dev/null; then
             git config user.name "Linorobot2 Deploy Engine" || true
         fi
         if git commit -m "${commitMsgEsc}"; then
-            success "Git commit created on branch '${branch}'"
+            success "Git commit created on branch '$(git rev-parse --abbrev-ref HEAD)'"
         else
             warn "git commit failed; the generated configuration remains staged."
         fi

--- a/tools/robot_config_engine/web/app.js
+++ b/tools/robot_config_engine/web/app.js
@@ -833,10 +833,12 @@ function populateFormFromSpec(spec) {
   const setCk  = (id, v) => { const el = document.getElementById(id); if (el) el.checked = !!v; };
   setVal("cfg-syslog-ip", adv.syslog_ip);
   setVal("cfg-syslog-port", adv.syslog_port);
+  setVal("cfg-wifi-monitor", adv.wifi_monitor);
   setVal("cfg-lidar-ip", adv.lidar_ip);
   setVal("cfg-lidar-port", adv.lidar_port);
   setVal("cfg-lidar-rxd", adv.lidar_rxd);
   setVal("cfg-lidar-uart", adv.lidar_serial);
+  setVal("cfg-lidar-baud", adv.lidar_baudrate);
   setVal("cfg-ota-hostname", adv.ota_hostname);
   setVal("cfg-ota-password", adv.ota_password);
   setVal("cfg-ota-ip", adv.ota_ip);
@@ -858,10 +860,14 @@ function populateFormFromSpec(spec) {
   } else {
     setNum("cfg-mag-bias-x", null); setNum("cfg-mag-bias-y", null); setNum("cfg-mag-bias-z", null);
   }
-  const covScalar = (v) => Array.isArray(v) ? (v.every(x => x === v[0]) ? v[0] : v[0]) : v;
+  const covScalar = (v) => Array.isArray(v) ? v[0] : v;
+  const covList = (v) => Array.isArray(v) ? v.join(", ") : (v ?? "");
   setNum("cfg-cov-accel", covScalar(tune.accel_cov));
   setNum("cfg-cov-gyro", covScalar(tune.gyro_cov));
   setNum("cfg-cov-ori", covScalar(tune.ori_cov));
+  setNum("cfg-cov-mag", covScalar(tune.mag_cov));
+  setNum("cfg-cov-pose", covList(tune.pose_cov));
+  setNum("cfg-cov-twist", covList(tune.twist_cov));
   setPinVal("pin-battery", p.battery_pin);
   setPinVal("pin-sonar-trig", p.sonar?.trig);
   setPinVal("pin-sonar-echo", p.sonar?.echo);
@@ -962,6 +968,22 @@ function readSpecFromForm() {
       if (ac !== null) t.accel_cov = ac;
       if (gc !== null) t.gyro_cov = gc;
       if (oc !== null) t.ori_cov = oc;
+      const mc = getFloatOrNull("cfg-cov-mag");
+      if (mc !== null) t.mag_cov = mc;
+      // POSE/TWIST_COV: scalar, or a comma list (usually 6); kept as typed.
+      const covField = (id) => {
+        const raw = (document.getElementById(id)?.value || "").trim();
+        if (!raw) return null;
+        if (raw.includes(",")) {
+          const arr = raw.split(",").map((x) => Number(x.trim()));
+          return arr.some((x) => Number.isNaN(x)) ? null : arr;
+        }
+        const n = Number(raw);
+        return Number.isNaN(n) ? null : n;
+      };
+      const pc = covField("cfg-cov-pose"), tc = covField("cfg-cov-twist");
+      if (pc !== null) t.pose_cov = pc;
+      if (tc !== null) t.twist_cov = tc;
       return t;
     })(),
     baudrate: document.getElementById("cfg-baudrate") ? parseInt(document.getElementById("cfg-baudrate").value, 10) : 921600,
@@ -999,11 +1021,12 @@ function readSpecFromForm() {
   spec.advanced = {
     syslog_ip: _v("cfg-syslog-ip"),
     syslog_port: getInt("cfg-syslog-port", 514),
+    wifi_monitor: getInt("cfg-wifi-monitor", 0),
     lidar_ip: _v("cfg-lidar-ip"),
     lidar_port: getInt("cfg-lidar-port", 8889),
     lidar_rxd: getInt("cfg-lidar-rxd", -1),
     lidar_serial: getInt("cfg-lidar-uart", 1),
-    lidar_baudrate: 230400,
+    lidar_baudrate: getInt("cfg-lidar-baud", 230400),
     ota_hostname: _v("cfg-ota-hostname"),
     ota_password: _v("cfg-ota-password"),
     ota_ip: _v("cfg-ota-ip"),
@@ -1111,6 +1134,24 @@ function updateDynamicUIState() {
   document.getElementById("wifi-config-box").style.display = (transport === "WIFI_UDP" || (isWifiMcu && wifiTelemetry)) ? "block" : "none";
   if (document.getElementById("group-serial-baudrate")) {
     document.getElementById("group-serial-baudrate").style.display = transport === "SERIAL" ? "block" : "none";
+  }
+  // Console serial monitor baud follows the firmware BAUDRATE until the user
+  // picks one explicitly (override for bootloader / MicroPython / other boards).
+  // "followedValue" is the last value we pushed; if the select no longer holds
+  // it, the user changed it by hand -> stop following.
+  const _cfgBaud = document.getElementById("cfg-baudrate");
+  const _monBaud = document.getElementById("serial-baud-select");
+  if (_cfgBaud && _monBaud) {
+    const _followed = _monBaud.dataset.followedValue;
+    if (_monBaud.dataset.autoManaged !== "false" &&
+        (_followed === undefined || _followed === _monBaud.value)) {
+      if ([..._monBaud.options].some((o) => o.value === _cfgBaud.value)) {
+        _monBaud.value = _cfgBaud.value;
+      }
+      _monBaud.dataset.followedValue = _monBaud.value;
+    } else {
+      _monBaud.dataset.autoManaged = "false";
+    }
   }
 
   // Watchdog Timeout Group
@@ -1614,14 +1655,24 @@ function generateCppHeader(spec) {
   if (Array.isArray(tune.mag_bias) && tune.mag_bias.length === 3) {
     lines.push(`#define MAG_BIAS { ${tune.mag_bias.map(Number).join(", ")} }`);
   }
-  const covLine = (macro, v) => {
-    if (v == null) return;
-    const t = Array.isArray(v) ? v.map(Number) : [Number(v), Number(v), Number(v)];
+  const covLine = (macro, v, n = 3) => {
+    if (v == null || v === "") return;
+    let t;
+    if (Array.isArray(v)) t = v.map(Number);
+    else {
+      const s = String(v).trim();
+      t = s.includes(",") ? s.split(",").map((x) => Number(x.trim()))
+                          : Array(n).fill(Number(s));
+    }
+    if (t.some((x) => Number.isNaN(x))) return;
     lines.push(`#define ${macro} { ${t.join(", ")} }`);
   };
   covLine("ACCEL_COV", tune.accel_cov);
   covLine("GYRO_COV", tune.gyro_cov);
   covLine("ORI_COV", tune.ori_cov);
+  covLine("MAG_COV", tune.mag_cov);
+  covLine("POSE_COV", tune.pose_cov, 6);
+  covLine("TWIST_COV", tune.twist_cov, 6);
 
   if (sensors.battery_monitor === "ADC_DIVIDER") {
     const numFmt = (x) => { const f = Number(x); return Number.isInteger(f) ? String(f) : String(f).replace(/0+$/,"").replace(/\.$/,""); };
@@ -1722,23 +1773,45 @@ function generateCppHeader(spec) {
   // Never emit WIFI_AP_LIST with a placeholder SSID — initWifis() blocks at
   // boot until it joins, so a placeholder would brick a bare board.
   const _haveRealSsid = wifi.ssid && wifi.ssid.trim() && wifi.ssid.trim() !== "YOUR_WIFI_SSID";
+
+  // For a WiFi-UDP transport the PlatformIO env pins board_microros_transport =
+  // wifi, so firmware.ino compiles `set_microros_net_transports(AGENT_IP,
+  // AGENT_PORT)` unconditionally — those two macros MUST exist even before the
+  // user fills in credentials. They are not secrets: emit compile-safe
+  // #ifndef-guarded defaults here, and let the git-ignored wifi_config.h
+  // override them once real values are entered.
+  if (isWifiTransport) {
+    const agentIp = adv.agent_ip || wifi.agent_ip || "192.168.1.100";
+    lines.push(
+      ``,
+      `// micro-ROS WiFi transport (credentials & host IPs -> git-ignored wifi_config.h)`,
+      `#if __has_include("wifi_config.h")`,
+      `  #include "wifi_config.h"`,
+      `#endif`,
+      `#define USE_WIFI`,
+      `#ifndef AGENT_IP`,
+      `  #define AGENT_IP ${ipC(agentIp)}`,
+      `#endif`,
+      `#ifndef AGENT_PORT`,
+      `  #define AGENT_PORT ${wifi.agent_port || 8888}`,
+      `#endif`
+    );
+  }
+
   if (enableWifiNet && _haveRealSsid) {
     // Secrets (WIFI_AP_LIST, AGENT_IP, SYSLOG_SERVER, LIDAR_SERVER, OTA_PASSWORD)
     // live ONLY in the git-ignored config/custom/wifi_config.h — this tracked
     // header carries the non-secret feature flags and pulls the rest in.
-    lines.push(
-      ``,
-      isWifiTransport
-        ? `// WiFi & micro-ROS Agent Settings`
-        : `// Background WiFi (OTA & Syslog telemetry while micro-ROS runs on Serial)`,
-      `// Credentials & host IPs are in the git-ignored config/custom/wifi_config.h`,
-      `// (regenerated by the deploy from your form; template: wifi_config.h.template).`,
-      `#if __has_include("wifi_config.h")`,
-      `  #include "wifi_config.h"`,
-      `#endif`
-    );
-    if (isWifiTransport) {
-      lines.push(`#define USE_WIFI`, `#define AGENT_PORT ${wifi.agent_port || 8888}`);
+    if (!isWifiTransport) {
+      lines.push(
+        ``,
+        `// Background WiFi (OTA & Syslog telemetry while micro-ROS runs on Serial)`,
+        `// Credentials & host IPs are in the git-ignored config/custom/wifi_config.h`,
+        `// (regenerated by the deploy from your form; template: wifi_config.h.template).`,
+        `#if __has_include("wifi_config.h")`,
+        `  #include "wifi_config.h"`,
+        `#endif`
+      );
     }
     lines.push(`#define USE_ARDUINO_OTA`);
     lines.push(`#define OTA_HOSTNAME "${adv.ota_hostname || spec.robot_name || "linorobot2"}"`);
@@ -1748,6 +1821,9 @@ function generateCppHeader(spec) {
       `#define DEVICE_HOSTNAME "${spec.robot_name || "robot"}"`,
       `#define APP_NAME "hardware"`
     );
+    if (adv.wifi_monitor && adv.wifi_monitor > 0) {
+      lines.push(`#define WIFI_MONITOR ${adv.wifi_monitor} // min. period to send WiFi RSSI to syslog`);
+    }
     // LiDAR-over-UDP forwarding — only when the user ticked "Forward LiDAR
     // over UDP" (a non-blank IP field default must NOT enable it; USE_LIDAR_UDP
     // pulls in ESP32-only HardwareSerial APIs that break the Pico build).
@@ -2491,6 +2567,15 @@ function readAutomationOptions() {
   };
 }
 
+// The firmware serial BAUDRATE chosen on Tab 1 (#cfg-baudrate). Single source
+// of truth for the micro-ROS agent -b flag and the console serial monitor.
+function firmwareBaud(spec) {
+  spec = spec || (typeof currentSpec !== "undefined" ? currentSpec : null) || {};
+  return spec.baudrate
+    || spec.telemetry?.baudrate
+    || ((spec.mcu || "").toUpperCase() === "GENDRV" ? 1500000 : 921600);
+}
+
 // Update Dynamic Previews across Tab 5
 function updateAutomationPreviews() {
   const opts = readAutomationOptions();
@@ -2557,7 +2642,8 @@ function updateAutomationPreviews() {
     const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
     const port = document.getElementById("auto-flash-port")?.value || (isESP32(spec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
     const multiPorts = document.getElementById("auto-agent-multiserial-ports")?.value.trim() || "/dev/ttyACM0 /dev/ttyUSB0";
-    const baud = document.getElementById("auto-agent-baud")?.value || "921600";
+    // Agent -b always matches the firmware BAUDRATE chosen on Tab 1.
+    const baud = firmwareBaud(spec);
     const isWiFi = /WIFI|UDP/i.test(spec.transport || "");
     if (isWiFi) {
       agentCmdEl.innerText = `source /opt/ros/${distro}/setup.bash && [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"; ros2 run micro_ros_agent micro_ros_agent udp4 --port 8888`;
@@ -3334,19 +3420,57 @@ async function sendSerialCommand() {
   writer.releaseLock();
 }
 
+// The console (#serial-terminal-screen) is fed by four unbounded streams —
+// /api/exec deploy output, `ros2 topic echo`, the UDP syslog stream and the
+// Web Serial monitor. Without a cap the <div> count grows until the browser
+// tab runs out of memory. Keep at most MAX_TERMINAL_LINES rows and drop the
+// oldest in chunks; autoscroll is coalesced onto one rAF so a fast stream
+// doesn't force a synchronous reflow per line.
+const MAX_TERMINAL_LINES = 4000;
+const TERMINAL_TRIM_CHUNK = 512;
+let _terminalScrollQueued = false;
+
+function _trimTerminal(screen) {
+  const over = screen.childElementCount - MAX_TERMINAL_LINES;
+  if (over <= 0) return;
+  for (let i = 0, n = over + TERMINAL_TRIM_CHUNK; i < n && screen.firstChild; i++) {
+    screen.removeChild(screen.firstChild);
+  }
+}
+
+function _queueTerminalScroll(screen) {
+  const autoScroll = document.getElementById("chk-serial-autoscroll")?.checked ?? true;
+  if (!autoScroll || _terminalScrollQueued) return;
+  _terminalScrollQueued = true;
+  requestAnimationFrame(() => {
+    _terminalScrollQueued = false;
+    screen.scrollTop = screen.scrollHeight;
+  });
+}
+
 function appendTerminalLine(text, type = "out") {
   const screen = document.getElementById("serial-terminal-screen");
   if (!screen) return;
-
   const lineEl = document.createElement("div");
   lineEl.className = `terminal-line terminal-${type}`;
   lineEl.innerText = text;
   screen.appendChild(lineEl);
+  _trimTerminal(screen);
+  _queueTerminalScroll(screen);
+}
 
-  const autoScroll = document.getElementById("chk-serial-autoscroll")?.checked ?? true;
-  if (autoScroll) {
-    screen.scrollTop = screen.scrollHeight;
-  }
+// Like appendTerminalLine but the caller supplies already-escaped innerHTML
+// (the syslog stream renders coloured multi-span rows). Goes through the same
+// line cap.
+function appendTerminalHtml(html, type = "out") {
+  const screen = document.getElementById("serial-terminal-screen");
+  if (!screen) return;
+  const lineEl = document.createElement("div");
+  lineEl.className = `terminal-line terminal-${type}`;
+  lineEl.innerHTML = html;
+  screen.appendChild(lineEl);
+  _trimTerminal(screen);
+  _queueTerminalScroll(screen);
 }
 
 function clearTerminalScreen() {
@@ -3577,7 +3701,7 @@ function initAutomationEventListeners() {
       const opts = readAutomationOptions();
       const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
       const port = document.getElementById("auto-flash-port")?.value.trim() || "/dev/ttyUSB0";
-      const baud = document.getElementById("auto-agent-baud")?.value || "921600";
+      const baud = firmwareBaud();
       const cmd = `[ -e "${port}" ] && [ ! -w "${port}" ] && sudo chmod a+rw "${port}" 2>/dev/null || true; source /opt/ros/${distro}/setup.bash && [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"; ros2 run micro_ros_agent micro_ros_agent serial --dev ${port} -b ${baud}`;
       executeCommandInTerminal(cmd, `Launching Single Serial micro-ROS Agent (${port} @ ${baud}) on Robot SBC`);
     });
@@ -3589,7 +3713,7 @@ function initAutomationEventListeners() {
       const opts = readAutomationOptions();
       const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
       const multiPorts = document.getElementById("auto-agent-multiserial-ports")?.value.trim() || "/dev/ttyACM0 /dev/ttyUSB0";
-      const baud = document.getElementById("auto-agent-baud")?.value || "921600";
+      const baud = firmwareBaud();
       const cmd = `for _d in ${multiPorts}; do [ -e "$_d" ] && [ ! -w "$_d" ] && sudo chmod a+rw "$_d" 2>/dev/null || true; done; source /opt/ros/${distro}/setup.bash && [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"; ros2 run micro_ros_agent micro_ros_agent multiserial --devs "${multiPorts}" -b ${baud}`;
       executeCommandInTerminal(cmd, `Launching Multi-Serial micro-ROS Agent (${multiPorts} @ ${baud}) on Robot SBC`);
     });
@@ -3618,13 +3742,6 @@ function initAutomationEventListeners() {
   if (multiPortsElem) {
     multiPortsElem.addEventListener("input", () => {
       multiPortsElem.dataset.autoManaged = "false";
-      updateAutomationPreviews();
-    });
-  }
-
-  const agentBaudElem = document.getElementById("auto-agent-baud");
-  if (agentBaudElem) {
-    agentBaudElem.addEventListener("change", () => {
       updateAutomationPreviews();
     });
   }
@@ -3739,6 +3856,7 @@ function initAutomationEventListeners() {
     btnSerialConnect.addEventListener("click", toggleWebSerialConnection);
   }
 
+
   const btnSerialClear = document.getElementById("btn-serial-clear");
   if (btnSerialClear) {
     btnSerialClear.addEventListener("click", clearTerminalScreen);
@@ -3811,6 +3929,10 @@ function applyHostIpDefaults(hostIp) {
 async function executeCommandInTerminal(command, title = "Executing Command") {
   const terminalScreen = document.getElementById("serial-terminal-screen");
   const btnCancel = document.getElementById("btn-cancel-exec");
+  // Only an adc_calibrate run streams the 4096-entry LUT; for every other
+  // command the per-line accumulate + substring scan below is dead weight that
+  // grows O(n) in memory and O(n^2) in CPU over a long build log.
+  const _isAdcCal = /\badc_calibrate\b/.test(command);
 
   // Scroll to terminal
   const terminalEl = document.querySelector(".web-serial-console-card");
@@ -3895,7 +4017,10 @@ async function executeCommandInTerminal(command, title = "Executing Command") {
     });
 
     if (!response.ok) {
-      appendTerminalLine(`❌ Server error: HTTP ${response.status}`, "err");
+      let detail = "";
+      try { detail = (await response.json())?.error || ""; } catch (_) {}
+      appendTerminalLine(`❌ ${detail || `Server error: HTTP ${response.status}`}`, "err");
+      if (detail) showToast(`⚠️ ${detail}`);
       if (btnCancel) btnCancel.style.display = "none";
       return;
     }
@@ -3966,10 +4091,10 @@ async function executeCommandInTerminal(command, title = "Executing Command") {
 
 
                 // Live ADC Calibration Stream Parser
-                if (payload.line.includes("Test Linearity") || payload.line.includes("Generating LUT") || payload.line.includes("ADC_LUT")) {
+                if (_isAdcCal && (textLine.includes("Test Linearity") || textLine.includes("Generating LUT") || textLine.includes("ADC_LUT"))) {
                   const statusText = document.getElementById("adc-status-text");
                   if (statusText) {
-                    statusText.innerText = payload.line.trim();
+                    statusText.innerText = String(textLine).trim();
                     statusText.style.color = "#38bdf8";
                   }
                 }
@@ -3988,8 +4113,8 @@ async function executeCommandInTerminal(command, title = "Executing Command") {
                   }
                 }
 
-                adcStreamBuffer += payload.line + "\n";
-                if (adcStreamBuffer.includes("ADC_LUT[4096]") && adcStreamBuffer.split("ADC_LUT[4096]").pop().includes("};")) {
+                if (_isAdcCal) adcStreamBuffer += textLine + "\n";
+                if (_isAdcCal && adcStreamBuffer.includes("ADC_LUT[4096]") && adcStreamBuffer.split("ADC_LUT[4096]").pop().includes("};")) {
                   try {
                     // Anchor on the LUT declaration so earlier build-log braces /
                     // numbers can't leak into the parsed array.
@@ -4054,6 +4179,21 @@ async function executeCommandInTerminal(command, title = "Executing Command") {
   } finally {
     if (btnCancel) btnCancel.style.display = "none";
     if (typeof execTimerInterval !== "undefined" && execTimerInterval) clearInterval(execTimerInterval);
+    // The hero-badge timer is otherwise only stopped on the "Deployment
+    // SUCCEEDED" line, so a failed / aborted / disconnected deploy leaks a
+    // 1 Hz setInterval (and stacks one more on every retry).
+    if (typeof deployTimerInterval !== "undefined" && deployTimerInterval) {
+      clearInterval(deployTimerInterval);
+      deployTimerInterval = null;
+      const _hb = document.getElementById("hero-deploy-badge");
+      if (_hb && _hb.className.indexOf("succeeded") === -1) {
+        _hb.className = "deploy-hero-badge";
+        const _ht = document.getElementById("hero-deploy-status-text");
+        if (_ht) _ht.innerText = "Idle";
+        const _htm = document.getElementById("hero-deploy-timer");
+        if (_htm) _htm.style.display = "none";
+      }
+    }
     const _ep = document.getElementById("exec-progress-pill");
     if (_ep && _ep.className.indexOf("pill-online") === -1 && _ep.className.indexOf("pill-offline") === -1) {
       _ep.style.display = "none";
@@ -5031,7 +5171,13 @@ async function checkSyslogStatus() {
 }
 
 function updateSyslogUIState(data) {
-  isSyslogRunning = !!data.running;
+  // /api/syslog/status reports data.running; the start/stop responses report
+  // data.status ("running"/"already_running"/"stopped"). Accept either.
+  const running = (typeof data.running === "boolean")
+    ? data.running
+    : (data.status === "running" || data.status === "already_running");
+  data = { ...data, running };
+  isSyslogRunning = running;
   const badge = document.getElementById('syslog-status-badge');
   const badgeText = document.getElementById('syslog-status-text');
   const btnStart = document.getElementById('btn-syslog-start');
@@ -5109,15 +5255,7 @@ async function startSyslogServer(requestedPort) {
       const fallbackNote = data.fallback ? ` (fell back to :${data.port})` : '';
       showToast(`🟢 Syslog Server listening on UDP port ${data.port}${fallbackNote}!`);
       
-      // Append notification to terminal
-      const terminalScreen = document.getElementById('serial-terminal-screen');
-      if (terminalScreen) {
-        const lineEl = document.createElement('div');
-        lineEl.className = 'terminal-line terminal-in';
-        lineEl.textContent = `[SYSLOG SERVER] Listening on UDP 0.0.0.0:${data.port} | Saving to ${data.logfile}`;
-        terminalScreen.appendChild(lineEl);
-        terminalScreen.scrollTop = terminalScreen.scrollHeight;
-      }
+      appendTerminalLine(`[SYSLOG SERVER] Listening on UDP 0.0.0.0:${data.port} | Saving to ${data.logfile}`, "in");
     } else {
       showToast(`⚠️ Failed to start syslog: ${data.error || 'Unknown error'}`);
     }
@@ -5136,14 +5274,7 @@ async function stopSyslogServer() {
       activeSyslogEventSource = null;
     }
     showToast(`⏹️ Syslog Server stopped. Total packets: ${data.packets || 0}`);
-    const terminalScreen = document.getElementById('serial-terminal-screen');
-    if (terminalScreen) {
-      const lineEl = document.createElement('div');
-      lineEl.className = 'terminal-line terminal-dim';
-      lineEl.textContent = `[SYSLOG SERVER] Stopped (Captured ${data.packets || 0} packets).`;
-      terminalScreen.appendChild(lineEl);
-      terminalScreen.scrollTop = terminalScreen.scrollHeight;
-    }
+    appendTerminalLine(`[SYSLOG SERVER] Stopped (Captured ${data.packets || 0} packets).`, "dim");
   } catch (e) {
     showToast(`⚠️ Syslog stop error: ${e.message}`);
   }
@@ -5175,20 +5306,12 @@ function connectSyslogStream() {
 
       const chkStream = document.getElementById('chk-stream-syslog-terminal');
       if (!chkStream || chkStream.checked) {
-        const terminalScreen = document.getElementById('serial-terminal-screen');
-        if (terminalScreen) {
-          const lineEl = document.createElement('div');
-          lineEl.className = 'terminal-line terminal-syslog';
-          const timePart = data.time ? data.time.split(' ')[1] || data.time : '';
-          const escapedMsg = (data.message || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-          lineEl.innerHTML = `<span class="badge-syslog">SYSLOG</span> <span class="syslog-time">${timePart}</span> <span class="syslog-sender">[${data.sender}]</span> <span class="syslog-msg">${escapedMsg}</span>`;
-          terminalScreen.appendChild(lineEl);
-          
-          const chkAutoScroll = document.getElementById('chk-serial-autoscroll');
-          if (!chkAutoScroll || chkAutoScroll.checked) {
-            terminalScreen.scrollTop = terminalScreen.scrollHeight;
-          }
-        }
+        const esc = (s) => String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        const timePart = data.time ? data.time.split(' ')[1] || data.time : '';
+        appendTerminalHtml(
+          `<span class="badge-syslog">SYSLOG</span> <span class="syslog-time">${esc(timePart)}</span> <span class="syslog-sender">[${esc(data.sender)}]</span> <span class="syslog-msg">${esc(data.message)}</span>`,
+          'syslog'
+        );
       }
     } catch (_) {}
   });

--- a/tools/robot_config_engine/web/app.js
+++ b/tools/robot_config_engine/web/app.js
@@ -412,7 +412,7 @@ function applyCurrentBranch(branch) {
 }
 
 // =============================================================================
-// Header Git Version Badge — shows the 8-char commit the web server booted on;
+// Header Git Version Badge — shows the 7-char commit the web server booted on;
 // click to reveal the branch, remotes and last 10 commits (GET /api/gitinfo).
 // =============================================================================
 function initGitVersionBadge() {
@@ -2825,7 +2825,15 @@ else
 fi` : "# Build tools check skipped"}
 
 ${opts.installPio ? `export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"
-if ! command -v pio &>/dev/null; then
+# "pio on PATH" is not enough — a stale/half-installed penv leaves a \`pio\`
+# entry-point that can no longer import platformio. Test that it actually runs.
+pio_ok() { command -v pio >/dev/null 2>&1 && pio --version >/dev/null 2>&1; }
+if ! pio_ok; then
+    if command -v pio >/dev/null 2>&1; then
+        warn "PlatformIO on PATH is broken (cannot import 'platformio') — rebuilding a clean venv..."
+        rm -rf "$HOME/.platformio/penv"
+        hash -r
+    fi
     info "Installing PlatformIO Core..."
     if ! curl -fsSL -o /tmp/get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py; then
         err "Could not download the PlatformIO installer (raw.githubusercontent.com unreachable)."
@@ -2836,11 +2844,22 @@ if ! command -v pio &>/dev/null; then
         exit 1
     fi
     export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"
+    hash -r
 fi
-if ! command -v pio &>/dev/null; then
-    err "PlatformIO Core is still not on PATH after installation."
+if ! pio_ok; then
+    err "PlatformIO Core is not working after installation ('pio --version' fails)."
     exit 1
 fi
+# The penv sometimes ships pip \`cmake\` / \`colcon\` shims that shadow the
+# working system tool but can't import their own modules — drop the dead ones.
+for _t in cmake colcon; do
+    _p="$HOME/.platformio/penv/bin/$_t"
+    if [ -e "$_p" ] && ! "$_p" --version >/dev/null 2>&1; then
+        warn "Removing broken PlatformIO penv shim: $_p"
+        rm -f "$_p"
+    fi
+done
+hash -r
 success "PlatformIO Core active: $(pio --version 2>/dev/null || echo 'Installed')"
 ` : "# PlatformIO install skipped"}
 
@@ -2886,7 +2905,11 @@ if [ ! -f "/opt/ros/${opts.rosDistro}/setup.bash" ]; then
 fi
 success "ROS 2 ${opts.rosDistro} available at /opt/ros/${opts.rosDistro}"
 
-${opts.buildMicrorosAgent ? `UROS_AGENT_BIN="$HOME/uros_ws/install/micro_ros_agent/lib/micro_ros_agent/micro_ros_agent"
+${opts.buildMicrorosAgent ? `# A failing agent-workspace build is NON-FATAL: the config merge/commit and the
+# firmware build + flash below do not need it. Only Phase 9 (agent handshake +
+# topic discovery) is skipped. AGENT_WS_OK tracks whether the agent is usable.
+AGENT_WS_OK=1
+UROS_AGENT_BIN="$HOME/uros_ws/install/micro_ros_agent/lib/micro_ros_agent/micro_ros_agent"
 # Rebuild if the agent binary is absent — colcon writes install/setup.bash even
 # when a package fails to compile, so that file alone is not proof of a build.
 if [ -d "/opt/ros/${opts.rosDistro}" ] && [ ! -x "$UROS_AGENT_BIN" ]; then
@@ -2898,49 +2921,45 @@ if [ -d "/opt/ros/${opts.rosDistro}" ] && [ ! -x "$UROS_AGENT_BIN" ]; then
         fi
     fi
     if ! command -v colcon >/dev/null 2>&1; then
-        err "colcon is required to build the micro-ROS agent but is not available."
-        err "Install 'python3-colcon-common-extensions', or set ROS Distro to 'none' to skip the agent build."
-        exit 1
-    fi
-    mkdir -p "$HOME/uros_ws/src"
-    pushd "$HOME/uros_ws" >/dev/null
-    # micro-ROS cuts a branch per ROS distro, but newer distros (e.g. lyrical)
-    # land in ROS before micro-ROS tags them — fall back to 'rolling', which
-    # builds fine against the current ROS headers.
-    uros_clone() {
-        local repo="\$1" dest="\$2"
-        git clone -b "${opts.rosDistro}" "\$repo" "\$dest" 2>/dev/null && return 0
-        warn "No '${opts.rosDistro}' branch for \$(basename \$repo .git); trying 'rolling'..."
-        git clone -b rolling "\$repo" "\$dest" 2>/dev/null && return 0
-        git clone "\$repo" "\$dest" 2>/dev/null && return 0
-        warn "Could not clone \$repo"
-        return 1
-    }
-    if [ ! -d "src/micro_ros_agent" ]; then
-        uros_clone https://github.com/micro-ROS/micro-ROS-Agent.git src/micro_ros_agent
-    fi
-    if [ ! -d "src/micro_ros_msgs" ]; then
-        uros_clone https://github.com/micro-ROS/micro_ros_msgs.git src/micro_ros_msgs
-    fi
-    if [ ! -d "src/micro_ros_agent" ] || [ ! -d "src/micro_ros_msgs" ]; then
+        warn "colcon is not available — skipping the micro-ROS agent build (firmware still builds & flashes)."
+        AGENT_WS_OK=0
+    else
+        mkdir -p "$HOME/uros_ws/src"
+        pushd "$HOME/uros_ws" >/dev/null
+        # micro-ROS cuts a branch per ROS distro, but newer distros (e.g. lyrical)
+        # land in ROS before micro-ROS tags them — fall back to 'rolling', which
+        # builds fine against the current ROS headers.
+        uros_clone() {
+            local repo="\$1" dest="\$2"
+            git clone -b "${opts.rosDistro}" "\$repo" "\$dest" 2>/dev/null && return 0
+            warn "No '${opts.rosDistro}' branch for \$(basename \$repo .git); trying 'rolling'..."
+            git clone -b rolling "\$repo" "\$dest" 2>/dev/null && return 0
+            git clone "\$repo" "\$dest" 2>/dev/null && return 0
+            warn "Could not clone \$repo"
+            return 1
+        }
+        [ -d "src/micro_ros_agent" ] || uros_clone https://github.com/micro-ROS/micro-ROS-Agent.git src/micro_ros_agent
+        [ -d "src/micro_ros_msgs" ]  || uros_clone https://github.com/micro-ROS/micro_ros_msgs.git src/micro_ros_msgs
+        if [ ! -d "src/micro_ros_agent" ] || [ ! -d "src/micro_ros_msgs" ]; then
+            warn "micro-ROS agent sources are missing — skipping the agent build."
+            AGENT_WS_OK=0
+        else
+            set +e
+            source "/opt/ros/${opts.rosDistro}/setup.bash"
+            colcon build --symlink-install \${COLCON_JOBS} --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+            COLCON_RC=\$?
+            set -e
+        fi
         popd >/dev/null
-        err "micro-ROS agent sources are missing; cannot build the agent workspace."
-        exit 1
+        if [ "\$AGENT_WS_OK" = "1" ] && { [ "\${COLCON_RC:-1}" -ne 0 ] || [ ! -x "$UROS_AGENT_BIN" ]; }; then
+            warn "micro-ROS agent workspace build FAILED at $HOME/uros_ws — micro-ROS-Agent may not support ROS 2 ${opts.rosDistro} yet (vendored spdlog vs system libfmt / GCC on newer distros)."
+            warn "Continuing anyway: config merge, git commit, firmware build and flash below are unaffected."
+            warn "To bridge the board afterwards, run an agent from a container, e.g.:  docker run --rm --net=host --privileged -v /dev:/dev microros/micro-ros-agent:${opts.rosDistro} serial --dev ${port} -b ${spec.baudrate || 921600}"
+            AGENT_WS_OK=0
+        fi
+        [ "\$AGENT_WS_OK" = "1" ] && success "micro-ROS agent workspace ready at $HOME/uros_ws"
     fi
-    set +e
-    source "/opt/ros/${opts.rosDistro}/setup.bash"
-    colcon build --symlink-install \${COLCON_JOBS} --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
-    COLCON_RC=$?
-    set -e
-    popd >/dev/null
-    if [ "\${COLCON_RC}" -ne 0 ] || [ ! -x "$UROS_AGENT_BIN" ]; then
-        err "Failed to build the micro-ROS agent workspace at $HOME/uros_ws."
-        err "micro-ROS-Agent may not yet support ROS 2 ${opts.rosDistro} (e.g. vendored spdlog vs the system libfmt on newer distros)."
-        err "The firmware build below is unaffected; run the agent from a supported distro or container."
-        exit 1
-    fi
-    success "micro-ROS agent workspace ready at $HOME/uros_ws"
-fi` : ""}
+fi` : "AGENT_WS_OK=0  # agent build not requested"}
 ` : `# ROS 2 Host setup skipped (Standalone Firmware mode)`}
 
 # -----------------------------------------------------------------------------
@@ -3093,10 +3112,10 @@ if [ "${target}" = "firmware" ] && [ "${opts.rosDistro}" != "none" ]; then
     ensure_serial_rw "${port}"
 
     if ! ros2 pkg prefix micro_ros_agent >/dev/null 2>&1; then
-        err "micro_ros_agent is not on the ROS 2 graph — the agent workspace did not build for '${opts.rosDistro}'."
-        err "Firmware was compiled and flashed successfully; bridge it with an agent from a supported distro/container."
-        exit 1
-    fi
+        warn "micro_ros_agent is not on the ROS 2 graph — the agent workspace did not build for '${opts.rosDistro}'."
+        warn "Firmware was built and flashed. Bridge the board with an agent from a supported distro/container, e.g.:"
+        warn "  docker run --rm --net=host --privileged -v /dev:/dev microros/micro-ros-agent:${opts.rosDistro} serial --dev ${port} -b ${spec.baudrate || 921600}"
+    else
 
     AGENT_LOG="/tmp/micro_ros_agent_${name}.log"
     info "Starting micro-ROS agent in background (logging to \${AGENT_LOG})..."
@@ -3152,6 +3171,7 @@ if [ "${target}" = "firmware" ] && [ "${opts.rosDistro}" != "none" ]; then
     info "========================================================="
     ros2 topic list -t 2>/dev/null || echo "  (no topics discovered yet)"
     info "========================================================="
+    fi
 fi
 
 info "========================================================="
@@ -3160,6 +3180,18 @@ info "========================================================="
 `;
 
   return script;
+}
+
+// Stage the generated deploy script on the Robot SBC and run it. Shared by the
+// header "Run Full Deploy" button and the Automation-tab hero card.
+function runFullDeploy() {
+  const spec = currentSpec;
+  const opts = readAutomationOptions();
+  const name = spec.robot_name || "scout_pico2";
+  const script = generateDeployScript(spec, opts);
+  const safeName = String(name).replace(/[^A-Za-z0-9._-]/g, "_");
+  const cmd = `cat << 'EOF_DEPLOY_SCRIPT_WRAPPER' > "deploy_${safeName}.sh"\n${script}\nEOF_DEPLOY_SCRIPT_WRAPPER\nchmod +x "deploy_${safeName}.sh" && bash "./deploy_${safeName}.sh"`;
+  executeCommandInTerminal(cmd, `Executing Full Deploy Lifecycle for '${name}'`);
 }
 
 // -----------------------------------------------------------------------------
@@ -3432,14 +3464,6 @@ function getDirectUploadOrBuildCmd(target, isUpload = true) {
 
 // Initialize Automation Event Listeners
 function initAutomationEventListeners() {
-  // Top Quick Deploy Button
-  const btnQuickDeploy = document.getElementById("btn-quick-deploy");
-  if (btnQuickDeploy) {
-    btnQuickDeploy.addEventListener("click", () => {
-      const tabBtn = document.querySelector('[data-tab="tab-automation"]');
-      if (tabBtn) tabBtn.click();
-    });
-  }
 
   // Re-detect OS Button
   const btnRedetect = document.getElementById("btn-redetect-os");
@@ -3661,14 +3685,18 @@ function initAutomationEventListeners() {
 
   const btnExecDeploy = document.getElementById("btn-exec-deploy-script");
   if (btnExecDeploy) {
-    btnExecDeploy.addEventListener("click", () => {
-      const spec = currentSpec;
-      const opts = readAutomationOptions();
-      const name = spec.robot_name || "scout_pico2";
-      const script = generateDeployScript(spec, opts);
-      const safeName = String(name).replace(/[^A-Za-z0-9._-]/g, "_");
-      const cmd = `cat << 'EOF_DEPLOY_SCRIPT_WRAPPER' > "deploy_${safeName}.sh"\n${script}\nEOF_DEPLOY_SCRIPT_WRAPPER\nchmod +x "deploy_${safeName}.sh" && bash "./deploy_${safeName}.sh"`;
-      executeCommandInTerminal(cmd, `Executing Full Deploy Lifecycle for '${name}'`);
+    btnExecDeploy.addEventListener("click", runFullDeploy);
+  }
+
+  // Header "Run Full Deploy" — jump to the Automation tab (so its terminal is
+  // visible) and kick off the same deploy. Keeps the first-run path short:
+  // set Robot Name -> "= name" -> Run Full Deploy.
+  const btnHeaderDeploy = document.getElementById("btn-header-deploy");
+  if (btnHeaderDeploy) {
+    btnHeaderDeploy.addEventListener("click", () => {
+      const tab = document.querySelector('[data-tab="tab-automation"]');
+      if (tab) tab.click();
+      runFullDeploy();
     });
   }
 
@@ -3687,13 +3715,20 @@ function initAutomationEventListeners() {
     });
   }
 
-  // Stream SBC Serial Monitor
+  // Stream SBC Serial Monitor — raw-read the MCU's serial port on the Robot SBC
+  // and pipe its output into the console. Pure coreutils (stty + cat), no
+  // pyserial dependency; press ⏹️ Stop Process to disconnect.
   const btnSbcMonitor = document.getElementById("btn-sbc-monitor");
   if (btnSbcMonitor) {
     btnSbcMonitor.addEventListener("click", () => {
       const port = document.getElementById("auto-flash-port")?.value.trim() || (isESP32(currentSpec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
       const baud = document.getElementById("serial-baud-select")?.value || "921600";
-      const cmd = `python3 -u -c "import serial, sys, time; ser = serial.Serial('${port}', ${baud}, timeout=0.2); print('📡 Connected to ${port} @ ${baud} baud. Streaming live microcontroller output (test_sensors / telemetry)... Click ⏹️ Stop Process to disconnect.\\n', flush=True); [sys.stdout.write(l.decode('utf-8', errors='replace')) or sys.stdout.flush() for l in iter(ser.readline, b'')] || true"`;
+      const cmd = [
+        `if [ ! -e "${port}" ]; then echo "❌ ${port} not present — plug in / flash the board first."; exit 1; fi`,
+        `stty -F "${port}" ${baud} raw -echo 2>/dev/null || true`,
+        `echo "📡 Connected to ${port} @ ${baud} baud. Streaming live microcontroller output (test_sensors / telemetry). Press ⏹️ Stop Process to disconnect."`,
+        `exec cat "${port}"`,
+      ].join("\n");
       executeCommandInTerminal(cmd, `📡 Streaming Serial Telemetry (${port} @ ${baud} baud)`);
     });
   }
@@ -4499,7 +4534,7 @@ async function loadExistingConfig(filename) {
 
 // Merge modified UI form settings into base configuration
 async function mergeCurrentConfig() {
-  readFormIntoSpec();
+  currentSpec = readSpecFromForm();
   try {
     const res = await fetch('/api/merge', {
       method: 'POST',
@@ -4524,10 +4559,10 @@ async function mergeCurrentConfig() {
 
 // Save merged configuration directly to config/custom/
 async function saveConfigToFirmware() {
-  readFormIntoSpec();
+  currentSpec = readSpecFromForm();
   const name = currentSpec.robot_name || 'robot';
   const filename = `${name}_config.h`;
-  const headerCode = generateCppConfigHeader(currentSpec);
+  const headerCode = generateCppHeader(currentSpec);
   try {
     const res = await fetch('/api/save', {
       method: 'POST',

--- a/tools/robot_config_engine/web/app.js
+++ b/tools/robot_config_engine/web/app.js
@@ -1,0 +1,7716 @@
+// Hardware USB MCU Classifier & Auto-detection Engine
+function guessMcuFromUsbDetail(detail) {
+  if (!detail) return null;
+  const vid = (detail.vid || "").toLowerCase();
+  const pid = (detail.pid || "").toLowerCase();
+  const chip = (detail.chip || "").toLowerCase();
+  const product = (detail.product || "").toLowerCase();
+
+  // Raspberry Pi (VID 2e8a): distinguish RP2350 (Pico 2) from RP2040 (Pico) by
+  // USB PID / product string — BOOTSEL is only a mode label, never the deciding
+  // factor (a Pico 2 in BOOTSEL is 2e8a:000f, still an RP2350).
+  if (vid === "2e8a" || chip.includes("rp204") || chip.includes("rp235") || product.includes("pico")) {
+    const isPico2 = ["000f", "0005", "0009"].includes(pid)
+      || chip.includes("rp2350") || chip.includes("pico 2") || product.includes("pico 2");
+    const bootsel = !!detail.is_bootsel;
+    return isPico2
+      ? { mcu: "PICO2", baudrate: 921600, preset: "bare", isBootsel: bootsel,
+          chipName: "Raspberry Pi Pico 2 (RP2350)" + (bootsel ? " [BOOTSEL Mode]" : "") }
+      : { mcu: "PICO", baudrate: 921600, preset: "bare", isBootsel: bootsel,
+          chipName: "Raspberry Pi Pico (RP2040)" + (bootsel ? " [BOOTSEL Mode]" : "") };
+  }
+  if (vid === "303a" || chip.includes("esp32-s3") || product.includes("esp32-s3")) {
+    return { mcu: "ESP32S3", baudrate: 921600, chipName: "ESP32-S3 (Native USB CDC)", preset: "bare" };
+  }
+  // CP2102N (Silicon Labs) is rated for and HW-verified at 1.5M baud (same
+  // bridge chip as GenDrv) — default straight to the high-throughput rate.
+  // CP2102N and plain CP2102 share the same VID:PID (10c4:ea60); server.py's
+  // chip string is the only thing that tells them apart (via the USB product
+  // descriptor), so trust it exactly rather than re-guessing from vid/mfr —
+  // a plain CP2102 (max ~1 Mbps per datasheet) must NOT take this branch.
+  if (chip.includes("gendrv") || product.includes("general driver") || chip.includes("cp2102n")) {
+    return { mcu: "ESP32", baudrate: 1500000, supportsHighBaud: true, chipName: "ESP32 DevKit (CP2102N)", preset: "bare" };
+  }
+  // FTDI FT232-family bridges are also reliable well past 921600.
+  if (chip.includes("ftdi")) {
+    return { mcu: "ESP32", baudrate: 1500000, supportsHighBaud: true, chipName: "ESP32 Microcontroller (FTDI)", preset: "bare" };
+  }
+  // CH340/CH341 and unidentified/plain CP210x bridges: no 1.5M reliability
+  // guarantee (plain CP2102 is rated ~1 Mbps max) — keep the conservative
+  // baseline and don't offer a speed the chip isn't confirmed to support.
+  if (chip.includes("esp32") || chip.includes("cp210") || chip.includes("ch340")) {
+    return { mcu: "ESP32", baudrate: 921600, supportsHighBaud: false, chipName: "ESP32 Microcontroller", preset: "bare" };
+  }
+  return null;
+}
+
+// Reflect a detected USB bridge chip onto the baud-rate UI: hide the 1.5M
+// option when the chip isn't confirmed to support it (e.g. a plain CP2102,
+// max ~1 Mbps), show/select it when it is, and display which chip drove
+// the decision. Native-USB-CDC boards (Pico/Pico2/ESP32-S3) don't set
+// `supportsHighBaud` and are left untouched — there's no bridge chip to
+// rate-limit them.
+// A freshly detected board is almost never a wired-up robot yet -- it is a
+// module someone just plugged in. Default it to fake wheel mode so the very
+// next thing they do (teleop, SLAM, Nav2 from Console) actually works, instead
+// of a silent zero-RPM robot. Only ever applied while the user has not touched
+// the simulation controls themselves, so an explicit choice is never undone.
+let userTouchedSimulation = false;
+
+function defaultSimulationForDetectedModule(chipName) {
+  if (userTouchedSimulation) return;
+  const fw = document.getElementById("cfg-fake-wheel");
+  if (!fw || fw.checked) return;
+  fw.checked = true;
+  fw.dispatchEvent(new Event("change"));
+  showToast(`🎮 ${chipName || "New module"} detected — fake wheel mode on so you can drive it untouched. Turn it off once the drivetrain is wired.`);
+}
+
+function applyDetectedChipToBaudUi(guessed) {
+  const baudSelect = document.getElementById("cfg-baudrate");
+  const hint = document.getElementById("cfg-baudrate-chip-hint");
+  if (!baudSelect) return;
+  const opt1500k = baudSelect.querySelector('option[value="1500000"]');
+  if (guessed && typeof guessed.supportsHighBaud === "boolean") {
+    if (opt1500k) {
+      opt1500k.hidden = !guessed.supportsHighBaud;
+      opt1500k.disabled = !guessed.supportsHighBaud;
+    }
+    if (!guessed.supportsHighBaud && baudSelect.value === "1500000") {
+      baudSelect.value = "921600";
+    }
+    if (guessed.baudrate) baudSelect.value = String(guessed.baudrate);
+    if (hint) {
+      hint.textContent = guessed.supportsHighBaud
+        ? `⚡ Detected: ${guessed.chipName} — 1.5M baud supported, suggested.`
+        : `Detected: ${guessed.chipName} — 1.5M not supported by this chip, hidden.`;
+      hint.style.display = "block";
+    }
+  } else if (guessed) {
+    if (guessed.baudrate) baudSelect.value = String(guessed.baudrate);
+    if (hint) hint.style.display = "none";
+  }
+}
+
+/**
+ * Linorobot2 Robot Configuration Engine - Client-Side App Logic
+ * Pure JavaScript - 100% Client-Side Safe, Zero-Dependency
+ */
+
+// When a board is auto-detected, propose a unique robot name postfixed with
+// the MCU family (e.g. rover_esp32s3) — but never overwrite a name the user
+// deliberately typed or picked. Returns null when the current name looks
+// intentional.
+function proposeMcuRobotName(mcu) {
+  const el = document.getElementById("cfg-robot-name");
+  if (!el || !mcu) return null;
+  const cur = (el.value || "").trim().toLowerCase();
+  let presetNames = [];
+  try { presetNames = Object.values(PRESETS || {}).map(p => p && p.robot_name).filter(Boolean); } catch (e) {}
+  const replaceable = new Set(["", "my_robot", "robot", "scout_pico2", ...presetNames]);
+  if (!replaceable.has(cur) && !/^rover_[a-z0-9]+(_\d+)?$/.test(cur)) return null;
+  const base = `rover_${String(mcu).toLowerCase().replace(/[^a-z0-9]/g, "")}`;
+  const taken = new Set((typeof existingConfigsList !== "undefined" ? existingConfigsList : [])
+    .map(c => String(c.filename || "").replace(/_config\.h$/, "")));
+  if (!taken.has(base)) return base;
+  for (let i = 2; i < 50; i++) if (!taken.has(`${base}_${i}`)) return `${base}_${i}`;
+  return base;
+}
+
+function applyMcuRobotName(mcu) {
+  const name = proposeMcuRobotName(mcu);
+  if (!name) return;
+  const el = document.getElementById("cfg-robot-name");
+  el.value = name;
+  el.dispatchEvent(new Event("input"));
+}
+
+// MCU Pin Constraints Constants
+const ESP32_STRAPPING_PINS = [0, 2, 12, 14, 15];
+const ESP32_INPUT_ONLY_PINS = [34, 35, 36, 39];
+const ESP32_FLASH_PINS = [6, 7, 8, 9, 10, 11];
+const ESP32S3_STRAPPING_PINS = [0, 3, 45, 46];
+const RP2040_ADC_PINS = [26, 27, 28, 29];
+
+// Reference Build Presets
+const PRESETS = {
+  // Bare module: nothing wired. Every pin is -1 ("no connection") so the
+  // firmware never drives a line that might be connected to an external
+  // peripheral — including the I2C bus (see firmware.ino: SDA_PIN/SCL_PIN < 0
+  // skips Wire.begin()). This is the initial state.
+  bare: {
+    robot_name: "bare_module", kinematics: "DIFFERENTIAL_DRIVE", mcu: "PICO2", transport: "SERIAL",
+    geometry: { wheel_diameter: 0.065, track_width: 0.20, wheelbase: 0.15, weight: 2.5 },
+    motors: { driver_type: "BTS7960", max_rpm: 330, cpr: 1320, operating_voltage: 12.0,
+              motor1_inv: false, motor2_inv: true, motor3_inv: false, motor4_inv: true },
+    sensors: { imu: "FAKE", mag: "NONE", battery_monitor: "NONE", sonar: false },
+    pins: {
+      led: -1,
+      motor1: { pwm: -1, in_a: -1, in_b: -1, pwm_r: -1, pwm_l: -1, en: -1, dir: -1 },
+      motor2: { pwm: -1, in_a: -1, in_b: -1, pwm_r: -1, pwm_l: -1, en: -1, dir: -1 },
+      motor3: { pwm: -1, in_a: -1, in_b: -1, pwm_r: -1, pwm_l: -1, en: -1, dir: -1 },
+      motor4: { pwm: -1, in_a: -1, in_b: -1, pwm_r: -1, pwm_l: -1, en: -1, dir: -1 },
+      encoders: { m1_a: -1, m1_b: -1, m2_a: -1, m2_b: -1, m3_a: -1, m3_b: -1, m4_a: -1, m4_b: -1 },
+      i2c: { sda: -1, scl: -1 }, battery_pin: -1, sonar: { trig: -1, echo: -1 }
+    }
+  },
+  pico2_diff: {
+    robot_name: "pico2_diff", kinematics: "DIFFERENTIAL_DRIVE", mcu: "PICO2", transport: "SERIAL",
+    geometry: { wheel_diameter: 0.065, track_width: 0.20, wheelbase: 0.15, weight: 2.5 },
+    motors: { driver_type: "BTS7960", max_rpm: 330, cpr: 1320, operating_voltage: 12.0,
+              motor1_inv: false, motor2_inv: true, motor3_inv: false, motor4_inv: true },
+    sensors: { imu: "FAKE", mag: "NONE", battery_monitor: "NONE", sonar: false },
+    pins: {
+      led: 25,
+      motor1: { pwm_r: 10, pwm_l: 11, en: 12 }, motor2: { pwm_r: 13, pwm_l: 14, en: 15 },
+      encoders: { m1_a: 2, m1_b: 3, m2_a: 4, m2_b: 5 },
+      i2c: { sda: 0, scl: 1 }, battery_pin: 26, sonar: { trig: 22, echo: 27 }
+    }
+  },
+  pico2_mecanum: {
+    robot_name: "pico2_mecanum", kinematics: "MECANUM", mcu: "PICO2", transport: "SERIAL",
+    geometry: { wheel_diameter: 0.08, track_width: 0.26, wheelbase: 0.22, weight: 4.0 },
+    motors: { driver_type: "BTS7960", max_rpm: 330, cpr: 1440, operating_voltage: 12.0,
+              motor1_inv: false, motor2_inv: true, motor3_inv: false, motor4_inv: true },
+    sensors: { imu: "FAKE", mag: "NONE", battery_monitor: "NONE", sonar: false },
+    pins: {
+      led: 25,
+      motor1: { pwm_r: 6, pwm_l: 7, en: 8 }, motor2: { pwm_r: 9, pwm_l: 10, en: 11 },
+      motor3: { pwm_r: 12, pwm_l: 13, en: 14 }, motor4: { pwm_r: 15, pwm_l: 16, en: 17 },
+      encoders: { m1_a: 0, m1_b: 1, m2_a: 2, m2_b: 3, m3_a: 4, m3_b: 5, m4_a: 18, m4_b: 19 },
+      i2c: { sda: 20, scl: 21 }, battery_pin: 26, sonar: { trig: 22, echo: 27 }
+    }
+  },
+  pico2_skid: {
+    robot_name: "pico2_skid", kinematics: "SKID_STEER", mcu: "PICO2", transport: "SERIAL",
+    geometry: { wheel_diameter: 0.08, track_width: 0.24, wheelbase: 0.20, weight: 4.0 },
+    motors: { driver_type: "BTS7960", max_rpm: 330, cpr: 1440, operating_voltage: 12.0,
+              motor1_inv: false, motor2_inv: true, motor3_inv: false, motor4_inv: true },
+    sensors: { imu: "FAKE", mag: "NONE", battery_monitor: "NONE", sonar: false },
+    pins: {
+      led: 25,
+      motor1: { pwm_r: 6, pwm_l: 7, en: 8 }, motor2: { pwm_r: 9, pwm_l: 10, en: 11 },
+      motor3: { pwm_r: 12, pwm_l: 13, en: 14 }, motor4: { pwm_r: 15, pwm_l: 16, en: 17 },
+      encoders: { m1_a: 0, m1_b: 1, m2_a: 2, m2_b: 3, m3_a: 4, m3_b: 5, m4_a: 18, m4_b: 19 },
+      i2c: { sda: 20, scl: 21 }, battery_pin: 26, sonar: { trig: 22, echo: 27 }
+    }
+  },
+  scout_pico2w: {
+    robot_name: "scout_pico2w",
+    kinematics: "DIFFERENTIAL_DRIVE",
+    mcu: "PICO2W",
+    transport: "SERIAL",
+    wifi_telemetry: false,
+    geometry: { wheel_diameter: 0.08, track_width: 0.22, wheelbase: 0.20, weight: 3.5 },
+    motors: { driver_type: "BTS7960", max_rpm: 330, cpr: 1320, motor1_inv: false, motor2_inv: true },
+    sensors: { imu: "FAKE", mag: "NONE", battery_monitor: "NONE", sonar: false }
+    ,
+    pins: {
+      motor1: { pwm: 14, in_a: 15, in_b: 13 },
+      motor2: { pwm: 16, in_a: 17, in_b: 12 },
+      encoders: { m1_a: 2, m1_b: 3, m2_a: 4, m2_b: 5 },
+      i2c: { sda: 8, scl: 9 },
+      battery_pin: 26,
+      sonar: { trig: 18, echo: 19 }
+    }
+  },
+  scout_pico2: {
+    robot_name: "scout_pico2",
+    kinematics: "DIFFERENTIAL_DRIVE",
+    mcu: "PICO2",
+    transport: "SERIAL",
+    geometry: {
+      wheel_diameter: 0.08,
+      track_width: 0.22,
+      wheelbase: 0.20,
+      weight: 3.5
+    },
+    motors: {
+      driver_type: "GENERIC_2_IN",
+      max_rpm: 330,
+      cpr: 1320,
+      operating_voltage: 12.0,
+      rated_torque: 1.5,
+      rated_voltage: 12.0,
+      motor1_inv: false,
+      motor2_inv: true,
+      motor3_inv: false,
+      motor4_inv: true
+    },
+    sensors: {
+      imu: "FAKE",
+      mag: "NONE",
+      battery_monitor: "NONE",
+      sonar: false
+    }
+    ,
+    pins: {
+      led: 25,
+      motor1: { pwm: 10, in_a: 11, in_b: 12 },
+      motor2: { pwm: 13, in_a: 14, in_b: 15 },
+      motor3: { pwm: 16, in_a: 17, in_b: 18 },
+      motor4: { pwm: 19, in_a: 20, in_b: 21 },
+      encoders: { m1_a: 2, m1_b: 3, m2_a: 4, m2_b: 5, m3_a: 6, m3_b: 7, m4_a: 8, m4_b: 9 },
+      i2c: { sda: 0, scl: 1 },
+      battery_pin: 26,
+      sonar: { trig: 22, echo: 27 }
+    }
+  },
+
+  mech_pico2: {
+    robot_name: "mech_pico2",
+    kinematics: "MECANUM",
+    mcu: "PICO2",
+    transport: "SERIAL",
+    geometry: {
+      wheel_diameter: 0.08,
+      track_width: 0.26,
+      wheelbase: 0.22,
+      weight: 4.0
+    },
+    motors: {
+      driver_type: "GENERIC_2_IN",
+      max_rpm: 330,
+      cpr: 1440,
+      operating_voltage: 12.0,
+      rated_torque: 2.0,
+      rated_voltage: 12.0,
+      motor1_inv: false,
+      motor2_inv: true,
+      motor3_inv: false,
+      motor4_inv: true
+    },
+    sensors: {
+      imu: "FAKE",
+      mag: "NONE",
+      battery_monitor: "ADC_DIVIDER",
+      battery_capacity: 3.0,
+      battery_nominal_voltage: 11.1,
+      battery_min_voltage: 9.0,
+      battery_max_voltage: 12.6,
+      sonar: true
+    },
+    pins: {
+      led: 25,
+      motor1: { pwm: 10, in_a: 11, in_b: 12 },
+      motor2: { pwm: 13, in_a: 14, in_b: 15 },
+      motor3: { pwm: 16, in_a: 17, in_b: 18 },
+      motor4: { pwm: 19, in_a: 20, in_b: 21 },
+      encoders: { m1_a: 2, m1_b: 3, m2_a: 4, m2_b: 5, m3_a: 6, m3_b: 7, m4_a: 8, m4_b: 9 },
+      i2c: { sda: 0, scl: 1 },
+      battery_pin: 26,
+      sonar: { trig: 22, echo: 27 }
+    }
+  },
+
+  mech_esp32: {
+    robot_name: "mech_esp32",
+    kinematics: "MECANUM",
+    mcu: "ESP32",
+    transport: "WIFI_UDP",
+    wifi_settings: {
+      ssid: "YOUR_WIFI_SSID",
+      password: "YOUR_WIFI_PASSWORD",
+      agent_ip: "192.168.1.100",
+      agent_port: 8888
+    },
+    geometry: {
+      wheel_diameter: 0.08,
+      track_width: 0.28,
+      wheelbase: 0.24
+    },
+    motors: {
+      driver_type: "GENERIC_2_IN",
+      max_rpm: 300,
+      cpr: 1500,
+      operating_voltage: 12.0,
+      motor1_inv: false,
+      motor2_inv: true,
+      motor3_inv: false,
+      motor4_inv: true
+    },
+    sensors: {
+      imu: "BNO085",
+      mag: "NONE",
+      battery_monitor: "INA219",
+      sonar: false
+    },
+    pins: {
+      led: 2,
+      motor1: { pwm: 13, in_a: 14, in_b: 27 },
+      motor2: { pwm: 25, in_a: 26, in_b: 33 },
+      motor3: { pwm: 18, in_a: 19, in_b: 23 },
+      motor4: { pwm: 15, in_a: 16, in_b: 17 },
+      encoders: { m1_a: 34, m1_b: 35, m2_a: 36, m2_b: 39, m3_a: 4, m3_b: 32, m4_a: 5, m4_b: 12 },
+      i2c: { sda: 21, scl: 22 },
+      battery_pin: 36,
+      sonar: { trig: 0, echo: 0 }
+    }
+  },
+
+  crawler_esp32s3: {
+    robot_name: "crawler_esp32s3",
+    kinematics: "SKID_STEER",
+    mcu: "ESP32S3",
+    transport: "SERIAL",
+    geometry: {
+      wheel_diameter: 0.085,
+      track_width: 0.26,
+      wheelbase: 0.22
+    },
+    motors: {
+      driver_type: "GENERIC_2_IN",
+      max_rpm: 280,
+      cpr: 1400,
+      operating_voltage: 12.0,
+      motor1_inv: false,
+      motor2_inv: true,
+      motor3_inv: false,
+      motor4_inv: true
+    },
+    sensors: {
+      imu: "MPU6050",
+      mag: "NONE",
+      battery_monitor: "ADC_DIVIDER",
+      sonar: true
+    },
+    pins: {
+      led: 48,
+      motor1: { pwm: 1, in_a: 2, in_b: 4 },
+      motor2: { pwm: 5, in_a: 6, in_b: 7 },
+      motor3: { pwm: 8, in_a: 9, in_b: 10 },
+      motor4: { pwm: 11, in_a: 12, in_b: 13 },
+      encoders: { m1_a: 14, m1_b: 15, m2_a: 16, m2_b: 17, m3_a: 18, m3_b: 21, m4_a: 38, m4_b: 39 },
+      i2c: { sda: 41, scl: 42 },
+      battery_pin: 3,
+      sonar: { trig: 47, echo: 40 }
+    }
+  },
+
+  waveshare_gendrv: {
+    robot_name: "waveshare_gendrv",
+    kinematics: "DIFFERENTIAL_DRIVE",
+    mcu: "GENDRV",
+    transport: "SERIAL",
+    baudrate: 1500000,
+    dual_core: true,
+    geometry: {
+      wheel_diameter: 0.065,
+      track_width: 0.20,
+      wheelbase: 0.18
+    },
+    motors: {
+      driver_type: "BTS7960",
+      max_rpm: 330,
+      cpr: 1320,
+      operating_voltage: 12.0,
+      motor1_inv: false,
+      motor2_inv: false,
+      motor3_inv: false,
+      motor4_inv: false
+    },
+    sensors: {
+      imu: "QMI8658",
+      mag: "AK09918",
+      battery_monitor: "INA219",
+      sonar: false
+    },
+    pins: {
+      led: -1,
+      motor1: { in_a: 17, in_b: 21 },
+      motor2: { in_a: 23, in_b: 22 },
+      encoders: { m1_a: 34, m1_b: 35, m2_a: 16, m2_b: 27 },
+      i2c: { sda: 32, scl: 33 },
+      battery_pin: -1,
+      sonar: { trig: -1, echo: -1 }
+    }
+  },
+
+  // ── Simulation-first designs ────────────────────────────────────────────
+  // A board on a desk with nothing wired to it, that still drives and maps.
+  // Both run fake wheel mode and the fake LD19, so cmd_vel produces odometry
+  // and /scan, and Console can go straight to teleop, SLAM and Nav2.
+  gendrv_serial_ld19: {
+    robot_name: "gendrv_serial_ld19",
+    kinematics: "DIFFERENTIAL_DRIVE",
+    mcu: "GENDRV",
+    transport: "SERIAL",
+    baudrate: 1500000,
+    // Off, and stated here rather than left to the generator to suppress: the
+    // fake LiDAR drives the simulated pose and its UART from the loop while a
+    // dual-core control task drives the same pose from the other core, with no
+    // lock between them, and the board crash-loops. Anyone reading this design
+    // should see the choice, not discover it from the generated header.
+    dual_core: false,
+    geometry: { wheel_diameter: 0.065, track_width: 0.20, wheelbase: 0.18, weight: 3.5 },
+    motors: {
+      driver_type: "BTS7960", max_rpm: 330, cpr: 1320, operating_voltage: 12.0,
+      motor1_inv: false, motor2_inv: false, motor3_inv: false, motor4_inv: false
+    },
+    sensors: { imu: "QMI8658", mag: "AK09918", battery_monitor: "INA219", sonar: false },
+    // Spelled out rather than left to the form defaults. A reference design
+    // that relies on defaults silently changes when they do -- which is how
+    // this one shipped a 6x4 m room after the default grew to 16x12.
+    simulation: {
+      fake_wheel: true, fake_ld19: true, fake_sonar: true,
+      map_width: 10.0, map_height: 6.0,
+      wall_obstacle: true, wall_x1: 2.0, wall_y1: -1.5, wall_x2: 2.0, wall_y2: 1.5
+    },
+    pins: {
+      led: -1,
+      motor1: { in_a: 17, in_b: 21 },
+      motor2: { in_a: 23, in_b: 22 },
+      encoders: { m1_a: 34, m1_b: 35, m2_a: 16, m2_b: 27 },
+      i2c: { sda: 32, scl: 33 },
+      battery_pin: -1,
+      // IO4 is the gendrv's LiDAR data line and is wired on the reference
+      // board, so the emulated scan has a route out over this UART -- the same
+      // line a real LD19 would feed in on. On a board where it is not wired,
+      // clear this to -1: the generator then leaves fake LD19 disabled rather
+      // than writing packets into an unconnected pad. (The WiFi design needs no
+      // pin at all: it sends the scan over UDP.)
+      lidar_rxd: 4,
+      sonar: { trig: -1, echo: -1 }
+    }
+  },
+
+  esp32_wifi_ld19: {
+    robot_name: "esp32_wifi_ld19",
+    kinematics: "DIFFERENTIAL_DRIVE",
+    mcu: "ESP32",
+    transport: "WIFI_UDP",
+    wifi_settings: {
+      ssid: "YOUR_WIFI_SSID",
+      password: "YOUR_WIFI_PASSWORD",
+      agent_ip: "192.168.1.100",
+      agent_port: 8888
+    },
+    // The simulated scan is delivered over WiFi UDP. That is the whole point of
+    // this design: no LiDAR UART pin, and no second cable to the board.
+    telemetry: { use_lidar_udp: true },
+    // Same reason as the serial design: simulation and a dual-core control
+    // task race on the pose with no lock and crash-loop the board.
+    dual_core: false,
+    geometry: { wheel_diameter: 0.065, track_width: 0.20, wheelbase: 0.15, weight: 3.5 },
+    motors: {
+      driver_type: "GENERIC_2_IN", max_rpm: 300, cpr: 1500, operating_voltage: 12.0,
+      motor1_inv: false, motor2_inv: true, motor3_inv: false, motor4_inv: true
+    },
+    sensors: { imu: "FAKE", mag: "NONE", battery_monitor: "NONE", sonar: false },
+    // Spelled out rather than left to the form defaults. A reference design
+    // that relies on defaults silently changes when they do -- which is how
+    // this one shipped a 6x4 m room after the default grew to 16x12.
+    simulation: {
+      fake_wheel: true, fake_ld19: true, fake_sonar: true,
+      map_width: 10.0, map_height: 6.0,
+      wall_obstacle: true, wall_x1: 2.0, wall_y1: -1.5, wall_x2: 2.0, wall_y2: 1.5
+    },
+    pins: {
+      led: 2,
+      motor1: { pwm: 13, in_a: 14, in_b: 27 },
+      motor2: { pwm: 25, in_a: 26, in_b: 33 },
+      encoders: { m1_a: 34, m1_b: 35, m2_a: 36, m2_b: 39 },
+      i2c: { sda: 21, scl: 22 },
+      battery_pin: -1,
+      // no lidar_rxd: this design ships the scan over WiFi UDP, so no UART pin
+      // is involved and none needs wiring
+      sonar: { trig: -1, echo: -1 }
+    }
+  }
+};
+
+// Only the Waveshare General Driver board has fixed, known wiring. Every other
+// preset is a DIY build with no committed pinout, so its pins are forced to
+// bare (-1 / "no connection") — a preset must never drive a pin the user has
+// not actually wired. Kinematics, geometry, driver and sensor picks are kept.
+const PINNED_PRESETS = ["bare", "waveshare_gendrv", "gendrv_serial_ld19", "esp32_wifi_ld19"];
+for (const [key, p] of Object.entries(PRESETS)) {
+  if (!PINNED_PRESETS.includes(key)) {
+    p.pins = JSON.parse(JSON.stringify(PRESETS.bare.pins));
+  }
+  // Every reference design starts in fake wheel mode. A design is a starting
+  // point for a robot that does not exist yet, so the board almost never has
+  // motors and encoders wired when it is first flashed -- and without this it
+  // would report zero RPM, leaving teleop, SLAM and Nav2 dead on arrival.
+  // Turn it off in the Simulation section once the real drivetrain is wired.
+  p.simulation = Object.assign({ fake_wheel: true }, p.simulation || {});
+}
+
+
+// Any manual toggle of the simulation controls is an explicit choice, and must
+// not be overridden the next time a module is detected.
+for (const id of ["cfg-fake-wheel", "cfg-fake-ld19"]) {
+  const el = document.getElementById(id);
+  if (el) el.addEventListener("change", () => {
+    userTouchedSimulation = true;
+    updateSimulationBanner();
+  });
+}
+
+// Simulation mode is easy to forget once it is on -- the config looks normal
+// and the board reports plausible odometry, so a real robot flashed with it
+// would sit still while the topics claimed it was driving. Keep a standing
+// banner up for as long as any simulated source is enabled.
+function updateSimulationBanner() {
+  const banner = document.getElementById("sim-mode-banner");
+  if (!banner) return;
+  const wheel = document.getElementById("cfg-fake-wheel")?.checked;
+  const lidar = document.getElementById("cfg-fake-ld19")?.checked;
+  const parts = [];
+  if (wheel) parts.push("wheels and encoders are simulated");
+  if (lidar) parts.push("the LiDAR scan is simulated");
+  banner.style.display = (wheel || lidar) ? "flex" : "none";
+  const what = document.getElementById("sim-mode-what");
+  if (what) what.textContent = parts.join(", and ");
+}
+
+const btnSimOff = document.getElementById("btn-sim-banner-off");
+if (btnSimOff) {
+  btnSimOff.addEventListener("click", () => {
+    for (const id of ["cfg-fake-wheel", "cfg-fake-ld19"]) {
+      const el = document.getElementById(id);
+      if (el && el.checked) {
+        el.checked = false;
+        el.dispatchEvent(new Event("change"));
+      }
+    }
+    userTouchedSimulation = true;
+    updateSimulationBanner();
+    showToast("Simulation off — this config now drives the real motors and encoders.");
+  });
+}
+
+// Current Active Spec State
+let currentSpec = {};
+let activeArtifact = "tab-code-header";
+
+function isESP32(mcu) {
+  return typeof mcu === "string" && (mcu.startsWith("ESP32") || mcu === "GENDRV");
+}
+
+// Only the classic ESP32, the ESP32-S2 and the ESP32-based Waveshare General
+// Driver carry a true hardware DAC — required for the adc_calibrate sweep.
+// ESP32-S3 / C3 / C6, RP2040/RP2350 and Teensy have none.
+function mcuHasDac(mcu) {
+  return mcu === "ESP32" || mcu === "ESP32S2" || mcu === "GENDRV";
+}
+
+// Valid DAC GPIOs per MCU: ESP32 -> 25/26, ESP32-S2 -> 17/18.
+function dacPinsForMcu(mcu) {
+  return mcu === "ESP32S2" ? [17, 18] : [25, 26];
+}
+
+// DOM Elements Initialization
+document.addEventListener("DOMContentLoaded", async () => {
+  initNavTabs();
+  initArtifactTabs();
+  initEventListeners();
+  initAutomationEventListeners();
+  initWorkflowHeaderListeners();
+  loadRemoteConfig();
+  initAdcCalibrationStudio();
+  initRos2TopicInspector();
+  detectClientOS();
+  checkServerRunnerStatus();
+  initGitVersionBadge();
+  initBranchPicker();
+  handleUrlParams();
+  const restored = await restoreWorkflowAndBoardSetup();
+  if (!restored) {
+    // A first-time visitor has no robot yet, so open on the simulated design:
+    // flash it and Console can drive, map and navigate with nothing wired.
+    loadPreset("gendrv_serial_ld19");
+  }
+  // A restored session bypasses the preset defaults entirely, so the banner has
+  // to be brought up from whatever state the form actually ended in.
+  updateSimulationBanner();
+});
+
+
+// =============================================================================
+// Workflow & Board Setup Persistence (Browser localStorage + Server-side .workflow_settings.json)
+// =============================================================================
+let saveWorkflowDebounceTimer = null;
+let isRestoringSettings = false;
+
+function updateRemoteBadge(val) {
+  const badge = document.getElementById("hdr-remote-badge");
+  if (!badge) return;
+  const host = (val || "").trim();
+  if (host) {
+    badge.className = "badge-pill badge-ok";
+    badge.textContent = `🤖 ${host.includes("@") ? host.split("@")[1] : host}`;
+    badge.title = `Remote Target: ${host}`;
+  } else {
+    badge.className = "badge-pill badge-ok";
+    badge.textContent = "💻 Local";
+    badge.title = "Target: Local Machine";
+  }
+}
+
+function saveWorkflowAndBoardSetup() {
+  if (isRestoringSettings) return;
+  clearTimeout(saveWorkflowDebounceTimer);
+  saveWorkflowDebounceTimer = setTimeout(async () => {
+    try {
+      const rosDistro = document.getElementById("hdr-ros-distro")?.value || "jazzy";
+      const buildEngine = document.getElementById("hdr-build-engine")?.value || "docker";
+      const agentEngine = document.getElementById("hdr-agent-engine")?.value || "docker";
+      const containerRegistry = document.getElementById("hdr-container-registry")?.value || "auto";
+      const customRegistry = (document.getElementById("hdr-custom-registry")?.value || "").trim();
+      const remoteFlash = (document.getElementById("hdr-remote-flash")?.value || "").trim();
+      const flashPort = (document.getElementById("auto-flash-port")?.value || "").trim();
+      const multiPorts = (document.getElementById("auto-agent-multiserial-ports")?.value || "").trim();
+      const robotName = (document.getElementById("cfg-robot-name")?.value || "").trim();
+      const branch = (document.getElementById("auto-git-branch")?.value || "").trim();
+      const preset = document.getElementById("preset-select")?.value || "bare";
+      
+      const payload = {
+        ros_distro: rosDistro,
+        build_engine: buildEngine,
+        agent_engine: agentEngine,
+        container_registry: containerRegistry,
+        custom_registry: customRegistry,
+        remote_flash: remoteFlash,
+        flash_port: flashPort,
+        multi_ports: multiPorts,
+        robot_name: robotName,
+        branch: branch,
+        preset: preset,
+        spec: currentSpec || null
+      };
+
+      try {
+        localStorage.setItem("linorobot2_workflow_settings", JSON.stringify(payload));
+      } catch (e) {}
+
+      await fetch("/api/workflow/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+    } catch (err) {
+      console.warn("Failed to persist workflow settings:", err);
+    }
+  }, 350);
+}
+
+async function restoreWorkflowAndBoardSetup() {
+  isRestoringSettings = true;
+  window.hasAutoDetectedHardware = true;
+  let settings = null;
+
+  try {
+    const res = await fetch("/api/workflow/settings");
+    if (res.ok) {
+      const data = await res.json();
+      if (data.status === "ok" && data.settings) {
+        settings = data.settings;
+      }
+    }
+  } catch (e) {
+    console.warn("Server workflow settings fetch failed, checking localStorage", e);
+  }
+
+  if (!settings || !settings.ros_distro) {
+    try {
+      const localStr = localStorage.getItem("linorobot2_workflow_settings");
+      if (localStr) settings = JSON.parse(localStr);
+    } catch (e) {}
+  }
+
+  if (!settings) return;
+
+  if (settings.ros_distro) {
+    const hdrRos = document.getElementById("hdr-ros-distro");
+    if (hdrRos) hdrRos.value = settings.ros_distro;
+    const autoRos = document.getElementById("auto-ros-distro");
+    if (autoRos) autoRos.value = settings.ros_distro;
+  }
+
+  if (settings.build_engine) {
+    const hdrBuild = document.getElementById("hdr-build-engine");
+    if (hdrBuild) hdrBuild.value = settings.build_engine;
+    const chkDocker = document.getElementById("chk-docker-builder");
+    if (chkDocker) chkDocker.checked = (settings.build_engine !== "native");
+  }
+
+  if (settings.agent_engine) {
+    const hdrAgent = document.getElementById("hdr-agent-engine");
+    if (hdrAgent) hdrAgent.value = settings.agent_engine;
+  }
+
+  if (settings.container_registry) {
+    const regMode = (settings.container_registry === "custom" || (!["auto", "cluster", "dockerhub"].includes(settings.container_registry))) ? "custom" : settings.container_registry;
+    const customVal = settings.custom_registry || (!["auto", "cluster", "dockerhub"].includes(settings.container_registry) ? settings.container_registry : "");
+    const hdrReg = document.getElementById("hdr-container-registry");
+    const cfgReg = document.getElementById("cfg-container-registry");
+    if (hdrReg) hdrReg.value = regMode;
+    if (cfgReg) cfgReg.value = regMode;
+    const hdrCustom = document.getElementById("hdr-custom-registry");
+    const cfgCustom = document.getElementById("cfg-custom-registry");
+    const grpCustom = document.getElementById("group-cfg-custom-registry");
+    if (hdrCustom) {
+      hdrCustom.value = customVal;
+      hdrCustom.style.display = (regMode === "custom" || regMode === "cluster") ? "inline-block" : "none";
+    }
+    if (cfgCustom) cfgCustom.value = customVal;
+    if (grpCustom) grpCustom.style.display = (regMode === "custom" || regMode === "cluster") ? "block" : "none";
+  }
+
+  if (settings.remote_flash !== undefined) {
+    const hdrRemote = document.getElementById("hdr-remote-flash");
+    if (hdrRemote) hdrRemote.value = settings.remote_flash;
+    const sshHost = document.getElementById("remote-ssh-host");
+    if (sshHost) sshHost.value = settings.remote_flash;
+    updateRemoteBadge(settings.remote_flash);
+    if (typeof updateRemoteUI === "function") updateRemoteUI();
+  }
+
+
+
+  const hasSavedSpec = settings.spec && typeof settings.spec === "object"
+    && Object.keys(settings.spec).length > 0;
+
+  if (settings.preset && document.getElementById("preset-select")) {
+    document.getElementById("preset-select").value = settings.preset;
+    // Only the dropdown was being restored. With no saved spec to populate
+    // from, the form stayed on raw HTML defaults while the dropdown claimed a
+    // design was loaded -- so the fields never matched the build named above
+    // them. Load the design for real instead.
+    if (!hasSavedSpec) loadPreset(settings.preset);
+  }
+
+  if (hasSavedSpec) {
+    currentSpec = settings.spec;
+    if (typeof populateFormFromSpec === "function") {
+      populateFormFromSpec(currentSpec);
+      if (typeof recomputeAll === "function") recomputeAll();
+    }
+  }
+
+  if (settings.robot_name) {
+    const nameInput = document.getElementById("cfg-robot-name");
+    if (nameInput) nameInput.value = settings.robot_name;
+    if (currentSpec) currentSpec.robot_name = settings.robot_name;
+  }
+  if (settings.branch) {
+    const branchInput = document.getElementById("auto-git-branch");
+    if (branchInput) {
+      branchInput.value = settings.branch;
+      branchInput.dataset.autoManaged = "false";
+    }
+  }
+
+  if (settings.flash_port && document.getElementById("auto-flash-port")) {
+    const pEl = document.getElementById("auto-flash-port");
+    pEl.value = settings.flash_port;
+    pEl.dataset.autoManaged = "false";
+  }
+
+  if (settings.multi_ports && document.getElementById("auto-agent-multiserial-ports")) {
+    const mpEl = document.getElementById("auto-agent-multiserial-ports");
+    mpEl.value = settings.multi_ports;
+    mpEl.dataset.autoManaged = "false";
+  }
+
+  if (typeof updateAutomationPreviews === "function") {
+    updateAutomationPreviews();
+  }
+  if (settings.flash_port && document.getElementById("auto-flash-port")) {
+    document.getElementById("auto-flash-port").value = settings.flash_port;
+    document.getElementById("auto-flash-port").dataset.autoManaged = "false";
+  }
+  setTimeout(() => { isRestoringSettings = false; }, 250);
+  return true;
+}
+
+function initWorkflowHeaderListeners() {
+  const hdrRos = document.getElementById("hdr-ros-distro");
+  const hdrBuild = document.getElementById("hdr-build-engine");
+  const hdrAgent = document.getElementById("hdr-agent-engine");
+  const hdrReg = document.getElementById("hdr-container-registry");
+  const hdrCustomReg = document.getElementById("hdr-custom-registry");
+  const cfgReg = document.getElementById("cfg-container-registry");
+  const cfgCustomReg = document.getElementById("cfg-custom-registry");
+  const grpCustomReg = document.getElementById("group-cfg-custom-registry");
+  const hdrRemote = document.getElementById("hdr-remote-flash");
+
+  const syncRegistryUI = (val, customVal) => {
+    // `cluster` and `custom` both take a user-supplied host:port
+    const isCustom = (val === "custom" || val === "cluster");
+    if (hdrReg) hdrReg.value = val;
+    if (cfgReg) cfgReg.value = val;
+    if (hdrCustomReg) {
+      if (customVal !== undefined) hdrCustomReg.value = customVal;
+      hdrCustomReg.style.display = isCustom ? "inline-block" : "none";
+      if (isCustom) hdrCustomReg.focus();
+    }
+    if (cfgCustomReg) {
+      if (customVal !== undefined) cfgCustomReg.value = customVal;
+    }
+    if (grpCustomReg) grpCustomReg.style.display = isCustom ? "block" : "none";
+  };
+
+  if (hdrReg) {
+    hdrReg.addEventListener("change", () => {
+      syncRegistryUI(hdrReg.value);
+      updateAutomationPreviews();
+      saveWorkflowAndBoardSetup();
+      showToast(`📦 Registry: ${hdrReg.options[hdrReg.selectedIndex]?.text || hdrReg.value}`);
+    });
+  }
+
+  if (cfgReg) {
+    cfgReg.addEventListener("change", () => {
+      syncRegistryUI(cfgReg.value);
+      updateAutomationPreviews();
+      saveWorkflowAndBoardSetup();
+    });
+  }
+
+  if (hdrCustomReg) {
+    hdrCustomReg.addEventListener("input", () => {
+      if (cfgCustomReg) cfgCustomReg.value = hdrCustomReg.value;
+      updateAutomationPreviews();
+      saveWorkflowAndBoardSetup();
+    });
+  }
+
+  if (cfgCustomReg) {
+    cfgCustomReg.addEventListener("input", () => {
+      if (hdrCustomReg) hdrCustomReg.value = cfgCustomReg.value;
+      updateAutomationPreviews();
+      saveWorkflowAndBoardSetup();
+    });
+  }
+  const btnRootless = document.getElementById("btn-rootless-info");
+  const modalRootless = document.getElementById("modal-rootless-docker");
+
+  if (hdrRos) {
+    hdrRos.addEventListener("change", () => {
+      const autoRos = document.getElementById("auto-ros-distro");
+      if (autoRos) autoRos.value = hdrRos.value;
+      updateAutomationPreviews();
+      saveWorkflowAndBoardSetup();
+      showToast(`🌐 ROS 2 Distro: ${hdrRos.options[hdrRos.selectedIndex]?.text || hdrRos.value}`);
+    });
+  }
+
+  const autoRos = document.getElementById("auto-ros-distro");
+  if (autoRos) {
+    autoRos.addEventListener("change", () => {
+      if (hdrRos) hdrRos.value = autoRos.value;
+      saveWorkflowAndBoardSetup();
+    });
+  }
+
+  if (hdrBuild) {
+    hdrBuild.addEventListener("change", () => {
+      const chkDocker = document.getElementById("chk-docker-builder");
+      if (chkDocker) chkDocker.checked = (hdrBuild.value !== "native");
+      const dockerDetails = document.getElementById("docker-builder-details");
+      if (dockerDetails) dockerDetails.style.display = (hdrBuild.value === "docker") ? "block" : "none";
+      updateAutomationPreviews();
+      saveWorkflowAndBoardSetup();
+      showToast(`🔨 Build Engine: ${hdrBuild.value.toUpperCase()}`);
+      ensureContainerEngine(hdrBuild.value);
+    });
+  }
+
+  if (hdrAgent) {
+    hdrAgent.addEventListener("change", () => {
+      updateAutomationPreviews();
+      saveWorkflowAndBoardSetup();
+      showToast(`🤖 micro-ROS Agent: ${hdrAgent.options[hdrAgent.selectedIndex]?.text || hdrAgent.value}`);
+      ensureContainerEngine(hdrAgent.value);
+    });
+  }
+
+  if (hdrRemote) {
+    let remoteDebounce = null;
+    hdrRemote.addEventListener("input", () => {
+      clearTimeout(remoteDebounce);
+      const val = hdrRemote.value.trim();
+      updateRemoteBadge(val);
+      const hostInput = document.getElementById("remote-ssh-host");
+      if (hostInput) {
+        if (val.includes("@")) {
+          const parts = val.split("@");
+          const userInput = document.getElementById("remote-ssh-user");
+          if (userInput) userInput.value = parts[0];
+          hostInput.value = parts[1];
+        } else {
+          hostInput.value = val;
+        }
+      }
+      remoteDebounce = setTimeout(() => {
+        saveWorkflowAndBoardSetup();
+        if (typeof testRemoteConnection === "function") testRemoteConnection();
+      }, 500);
+    });
+  }
+
+  // Rootless modal listeners
+  if (btnRootless && modalRootless) {
+    btnRootless.addEventListener("click", () => {
+      openRootlessModal();
+    });
+
+    const btnClose1 = document.getElementById("btn-close-rootless-modal");
+    const btnClose2 = document.getElementById("btn-close-rootless-modal-ok");
+    if (btnClose1) btnClose1.addEventListener("click", () => modalRootless.style.display = "none");
+    if (btnClose2) btnClose2.addEventListener("click", () => modalRootless.style.display = "none");
+
+    modalRootless.addEventListener("click", (e) => {
+      if (e.target === modalRootless) modalRootless.style.display = "none";
+    });
+
+    const btnCopyUbu = document.getElementById("btn-copy-rootless-ubuntu");
+    if (btnCopyUbu) {
+      btnCopyUbu.addEventListener("click", () => {
+        const text = document.getElementById("code-rootless-ubuntu")?.innerText || "";
+        navigator.clipboard.writeText(text).then(() => showToast("📋 Rootless Docker setup script copied!"));
+      });
+    }
+
+    const btnCopyPod = document.getElementById("btn-copy-rootless-podman");
+    if (btnCopyPod) {
+      btnCopyPod.addEventListener("click", () => {
+        const text = document.getElementById("code-rootless-podman")?.innerText || "";
+        navigator.clipboard.writeText(text).then(() => showToast("📋 Podman commands copied!"));
+      });
+    }
+
+    const btnTestDaemon = document.getElementById("btn-test-rootless-daemon");
+    if (btnTestDaemon) {
+      btnTestDaemon.addEventListener("click", async () => {
+        const statusText = document.getElementById("rootless-status-text");
+        if (statusText) statusText.textContent = "Checking daemon socket...";
+        try {
+          const res = await fetch("/api/docker/status");
+          const d = await res.json();
+          if (d.has_docker) {
+            const rootlessNote = d.is_rootless_docker ? " (Rootless active ✅)" : " (Standard rootful — rootless recommended for Linux)";
+            if (statusText) statusText.textContent = `✅ Docker Engine active${rootlessNote}`;
+            showToast(`Docker: Active${rootlessNote}`);
+          } else if (d.has_podman) {
+            if (statusText) statusText.textContent = "✅ Podman active (Rootless by default)";
+            showToast("Podman: Active (Rootless)");
+          } else {
+            if (statusText) statusText.textContent = "❌ Neither Docker nor Podman detected on host.";
+            showToast("No container engine found.");
+          }
+        } catch (e) {
+          if (statusText) statusText.textContent = "❌ Error contacting server: " + e.message;
+        }
+      });
+    }
+  }
+}
+
+
+// Automated Rootless Docker & Container Engine Setup Helpers
+async function triggerRootlessDockerSetup(isManual = false) {
+  const statusText = document.getElementById("rootless-status-text");
+  const btnSetup = document.getElementById("btn-setup-rootless-docker");
+  if (statusText) statusText.textContent = "⚡ Configuring Rootless Docker daemon...";
+  if (btnSetup) {
+    btnSetup.disabled = true;
+    btnSetup.textContent = "Setting up...";
+  }
+
+  try {
+    const res = await fetch("/api/docker/setup_rootless", { method: "POST" }).then(r => r.json());
+    if (statusText) {
+      if (res.success || res.is_rootless) {
+        statusText.textContent = `✅ ${res.message || "Rootless Docker active!"}`;
+        if (!isManual) showToast("🐳 Rootless Docker was automatically configured for this session.");
+      } else {
+        statusText.textContent = `⚠️ ${res.message || "Setup completed with warnings. Check logs."}`;
+      }
+    }
+    return res;
+  } catch (err) {
+    if (statusText) statusText.textContent = `⚠️ Setup error: ${err.message}`;
+    return { success: false, error: err.message };
+  } finally {
+    if (btnSetup) {
+      btnSetup.disabled = false;
+      btnSetup.textContent = "⚡ Setup Rootless Now";
+    }
+  }
+}
+
+async function checkAndAutoSetupRootlessDocker() {
+  try {
+    const status = await fetch("/api/docker/status").then(r => r.json());
+    if (status.platform_system === "Linux" && status.has_docker && !status.is_rootless_docker) {
+      console.log("[Robot Config Engine] Auto-configuring rootless Docker...");
+      await triggerRootlessDockerSetup(false);
+    }
+  } catch (e) {}
+}
+
+async function ensureContainerEngine(engine) {
+  if (engine === "native") return { installed: true };
+  const targetEngine = (engine === "podman" || engine === "podman_systemd") ? "podman" : "docker";
+
+  try {
+    const status = await fetch("/api/docker/status").then(r => r.json());
+    if (targetEngine === "podman" && !status.has_podman) {
+      showToast("🦭 Podman not found on system. Installing automatically...", 5000);
+      const res = await fetch("/api/container/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ engine: "podman" })
+      }).then(r => r.json());
+      if (res.installed) {
+        showToast("✅ Podman installed successfully!", 4000);
+      } else {
+        showToast("⚠️ Podman auto-install failed: " + res.message, 6000);
+      }
+      return res;
+    } else if (targetEngine === "docker") {
+      if (!status.has_docker) {
+        showToast("🐳 Docker not found on system. Installing Rootless Docker automatically...", 6000);
+        const res = await fetch("/api/container/install", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ engine: "docker" })
+        }).then(r => r.json());
+        if (res.installed) {
+          showToast("✅ Docker (Rootless) installed and configured!", 4000);
+        } else {
+          showToast("⚠️ Docker auto-install failed: " + res.message, 6000);
+        }
+        return res;
+      } else if (!status.is_rootless_docker && status.platform_system === "Linux") {
+        await triggerRootlessDockerSetup(false);
+      }
+    }
+  } catch (e) {
+    console.warn("Container auto-check error:", e);
+  }
+}
+
+
+async function openRootlessModal() {
+  const modal = document.getElementById("modal-rootless-docker");
+  if (!modal) return;
+  modal.style.display = "flex";
+  const statusText = document.getElementById("rootless-status-text");
+  try {
+    const res = await fetch("/api/docker/rootless_info");
+    const info = await res.json();
+    if (statusText) {
+      if (info.is_rootless) {
+        statusText.textContent = `✅ Rootless Docker is active for user '${info.user}' (UID ${info.uid})`;
+      } else if (info.has_docker) {
+        statusText.textContent = `⚠️ Docker is running in standard (rootful) mode. Run setup below to enable rootless daemon.`;
+      } else if (info.has_podman) {
+        statusText.textContent = `✅ Podman is available (Rootless by default, no daemon needed).`;
+      } else {
+        statusText.textContent = `ℹ️ Neither Docker nor Podman found. Follow setup below to install.`;
+      }
+    }
+  } catch (e) {
+    if (statusText) statusText.textContent = "ℹ️ Container info unavailable";
+  }
+}
+
+async function checkAndWarnRootlessDocker() {
+  try {
+    const res = await fetch("/api/docker/status");
+    const d = await res.json();
+    if (d.has_docker && d.platform_system === "Linux" && !d.is_rootless_docker) {
+      showToast("💡 Tip: On Linux, click '❓ Guide' to setup rootless Docker and avoid root-owned files.", 6000);
+    }
+  } catch (e) {}
+}
+
+// Mirror the Robot SBC's current git branch into the Tab 5 merge/commit
+// branch field until the user edits it. "Run Merge & Commit" then checks that
+// branch out (creating it if new).
+function applyCurrentBranch(branch) {
+  const el = document.getElementById("auto-git-branch");
+  if (!el || !branch || branch === "(detached)") return;
+  if (el.dataset.autoManaged === "false") return;
+  el.value = branch;
+  el.dataset.autoManaged = "true";
+}
+
+// =============================================================================
+// Header Branch Picker — clicking the "Branch:" field (or its ▾) drops a list
+// of the Robot SBC's local git branches (GET /api/gitinfo → branches[]).
+// Picking one fills the field; typing a new name still creates it on Merge/Commit.
+// =============================================================================
+function initBranchPicker() {
+  const input = document.getElementById("auto-git-branch");
+  const caret = document.getElementById("btn-branch-menu");
+  const menu = document.getElementById("branch-menu");
+  if (!input || !menu) return;
+
+  const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
+  ));
+
+  const close = () => {
+    menu.hidden = true;
+    if (caret) caret.setAttribute("aria-expanded", "false");
+  };
+
+  const pick = (name) => {
+    input.value = name;
+    input.dataset.autoManaged = "false";   // user chose it — stop mirroring HEAD
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    if (typeof updateAutomationPreviews === "function") updateAutomationPreviews();
+    close();
+    // Check the branch out on the Robot SBC right now (same command the
+    // "= name" button uses: create if missing, otherwise just switch).
+    const cmd = [
+      `set -e`,
+      `if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then echo "Not a git repository."; exit 1; fi`,
+      `git checkout -b "${name}" 2>/dev/null || git checkout "${name}"`,
+      `echo "Now on branch: $(git rev-parse --abbrev-ref HEAD)"`,
+    ].join("\n");
+    executeCommandInTerminal(cmd, `Switching to Git branch '${name}'`);
+  };
+
+  const render = (info) => {
+    const branches = (info && Array.isArray(info.branches)) ? info.branches : [];
+    const cur = info && info.branch;
+    const typed = input.value.trim();
+    if (!branches.length) {
+      menu.innerHTML = `<div class="branch-empty">No branches reported by the Robot SBC.</div>`;
+      return;
+    }
+    menu.innerHTML = branches.map((b) => `
+      <button type="button" role="option" class="branch-item${b === cur ? " is-current" : ""}${b === typed ? " is-active" : ""}" data-branch="${esc(b)}">
+        <span class="branch-cur-dot"></span><span>${esc(b)}</span>${b === cur ? '<span style="margin-left:auto;font-size:0.68rem;color:var(--text-muted)">current</span>' : ""}
+      </button>`).join("");
+    menu.querySelectorAll(".branch-item").forEach((btn) => {
+      btn.addEventListener("click", () => pick(btn.dataset.branch));
+    });
+  };
+
+  const open = async () => {
+    menu.hidden = false;
+    if (caret) caret.setAttribute("aria-expanded", "true");
+    menu.innerHTML = `<div class="branch-empty">Loading branches…</div>`;
+    let info = null;
+    try {
+      const res = await fetch("/api/gitinfo", { cache: "no-cache" });
+      if (res.ok) info = await res.json();
+    } catch (_) { /* offline: fall through to empty */ }
+    render(info);
+  };
+
+  const toggle = (e) => {
+    if (e) e.stopPropagation();
+    if (menu.hidden) open(); else close();
+  };
+
+  input.addEventListener("click", (e) => { e.stopPropagation(); if (menu.hidden) open(); });
+  input.addEventListener("keydown", (e) => {
+    if ((e.key === "ArrowDown" || e.key === "ArrowUp") && menu.hidden) { e.preventDefault(); open(); }
+  });
+  if (caret) caret.addEventListener("click", toggle);
+  // Re-filter the visible list as the user types a name.
+  input.addEventListener("input", () => {
+    if (menu.hidden) return;
+    menu.querySelectorAll(".branch-item").forEach((btn) => {
+      const hit = btn.dataset.branch.toLowerCase().includes(input.value.trim().toLowerCase());
+      btn.style.display = hit ? "" : "none";
+      btn.classList.toggle("is-active", btn.dataset.branch === input.value.trim());
+    });
+  });
+  document.addEventListener("click", (e) => {
+    if (!menu.hidden && !menu.contains(e.target) && e.target !== input && e.target !== caret) close();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && !menu.hidden) { close(); input.blur(); }
+  });
+}
+
+// =============================================================================
+// Header Git Version Badge — shows the 7-char commit the web server booted on;
+// click to reveal the branch, remotes and last 10 commits (GET /api/gitinfo).
+// =============================================================================
+function initGitVersionBadge() {
+  const badge = document.getElementById("git-version-badge");
+  const text = document.getElementById("git-version-text");
+  const popover = document.getElementById("git-version-popover");
+  if (!badge || !text || !popover) return;
+
+  const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
+  ));
+
+  let loaded = null;
+
+  const render = (info) => {
+    const remotes = (info.remotes || []).map((r) => `
+      <div class="gv-line">
+        <span class="gv-remote-name">${esc(r.name)}</span>
+        <span class="gv-val">${esc(r.url)}</span>
+      </div>`).join("") || `<div class="gv-line"><span class="gv-val">(no remotes)</span></div>`;
+
+    const commits = (info.commits || []).map((c) => `
+      <li>
+        <div><span class="gv-hash">${esc(c.hash)}</span> <span class="gv-subject">${esc(c.subject)}</span></div>
+        <div class="gv-meta">${esc(c.author)} · ${esc(c.date)} (${esc(c.reldate)})</div>
+      </li>`).join("") || `<li><span class="gv-meta">(no commit history)</span></li>`;
+
+    const movedNote = info.moved_since_start
+      ? `<div class="gv-note">⚠ HEAD is now at <code>${esc(info.version)}</code> — the server is still running the <code>${esc(info.version_at_start)}</code> build. Restart server.py to pick up the new code.</div>`
+      : "";
+    const dirtyNote = info.dirty
+      ? `<div class="gv-note">Working tree has uncommitted changes.</div>`
+      : "";
+
+    popover.innerHTML = `
+      <h4>Version</h4>
+      <div class="gv-line"><span class="gv-key">server @</span><span class="gv-val">${esc(info.version_at_start)}</span></div>
+      <div class="gv-line"><span class="gv-key">branch</span><span class="gv-val">${esc(info.branch)}</span></div>
+      <h4>Remotes</h4>
+      ${remotes}
+      <h4>Last 10 commits</h4>
+      <ol class="gv-commits">${commits}</ol>
+      ${movedNote}
+      ${dirtyNote}`;
+  };
+
+  const load = async () => {
+    try {
+      const res = await fetch("/api/gitinfo", { cache: "no-cache" });
+      if (!res.ok) return null;
+      return await res.json();
+    } catch (e) {
+      return null;
+    }
+  };
+
+  const closePopover = () => {
+    popover.hidden = true;
+    badge.setAttribute("aria-expanded", "false");
+  };
+
+  const openPopover = async () => {
+    // Always re-fetch: the branch and recent commits change during a session
+    // whenever a robot-config Full Deploy writes a config commit / branch.
+    const fresh = await load();
+    if (fresh) { loaded = fresh; render(loaded); applyCurrentBranch(fresh.branch); }
+    if (!loaded) return;
+    popover.hidden = false;
+    badge.setAttribute("aria-expanded", "true");
+  };
+
+  badge.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (popover.hidden) openPopover();
+    else closePopover();
+  });
+  document.addEventListener("click", (e) => {
+    if (!popover.hidden && !popover.contains(e.target) && e.target !== badge) closePopover();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && !popover.hidden) closePopover();
+  });
+
+  // Prime the badge label at startup.
+  load().then((info) => {
+    if (!info) { text.textContent = "no-git"; return; }
+    loaded = info;
+    render(info);
+    text.textContent = info.version_at_start || "unknown";
+    if (info.dirty || info.moved_since_start) badge.classList.add("is-dirty");
+    applyCurrentBranch(info.branch);
+  });
+}
+
+// URL Query Parameter Handling (e.g. ?preset=mech_esp32&tab=tab-drive&artifact=tab-code-pio)
+function handleUrlParams() {
+  const params = new URLSearchParams(window.location.search);
+  const preset = params.get("preset");
+  const tab = params.get("tab");
+  const artifact = params.get("artifact");
+
+  if (preset && PRESETS[preset]) {
+    const sel = document.getElementById("preset-select");
+    if (sel) sel.value = preset;
+    loadPreset(preset);
+  }
+
+  if (tab) {
+    const tabBtn = document.querySelector(`[data-tab="${tab}"]`);
+    if (tabBtn) tabBtn.click();
+  }
+
+  if (artifact) {
+    const artBtn = document.querySelector(`[data-artifact="${artifact}"]`);
+    if (artBtn) artBtn.click();
+  }
+}
+
+// Tab Navigation Handlers
+function initNavTabs() {
+  const navTabs = document.querySelectorAll(".nav-tab");
+  navTabs.forEach(tab => {
+    tab.addEventListener("click", () => {
+      navTabs.forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".tab-pane").forEach(p => p.classList.remove("active"));
+      tab.classList.add("active");
+      const target = document.getElementById(tab.dataset.tab);
+      if (target) target.classList.add("active");
+    });
+  });
+}
+
+function initArtifactTabs() {
+  const artTabs = document.querySelectorAll(".artifact-tab");
+  artTabs.forEach(tab => {
+    tab.addEventListener("click", () => {
+      artTabs.forEach(t => t.classList.remove("active"));
+      tab.classList.add("active");
+      activeArtifact = tab.dataset.artifact;
+      renderActiveCode();
+    });
+  });
+}
+
+// Global Event Listeners
+function initEventListeners() {
+  // Preset Selector
+  document.getElementById("preset-select").addEventListener("change", (e) => {
+    loadPreset(e.target.value);
+  });
+
+  // Header "= name" button: point the branch field at the robot name and
+  // switch the Robot SBC to that branch (creating it if new).
+  const btnBranchToName = document.getElementById("btn-branch-to-name");
+  if (btnBranchToName) {
+    btnBranchToName.addEventListener("click", () => {
+      const name = (currentSpec.robot_name
+        || document.getElementById("cfg-robot-name")?.value || "robot").trim();
+      const el = document.getElementById("auto-git-branch");
+      if (el) { el.value = name; el.dataset.autoManaged = "false"; updateAutomationPreviews(); }
+      const cmd = [
+        `set -e`,
+        `if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then echo "Not a git repository."; exit 1; fi`,
+        `git checkout -b "${name}" 2>/dev/null || git checkout "${name}"`,
+        `echo "Now on branch: $(git rev-parse --abbrev-ref HEAD)"`,
+      ].join("\n");
+      executeCommandInTerminal(cmd, `Switching to Git branch '${name}'`);
+    });
+  }
+
+  // Dynamic Input Form Listeners
+  const allInputs = document.querySelectorAll(".form-input, .form-select, input[type='checkbox']");
+  allInputs.forEach(input => {
+    input.addEventListener("input", handleInputChange);
+    input.addEventListener("change", handleInputChange);
+  });
+  const otaHostEl = document.getElementById("cfg-ota-hostname");
+  if (otaHostEl) otaHostEl.addEventListener("input", () => { otaHostEl.dataset.autoManaged = "false"; });
+  // Typing in a covariance field marks it user-owned so a later sensor change
+  // won't overwrite it with the datasheet default.
+  ["cfg-cov-accel", "cfg-cov-gyro", "cfg-cov-ori", "cfg-cov-mag", "cfg-cov-env",
+   "cfg-cov-pose", "cfg-cov-twist"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) el.addEventListener("input", () => { delete el.dataset.autoCov; });
+  });
+  // show/hide password toggles
+  [["cfg-wifi-pass-show", "cfg-wifi-pass"], ["cfg-ota-password-show", "cfg-ota-password"]].forEach(([chk, fld]) => {
+    const c = document.getElementById(chk), f = document.getElementById(fld);
+    if (c && f) c.addEventListener("change", () => { f.type = c.checked ? "text" : "password"; });
+  });
+  ["cfg-agent-ip", "cfg-syslog-ip", "cfg-lidar-ip"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) el.addEventListener("input", () => { el.dataset.autoManaged = "false"; });
+  });
+
+  // Smart Auto-Assign Pinout Button
+  document.getElementById("btn-smart-alloc").addEventListener("click", autoAssignPins);
+
+  // Copy Code Button
+  document.getElementById("btn-copy-code").addEventListener("click", copyActiveCode);
+
+  // Download Artifact Button
+  document.getElementById("btn-download-artifact").addEventListener("click", downloadActiveArtifact);
+
+  // Export JSON Spec Button
+  document.getElementById("btn-export-json").addEventListener("click", exportSpecJson);
+
+  // Import JSON File
+  // Board Config Loader
+  document.getElementById("btn-load-board")?.addEventListener("click", openBoardSelector);
+  document.getElementById("btn-board-cancel")?.addEventListener("click", () => {
+    document.getElementById("modal-board-select").style.display = "none";
+  });
+  document.getElementById("btn-board-confirm")?.addEventListener("click", async () => {
+    const envName = document.getElementById("board-select").value;
+    document.getElementById("modal-board-select").style.display = "none";
+    if (envName) await loadBoardConfig(envName);
+  });
+  // Close modal on backdrop click
+  document.getElementById("modal-board-select")?.addEventListener("click", (e) => {
+    if (e.target === document.getElementById("modal-board-select"))
+      document.getElementById("modal-board-select").style.display = "none";
+  });
+  // JSON Import file listener
+  document.getElementById("import-json-file")?.addEventListener("change", handleImportFile);
+
+  // AI I2C Sensor Auto-Detection Button
+  const btnI2cDetect = document.getElementById("btn-auto-detect-i2c");
+  if (btnI2cDetect) {
+    btnI2cDetect.addEventListener("click", runI2cSensorAutoDetect);
+  }
+}
+
+// Load a Preset into State and Form
+function loadPreset(presetKey) {
+  if (!PRESETS[presetKey]) return;
+  currentSpec = JSON.parse(JSON.stringify(PRESETS[presetKey]));
+  const sel = document.getElementById("preset-select");
+  if (sel && sel.value !== presetKey) sel.value = presetKey;
+  populateFormFromSpec(currentSpec);
+  recomputeAll();
+  updateSimulationBanner();
+}
+
+// Map a parsed backend header spec (parser.py shape) onto the frontend form shape.
+// The Web UI form / presets / export use `sensors.imu`, `sensors.mag`,
+// `sensors.battery_monitor`, `sensors.sonar`, `dual_core`, `baudrate`, `transport`,
+// whereas the C++ parser emits `sensors.imu_type`, `sensors.mag_type`,
+// `sensors.use_ina219`, `sensors.sonar_trig/echo`, `telemetry.*`.
+// This shim bridges the two so board-config / C++-header imports populate the form.
+// Idempotent: never overwrites a frontend-shape key that is already present.
+function normalizeSpecToFormShape(spec) {
+  if (!spec) return spec;
+  if (!spec.sensors) spec.sensors = {};
+  const s = spec.sensors;
+
+  // Only bridge parser-style keys when at least one is present and the
+  // front-end-style key has not already been supplied (stay idempotent).
+  const hasParserKeys =
+    s.imu_type != null || s.mag_type != null || s.use_ina219 !== undefined ||
+    s.sonar_trig !== undefined || s.battery_monitor == null;
+
+  if (hasParserKeys) {
+    // IMU: USE_QMI8658_IMU -> QMI8658, USE_FAKE_IMU -> FAKE
+    if (s.imu == null && s.imu_type != null) {
+      const v = String(s.imu_type).replace(/^USE_/, "").replace(/_IMU$/, "");
+      if (v && v !== "IMU") s.imu = v;
+    }
+    // MAG: USE_AK09918_MAG -> AK09918, USE_FAKE_MAG -> NONE (no mag option exists)
+    if (s.mag == null && s.mag_type != null) {
+      let v = String(s.mag_type).replace(/^USE_/, "").replace(/_MAG$/, "");
+      if (v === "FAKE") v = "NONE";
+      if (v && v !== "MAG") s.mag = v;
+    }
+    // Battery monitor: INA219 vs ADC divider vs none
+    if (s.battery_monitor == null) {
+      if (s.use_ina219) s.battery_monitor = "INA219";
+      else if (typeof s.battery_pin === "number" && s.battery_pin >= 0) s.battery_monitor = "ADC_DIVIDER";
+    }
+    // Sonar enabled when both trigger & echo pins are set
+    if (s.sonar == null &&
+        typeof s.sonar_trig === "number" && s.sonar_trig >= 0 &&
+        typeof s.sonar_echo === "number" && s.sonar_echo >= 0) {
+      s.sonar = true;
+    }
+    // Environmental barometer: parser emits env_type / use_bmp280
+    if (s.env == null) {
+      if (s.env_type) s.env = String(s.env_type).toUpperCase();
+      else if (s.use_bmp280) s.env = "BMP280";
+    }
+    // Battery numeric fields use different names in the parser
+    if (s.battery_capacity == null && s.battery_cap != null)            s.battery_capacity = s.battery_cap;
+    if (s.battery_min_voltage == null && s.battery_min != null)         s.battery_min_voltage = s.battery_min;
+    if (s.battery_max_voltage == null && s.battery_max != null)         s.battery_max_voltage = s.battery_max;
+    if (s.battery_nominal_voltage == null && s.battery_nominal != null) s.battery_nominal_voltage = s.battery_nominal;
+    if (s.battery_r1 == null && s.battery_divider_r1 != null)           s.battery_r1 = s.battery_divider_r1;
+    if (s.battery_r2 == null && s.battery_divider_r2 != null)           s.battery_r2 = s.battery_divider_r2;
+  }
+
+  // Dual-core: parser puts it under telemetry / top-level may lack it
+  if (spec.dual_core == null && spec.telemetry && typeof spec.telemetry.use_dual_core === "boolean") {
+    spec.dual_core = spec.telemetry.use_dual_core;
+  }
+  // Baudrate & transport fallbacks from the telemetry block
+  if (spec.baudrate == null && spec.telemetry && spec.telemetry.baudrate != null) spec.baudrate = spec.telemetry.baudrate;
+  if (spec.transport == null && spec.telemetry && spec.telemetry.transport) spec.transport = spec.telemetry.transport;
+
+  return spec;
+}
+
+// Populate UI Form Fields from Spec Object
+function populateFormFromSpec(spec) {
+  spec = normalizeSpecToFormShape(spec);
+  document.getElementById("cfg-robot-name").value = spec.robot_name || "my_robot";
+  document.getElementById("cfg-kinematics").value = spec.kinematics || "DIFFERENTIAL_DRIVE";
+  document.getElementById("cfg-mcu").value = spec.mcu || "PICO2";
+  document.getElementById("cfg-transport").value = spec.transport || "SERIAL";
+  if (document.getElementById("cfg-baudrate")) {
+    document.getElementById("cfg-baudrate").value = String(spec.baudrate || spec.telemetry?.baudrate || (spec.mcu === "GENDRV" ? 1500000 : 921600));
+  }
+  if (document.getElementById("cfg-serial-interface")) {
+    document.getElementById("cfg-serial-interface").value = spec.serial_interface || "CDC";
+  }
+
+  if (spec.wifi_settings) {
+    document.getElementById("cfg-wifi-ssid").value = spec.wifi_settings.ssid || "";
+    document.getElementById("cfg-wifi-pass").value = spec.wifi_settings.password || "";
+    document.getElementById("cfg-agent-ip").value = spec.wifi_settings.agent_ip || "192.168.1.100";
+    document.getElementById("cfg-agent-port").value = spec.wifi_settings.agent_port || 8888;
+    // A real SSID came from config/custom/wifi_config.h — show the WiFi block.
+    const _ss = (spec.wifi_settings.ssid || "").trim();
+    if (_ss && _ss !== "YOUR_WIFI_SSID") {
+      const bg = document.getElementById("cfg-wifi-telemetry");
+      if (bg) bg.checked = true;
+    }
+  }
+
+  // Geometry
+  document.getElementById("cfg-wheel-dia").value = spec.geometry?.wheel_diameter || 0.08;
+  document.getElementById("cfg-track-width").value = spec.geometry?.track_width || 0.22;
+  document.getElementById("cfg-wheelbase").value = spec.geometry?.wheelbase || 0.20;
+  if (document.getElementById("cfg-weight")) document.getElementById("cfg-weight").value = spec.geometry?.weight || 3.5;
+  if (document.getElementById("cfg-fake-wheel")) document.getElementById("cfg-fake-wheel").checked = Boolean(spec.simulation?.fake_wheel);
+  // loading a spec is not the user reaching for the checkbox
+  userTouchedSimulation = false;
+  updateSimulationBanner();
+  if (document.getElementById("cfg-fake-ld19")) {
+    const fakeLidar = Boolean(spec.simulation?.fake_ld19);
+    document.getElementById("cfg-fake-ld19").checked = fakeLidar;
+    const block = document.getElementById("fake-ld19-settings-block");
+    if (block) block.style.display = fakeLidar ? "block" : "none";
+  }
+  // Defaults must match the firmware (fake_ld19.h: 16.0 x 12.0). These run on
+  // every preset load and overwrite the markup, so a stale value here silently
+  // shrinks the simulated room for every design that does not set its own.
+  if (document.getElementById("cfg-map-width")) document.getElementById("cfg-map-width").value = spec.simulation?.map_width ?? 10.0;
+  if (document.getElementById("cfg-map-height")) document.getElementById("cfg-map-height").value = spec.simulation?.map_height ?? 6.0;
+  if (document.getElementById("cfg-wall-obstacle")) document.getElementById("cfg-wall-obstacle").checked = spec.simulation?.wall_obstacle !== false;
+  if (document.getElementById("cfg-wall-x1")) document.getElementById("cfg-wall-x1").value = spec.simulation?.wall_x1 ?? 2.0;
+  if (document.getElementById("cfg-wall-y1")) document.getElementById("cfg-wall-y1").value = spec.simulation?.wall_y1 ?? -1.5;
+  if (document.getElementById("cfg-wall-x2")) document.getElementById("cfg-wall-x2").value = spec.simulation?.wall_x2 ?? 2.0;
+  if (document.getElementById("cfg-wall-y2")) document.getElementById("cfg-wall-y2").value = spec.simulation?.wall_y2 ?? 1.5;
+  // Defaults on with the fake LiDAR: the range comes from the same raycast, so
+  // it needs no pins, and a beginner driving a simulated robot into a wall
+  // should get the same protection a real one would have.
+  if (document.getElementById("cfg-fake-sonar")) document.getElementById("cfg-fake-sonar").checked = spec.simulation?.fake_sonar !== false;
+
+  // Motors
+  document.getElementById("cfg-driver-type").value = spec.motors?.driver_type || "BTS7960";
+  document.getElementById("cfg-max-rpm").value = spec.motors?.max_rpm || 330;
+  document.getElementById("cfg-cpr").value = spec.motors?.cpr || 1440;
+  document.getElementById("cfg-motor-voltage").value = spec.motors?.operating_voltage || 12.0;
+  if (document.getElementById("cfg-motor-torque")) document.getElementById("cfg-motor-torque").value = spec.motors?.rated_torque || 1.5;
+
+  for (let i = 1; i <= 4; i++) {
+    const el = document.getElementById(`pin-m${i}-inv`);
+    if (el) el.checked = !!spec.motors?.[`motor${i}_inv`];
+  }
+
+  // Sensors
+  document.getElementById("cfg-imu").value = spec.sensors?.imu || "NONE";
+  document.getElementById("cfg-mag").value = spec.sensors?.mag || "NONE";
+  document.getElementById("cfg-battery").value = spec.sensors?.battery_monitor || "NONE";
+  if (document.getElementById("cfg-bat-cap")) document.getElementById("cfg-bat-cap").value = spec.sensors?.battery_capacity || 2.2;
+  if (document.getElementById("cfg-bat-nom")) document.getElementById("cfg-bat-nom").value = spec.sensors?.battery_nominal_voltage || 11.1;
+  if (document.getElementById("cfg-bat-min")) document.getElementById("cfg-bat-min").value = spec.sensors?.battery_min_voltage || 9.0;
+  if (document.getElementById("cfg-bat-max")) document.getElementById("cfg-bat-max").value = spec.sensors?.battery_max_voltage || 12.6;
+  if (document.getElementById("cfg-bat-dip")) document.getElementById("cfg-bat-dip").value = spec.sensors?.battery_dip ?? "";
+  if (document.getElementById("cfg-bat-r1")) document.getElementById("cfg-bat-r1").value = spec.sensors?.battery_r1 || 30000;
+  if (document.getElementById("cfg-bat-r2")) document.getElementById("cfg-bat-r2").value = spec.sensors?.battery_r2 || 7500;
+  if (document.getElementById("cfg-bat-cap-val")) document.getElementById("cfg-bat-cap-val").value = spec.sensors?.battery_adc_cap || 1000;
+  const _dacPinLoad = spec.pins?.dac_pin ?? spec.sensors?.dac_pin;
+  if (document.getElementById("cfg-dac-pin") && _dacPinLoad != null && _dacPinLoad >= 0) {
+    document.getElementById("cfg-dac-pin").value = String(_dacPinLoad);
+  }
+  document.getElementById("cfg-sonar").value = spec.sensors?.sonar ? "true" : "false";
+  if (document.getElementById("cfg-env")) document.getElementById("cfg-env").value = spec.sensors?.env || "NONE";
+
+  // Dual-Core
+  if (document.getElementById("cfg-dual-core")) {
+    document.getElementById("cfg-dual-core").checked = spec.dual_core !== false;
+  }
+
+  // Hardware Watchdog
+  if (document.getElementById("cfg-wdt-enable")) {
+    const wdtEnabled = !!spec.watchdog?.enabled || (typeof spec.watchdog === "number" && spec.watchdog > 0);
+    document.getElementById("cfg-wdt-enable").checked = wdtEnabled;
+    const wdtTimeoutGroup = document.getElementById("group-wdt-timeout");
+    if (wdtTimeoutGroup) wdtTimeoutGroup.style.display = wdtEnabled ? "flex" : "none";
+    if (document.getElementById("cfg-wdt-timeout")) {
+      const to = spec.watchdog?.timeout_sec || (typeof spec.watchdog === "number" ? spec.watchdog : 60);
+      document.getElementById("cfg-wdt-timeout").value = to;
+    }
+  }
+
+  // Pins
+  const p = spec.pins || {};
+  document.getElementById("pin-led").value = p.led !== undefined ? p.led : 25;
+
+  const dt = spec.motors?.driver_type || "GENERIC_2_IN";
+  const _pick = (...v) => v.find((x) => x !== undefined && x !== null);
+  for (let i = 1; i <= 4; i++) {
+    const m = p[`motor${i}`] || {};
+    let p1, p2, p3;
+    if (dt === "BTS7960") {
+      // Two outputs: RPWM (IN_A) and LPWM (IN_B). Accept legacy pwm_r/pwm_l/en.
+      p1 = _pick(m.in_a, m.pwm_l, m.pwm_r, m.pwm);
+      p2 = _pick(m.in_b, m.en);
+      p3 = undefined;
+    } else if (dt === "GENERIC_1_IN") {
+      p1 = m.pwm; p2 = _pick(m.dir, m.in_a); p3 = m.in_b;
+    } else {
+      p1 = m.pwm; p2 = m.in_a; p3 = m.in_b;
+    }
+    setPinVal(`pin-m${i}-p1`, p1);
+    setPinVal(`pin-m${i}-p2`, p2);
+    setPinVal(`pin-m${i}-p3`, p3);
+  }
+
+  const enc = p.encoders || {};
+  setPinVal("pin-enc-1a", enc.m1_a);
+  setPinVal("pin-enc-1b", enc.m1_b);
+  setPinVal("pin-enc-2a", enc.m2_a);
+  setPinVal("pin-enc-2b", enc.m2_b);
+  setPinVal("pin-enc-3a", enc.m3_a);
+  setPinVal("pin-enc-3b", enc.m3_b);
+  setPinVal("pin-enc-4a", enc.m4_a);
+  setPinVal("pin-enc-4b", enc.m4_b);
+
+  // Encoder invert flags
+  for (let i = 1; i <= 4; i++) {
+    const cb = document.getElementById(`pin-enc-${i}-inv`);
+    if (cb) cb.checked = !!enc[`m${i}_inv`];
+  }
+
+  setPinVal("pin-i2c-sda", p.i2c?.sda);
+  setPinVal("pin-i2c-scl", p.i2c?.scl);
+
+  // advanced telemetry (syslog / LiDAR-UDP / OTA)
+  const adv = spec.advanced || {};
+  const setVal = (id, v) => { const el = document.getElementById(id); if (el && v !== undefined && v !== null && v !== "") el.value = v; };
+  const setCk  = (id, v) => { const el = document.getElementById(id); if (el) el.checked = !!v; };
+  setVal("cfg-syslog-ip", adv.syslog_ip);
+  setVal("cfg-syslog-port", adv.syslog_port);
+  setVal("cfg-wifi-monitor", adv.wifi_monitor);
+  setVal("cfg-lidar-ip", adv.lidar_ip);
+  setVal("cfg-lidar-port", adv.lidar_port);
+  // Reference designs carry this under pins (it is a pin), the form and the
+  // rest of the spec keep it under advanced. Read both, or a preset that sets
+  // pins.lidar_rxd loads as -1 and the generated header says LIDAR_RXD -1 --
+  // the firmware then starts the LD19 emulator with no output and silently
+  // transmits nothing.
+  setVal("cfg-lidar-rxd", spec.pins?.lidar_rxd ?? adv.lidar_rxd);
+  setVal("cfg-lidar-uart", adv.lidar_serial);
+  setVal("cfg-lidar-baud", adv.lidar_baudrate);
+  setVal("cfg-ota-hostname", adv.ota_hostname);
+  setVal("cfg-ota-password", adv.ota_password);
+  setVal("cfg-ota-ip", adv.ota_ip);
+  setVal("cfg-topic-prefix", adv.topic_prefix);
+  setCk("cfg-lidar-udp", spec.telemetry?.use_lidar_udp);
+  setCk("cfg-ota-enable", adv.ota_enable);
+
+  // PID constants + IMU / mag tuning
+  const pid = spec.pid || {};
+  setVal("cfg-pid-kp", pid.kp);
+  setVal("cfg-pid-ki", pid.ki);
+  setVal("cfg-pid-kd", pid.kd);
+  const tune = spec.imu_tuning || {};
+  const setNum = (id, v) => { const el = document.getElementById(id); if (el) el.value = (v === undefined || v === null) ? "" : v; };
+  if (Array.isArray(tune.mag_bias)) {
+    setNum("cfg-mag-bias-x", tune.mag_bias[0]);
+    setNum("cfg-mag-bias-y", tune.mag_bias[1]);
+    setNum("cfg-mag-bias-z", tune.mag_bias[2]);
+  } else {
+    setNum("cfg-mag-bias-x", null); setNum("cfg-mag-bias-y", null); setNum("cfg-mag-bias-z", null);
+  }
+  const covScalar = (v) => Array.isArray(v) ? v[0] : v;
+  const covList = (v) => Array.isArray(v) ? v.join(", ") : (v ?? "");
+  setNum("cfg-cov-accel", covScalar(tune.accel_cov));
+  setNum("cfg-cov-gyro", covScalar(tune.gyro_cov));
+  setNum("cfg-cov-ori", covScalar(tune.ori_cov));
+  setNum("cfg-cov-mag", covScalar(tune.mag_cov));
+  setNum("cfg-cov-pose", covList(tune.pose_cov));
+  setNum("cfg-cov-twist", covList(tune.twist_cov));
+  setNum("cfg-cov-env", covList(tune.env_cov));
+  setPinVal("pin-battery", p.battery_pin);
+  setPinVal("pin-sonar-trig", p.sonar?.trig);
+  setPinVal("pin-sonar-echo", p.sonar?.echo);
+
+  const robotName = spec.robot_name || "my_robot";
+  // The git branch field mirrors the Robot SBC's current branch (populated
+  // from /api/gitinfo), not the robot name — leave it to applyCurrentBranch().
+  const gitCommitInput = document.getElementById("auto-git-commit-msg");
+  if (gitCommitInput && gitCommitInput.dataset.autoManaged !== "false") {
+    gitCommitInput.value = `feat(config): add configuration for ${robotName}`;
+  }
+  const portInput = document.getElementById("auto-flash-port");
+  if (portInput && portInput.dataset.autoManaged !== "false") {
+    const isEsp = (spec.mcu || "").toUpperCase().startsWith("ESP");
+    portInput.value = isEsp ? "/dev/ttyUSB0" : "/dev/ttyACM0";
+  }
+
+
+  updateDynamicUIState();
+  // Fill datasheet covariance defaults for the loaded IMU/mag/barometer, but
+  // only into fields the imported spec left blank (explicit values are kept).
+  applySensorCovDefaults();
+}
+
+function setPinVal(id, val) {
+  const el = document.getElementById(id);
+  if (el) el.value = val !== undefined ? val : "";
+}
+
+function getInt(id, defaultVal = 0) {
+  const el = document.getElementById(id);
+  if (!el || el.value === "" || isNaN(parseInt(el.value, 10))) return defaultVal;
+  return parseInt(el.value, 10);
+}
+
+function getFloat(id, defaultVal = 0.0) {
+  const el = document.getElementById(id);
+  if (!el || el.value === "" || isNaN(parseFloat(el.value))) return defaultVal;
+  return parseFloat(el.value);
+}
+
+// Like getFloat but returns null (not a default) when the field is left blank,
+// so optional numeric settings can be "unset".
+function getFloatOrNull(id) {
+  const el = document.getElementById(id);
+  if (!el || el.value.trim() === "" || isNaN(parseFloat(el.value))) return null;
+  return parseFloat(el.value);
+}
+
+// Read Current Values from Form and update State
+function readSpecFromForm() {
+  const kinematics = document.getElementById("cfg-kinematics").value;
+  const driverType = document.getElementById("cfg-driver-type").value;
+  const transport = document.getElementById("cfg-transport").value;
+  const is4WD = kinematics !== "DIFFERENTIAL_DRIVE";
+
+  const spec = {
+    robot_name: document.getElementById("cfg-robot-name").value.trim().toLowerCase().replace(/[^a-z0-9_]/g, "_") || "my_robot",
+    kinematics: kinematics,
+    mcu: document.getElementById("cfg-mcu").value,
+    transport: transport,
+    serial_interface: document.getElementById("cfg-serial-interface") ? document.getElementById("cfg-serial-interface").value : "CDC",
+    geometry: {
+      wheel_diameter: getFloat("cfg-wheel-dia", 0.08),
+      track_width: getFloat("cfg-track-width", 0.22),
+      // emitted as ROBOT_WEIGHT, which fake wheel mode uses as the simulated mass
+      weight: getFloat("cfg-weight", 3.5),
+    },
+    simulation: {
+      fake_wheel: document.getElementById("cfg-fake-wheel")
+        ? document.getElementById("cfg-fake-wheel").checked
+        : false,
+      fake_ld19: document.getElementById("cfg-fake-ld19")
+        ? document.getElementById("cfg-fake-ld19").checked
+        : false,
+      map_width: getFloat("cfg-map-width", 10.0),
+      map_height: getFloat("cfg-map-height", 6.0),
+      wall_obstacle: document.getElementById("cfg-wall-obstacle")
+        ? document.getElementById("cfg-wall-obstacle").checked
+        : true,
+      wall_x1: getFloat("cfg-wall-x1", 2.0),
+      wall_y1: getFloat("cfg-wall-y1", -1.5),
+      wall_x2: getFloat("cfg-wall-x2", 2.0),
+      wall_y2: getFloat("cfg-wall-y2", 1.5),
+      fake_sonar: document.getElementById("cfg-fake-sonar")
+        ? document.getElementById("cfg-fake-sonar").checked
+        : true,
+    },
+    motors: {
+      driver_type: driverType,
+      max_rpm: getFloat("cfg-max-rpm", 330),
+      cpr: getFloat("cfg-cpr", 1440),
+      operating_voltage: getFloat("cfg-motor-voltage", 12.0),
+      motor1_inv: !!document.getElementById("pin-m1-inv")?.checked,
+      motor2_inv: !!document.getElementById("pin-m2-inv")?.checked,
+      motor3_inv: !!document.getElementById("pin-m3-inv")?.checked,
+      motor4_inv: !!document.getElementById("pin-m4-inv")?.checked
+    },
+    pid: {
+      kp: getFloat("cfg-pid-kp", 0.6),
+      ki: getFloat("cfg-pid-ki", 0.8),
+      kd: getFloat("cfg-pid-kd", 0.5)
+    },
+    sensors: {
+      imu: document.getElementById("cfg-imu").value,
+      mag: document.getElementById("cfg-mag").value,
+      battery_monitor: document.getElementById("cfg-battery").value,
+      battery_capacity: getFloat("cfg-bat-cap", 2.2),
+      battery_nominal_voltage: getFloat("cfg-bat-nom", 11.1),
+      battery_min_voltage: getFloat("cfg-bat-min", 9.0),
+      battery_max_voltage: getFloat("cfg-bat-max", 12.6),
+      battery_dip: getFloatOrNull("cfg-bat-dip"),   // blank = disabled (no BATTERY_DIP emitted)
+      battery_r1: getFloat("cfg-bat-r1", 30000.0),
+      battery_r2: getFloat("cfg-bat-r2", 7500.0),
+      battery_adc_cap: getFloat("cfg-bat-cap-val", 1000.0),
+      sonar: document.getElementById("cfg-sonar").value === "true",
+      env: document.getElementById("cfg-env")?.value || "NONE"
+    },
+    imu_tuning: (() => {
+      const bx = getFloatOrNull("cfg-mag-bias-x"), by = getFloatOrNull("cfg-mag-bias-y"), bz = getFloatOrNull("cfg-mag-bias-z");
+      const t = {};
+      if (bx !== null || by !== null || bz !== null) t.mag_bias = [bx || 0, by || 0, bz || 0];
+      const ac = getFloatOrNull("cfg-cov-accel"), gc = getFloatOrNull("cfg-cov-gyro"), oc = getFloatOrNull("cfg-cov-ori");
+      if (ac !== null) t.accel_cov = ac;
+      if (gc !== null) t.gyro_cov = gc;
+      if (oc !== null) t.ori_cov = oc;
+      const mc = getFloatOrNull("cfg-cov-mag");
+      if (mc !== null) t.mag_cov = mc;
+      // POSE/TWIST_COV: scalar, or a comma list (usually 6); kept as typed.
+      const covField = (id) => {
+        const raw = (document.getElementById(id)?.value || "").trim();
+        if (!raw) return null;
+        if (raw.includes(",")) {
+          const arr = raw.split(",").map((x) => Number(x.trim()));
+          return arr.some((x) => Number.isNaN(x)) ? null : arr;
+        }
+        const n = Number(raw);
+        return Number.isNaN(n) ? null : n;
+      };
+      const pc = covField("cfg-cov-pose"), tc = covField("cfg-cov-twist");
+      if (pc !== null) t.pose_cov = pc;
+      if (tc !== null) t.twist_cov = tc;
+      // ENV_COV: BMP280 FluidPressure/Temperature/RelativeHumidity .variance
+      // { pressure Pa^2, temperature C^2, humidity (0..1)^2 } — scalar or 3-list.
+      const evc = covField("cfg-cov-env");
+      if (evc !== null) t.env_cov = evc;
+      return t;
+    })(),
+    baudrate: document.getElementById("cfg-baudrate") ? parseInt(document.getElementById("cfg-baudrate").value, 10) : 921600,
+    telemetry: {
+      use_dual_core: document.getElementById("cfg-dual-core") ? document.getElementById("cfg-dual-core").checked : true,
+      baudrate: document.getElementById("cfg-baudrate") ? parseInt(document.getElementById("cfg-baudrate").value, 10) : 921600
+    },
+    dual_core: document.getElementById("cfg-dual-core") ? document.getElementById("cfg-dual-core").checked : true,
+    watchdog: {
+      enabled: document.getElementById("cfg-wdt-enable") ? document.getElementById("cfg-wdt-enable").checked : false,
+      timeout_sec: getInt("cfg-wdt-timeout", 60)
+    },
+    pins: {
+      led: getInt("pin-led", 25),
+      encoders: {
+        m1_a: getInt("pin-enc-1a"),
+        m1_b: getInt("pin-enc-1b"),
+        m2_a: getInt("pin-enc-2a"),
+        m2_b: getInt("pin-enc-2b"),
+        m1_inv: !!(document.getElementById("pin-enc-1-inv")?.checked),
+        m2_inv: !!(document.getElementById("pin-enc-2-inv")?.checked),
+        m3_inv: !!(document.getElementById("pin-enc-3-inv")?.checked),
+        m4_inv: !!(document.getElementById("pin-enc-4-inv")?.checked)
+      },
+      i2c: {
+        sda: getInt("pin-i2c-sda"),
+        scl: getInt("pin-i2c-scl")
+      }
+    }
+  };
+
+  // Advanced telemetry: syslog / LiDAR-UDP / Arduino OTA (Sensors tab)
+  const _v = (id) => (document.getElementById(id)?.value || "").trim();
+  const _ck = (id) => !!document.getElementById(id)?.checked;
+  spec.advanced = {
+    syslog_ip: _v("cfg-syslog-ip"),
+    syslog_port: getInt("cfg-syslog-port", 514),
+    wifi_monitor: getInt("cfg-wifi-monitor", 0),
+    lidar_ip: _v("cfg-lidar-ip"),
+    lidar_port: getInt("cfg-lidar-port", 8889),
+    lidar_rxd: getInt("cfg-lidar-rxd", -1),
+    lidar_serial: getInt("cfg-lidar-uart", 1),
+    lidar_baudrate: getInt("cfg-lidar-baud", 230400),
+    ota_hostname: _v("cfg-ota-hostname"),
+    ota_password: _v("cfg-ota-password"),
+    ota_ip: _v("cfg-ota-ip"),
+    ota_enable: _ck("cfg-ota-enable"),
+    topic_prefix: _v("cfg-topic-prefix")
+  };
+  spec.telemetry = Object.assign({}, spec.telemetry, { use_lidar_udp: _ck("cfg-lidar-udp") });
+  // Background WiFi (OTA/syslog while micro-ROS stays on serial) turns on
+  // whenever any of these wireless features are requested.
+  if (_ck("cfg-lidar-udp") || _ck("cfg-ota-enable")) spec.enable_ota_syslog = true;
+
+  if (is4WD) {
+    spec.geometry.wheelbase = getFloat("cfg-wheelbase", 0.20);
+    spec.pins.encoders.m3_a = getInt("pin-enc-3a");
+    spec.pins.encoders.m3_b = getInt("pin-enc-3b");
+    spec.pins.encoders.m4_a = getInt("pin-enc-4a");
+    spec.pins.encoders.m4_b = getInt("pin-enc-4b");
+  }
+
+  // Motor Pin Structures
+  const parseMotorPin = (prefix) => {
+    const p1 = getInt(`${prefix}-p1`);
+    const p2 = getInt(`${prefix}-p2`);
+    const p3 = getInt(`${prefix}-p3`);
+
+    if (driverType === "BTS7960") {
+      // Two outputs only: p1 = RPWM (MOTORx_IN_A), p2 = LPWM (MOTORx_IN_B).
+      return { in_a: p1, in_b: p2 };
+    } else if (driverType === "GENERIC_2_IN") {
+      return { pwm: p1, in_a: p2, in_b: p3 };
+    } else if (driverType === "GENERIC_1_IN") {
+      return { pwm: p1, dir: p2 };
+    } else {
+      return { pwm: p1 };
+    }
+  };
+
+  spec.pins.motor1 = parseMotorPin("pin-m1");
+  spec.pins.motor2 = parseMotorPin("pin-m2");
+  if (is4WD) {
+    spec.pins.motor3 = parseMotorPin("pin-m3");
+    spec.pins.motor4 = parseMotorPin("pin-m4");
+  }
+
+  if (spec.sensors.battery_monitor === "ADC_DIVIDER") {
+    spec.pins.battery_pin = getInt("pin-battery");
+    // DAC sweep pin — only meaningful where a hardware DAC exists.
+    if (mcuHasDac(spec.mcu)) {
+      const dp = getInt("cfg-dac-pin", -1);
+      if (dp >= 0) spec.pins.dac_pin = dp;
+    }
+  }
+  if (spec.sensors.sonar) {
+    spec.pins.sonar = {
+      trig: getInt("pin-sonar-trig"),
+      echo: getInt("pin-sonar-echo")
+    };
+  }
+
+  // WiFi credentials are needed both for WIFI_UDP transport AND for the
+  // "Enable Background WiFi for OTA & Syslog" mode (micro-ROS stays on serial
+  // but the firmware still joins WiFi for USE_SYSLOG / USE_ARDUINO_OTA).
+  const _ssidRaw = (document.getElementById("cfg-wifi-ssid")?.value || "").trim();
+  const _ssidReal = _ssidRaw && _ssidRaw !== "YOUR_WIFI_SSID";
+  // "Enable Background WiFi" only takes effect once a real SSID is entered —
+  // otherwise a bare first-run would emit WIFI_AP_LIST with the placeholder and
+  // the firmware would hang at boot trying to join "YOUR_WIFI_SSID".
+  const bgWifi = !!document.getElementById("cfg-wifi-telemetry")?.checked && _ssidReal;
+  if (transport === "WIFI_UDP" || bgWifi) {
+    spec.wifi_settings = {
+      ssid: _ssidRaw,
+      password: document.getElementById("cfg-wifi-pass").value,
+      agent_ip: document.getElementById("cfg-agent-ip").value,
+      agent_port: getInt("cfg-agent-port", 8888)
+    };
+  }
+  if (bgWifi && transport !== "WIFI_UDP") spec.enable_ota_syslog = true;
+
+  return spec;
+}
+
+// Handle Form Changes
+// Datasheet-derived default measurement variances. Auto-filled into the
+// Covariance Overrides when a sensor is enabled, so the generated header
+// ships realistic ACCEL/GYRO/ORI/MAG/ENV_COV instead of the firmware's
+// generic 1e-5 fallback. variance ≈ (noise_density · √(~100 Hz bandwidth))².
+// A value the user types is never overwritten (see applySensorCovDefaults).
+const SENSOR_COV_DEFAULTS = {
+  imu: {   // { accel: (m/s²)² , gyro: (rad/s)² , ori?: rad² (fused output only) }
+    BNO085:   { accel: 2.2e-4, gyro: 1.5e-6, ori: 4e-3 },
+    LSM6DSOX: { accel: 4.7e-5, gyro: 4.4e-7 },
+    ICM20948: { accel: 5.1e-4, gyro: 6.9e-6 },
+    QMI8658:  { accel: 8e-5,   gyro: 2e-6 },
+    MPU9250:  { accel: 9e-4,   gyro: 3e-6 },
+    MPU9150:  { accel: 1.5e-3, gyro: 3e-6 },
+    MPU6050:  { accel: 1.5e-3, gyro: 3e-6 },
+    GY85:     { accel: 1.8e-3, gyro: 4.4e-5 },
+  },
+  mag: {   // Tesla²
+    AK09918:  2.3e-14, ICM20948: 2.3e-14,
+    QMC5883L: 4e-14,   HMC5883L: 4e-14,
+    AK8963:   9e-14,   AK8975:   9e-14,
+  },
+  env: {   // [ pressure Pa² (σ≈1.7 Pa, IIR-x4) , temperature °C² (±0.5°C accuracy) , humidity (0..1)² (±3% RH) ]
+    BMP280: [3, 0.25, 0],
+    BME280: [3, 0.25, 9e-4],
+  },
+};
+
+// Fill the ACCEL/GYRO/ORI/MAG/ENV_COV fields from SENSOR_COV_DEFAULTS for the
+// currently-selected IMU / magnetometer / barometer. Only touches a field that
+// is empty or that we filled ourselves (data-auto-cov); a user-typed value —
+// or one being typed right now — is left alone. Clearing a sensor back to
+// NONE/FAKE also clears its auto-filled covariance.
+function applySensorCovDefaults() {
+  const setAuto = (id, val) => {
+    const el = document.getElementById(id);
+    if (!el || document.activeElement === el) return;
+    const userTyped = (el.value || "").trim() !== "" && el.dataset.autoCov !== "1";
+    if (userTyped) return;
+    if (val == null || val === "") {
+      if (el.dataset.autoCov === "1") { el.value = ""; delete el.dataset.autoCov; }
+      return;
+    }
+    el.value = Array.isArray(val) ? val.join(", ") : String(val);
+    el.dataset.autoCov = "1";
+  };
+  const d = SENSOR_COV_DEFAULTS.imu[document.getElementById("cfg-imu")?.value];
+  setAuto("cfg-cov-accel", d ? d.accel : null);
+  setAuto("cfg-cov-gyro",  d ? d.gyro  : null);
+  setAuto("cfg-cov-ori",   d && d.ori != null ? d.ori : null);
+  setAuto("cfg-cov-mag", SENSOR_COV_DEFAULTS.mag[document.getElementById("cfg-mag")?.value] ?? null);
+  setAuto("cfg-cov-env", SENSOR_COV_DEFAULTS.env[document.getElementById("cfg-env")?.value] ?? null);
+}
+
+function handleInputChange() {
+  updateDynamicUIState();
+  applySensorCovDefaults();
+  recomputeAll();
+}
+
+// Update Dynamic Visibility of Form Components
+function updateDynamicUIState() {
+  const kinematics = document.getElementById("cfg-kinematics").value;
+  const is4WD = kinematics !== "DIFFERENTIAL_DRIVE";
+  const transport = document.getElementById("cfg-transport").value;
+  const driverType = document.getElementById("cfg-driver-type").value;
+  const batteryType = document.getElementById("cfg-battery").value;
+  const sonarActive = document.getElementById("cfg-sonar").value === "true";
+
+  // Simulation Fake LD19 Elements
+  const fakeLidarEl = document.getElementById("cfg-fake-ld19");
+  const fakeLidarBox = document.getElementById("fake-ld19-settings-block");
+  if (fakeLidarEl && fakeLidarBox) {
+    fakeLidarBox.style.display = fakeLidarEl.checked ? "block" : "none";
+  }
+
+  // 4WD Elements
+  document.getElementById("group-wheelbase").style.display = is4WD ? "flex" : "none";
+  // motor 3/4 invert checkboxes live in the pinout matrix rows, which
+  // already show/hide with row-motor-3 / row-motor-4
+  document.getElementById("row-motor-3").style.display = is4WD ? "table-row" : "none";
+  document.getElementById("row-motor-4").style.display = is4WD ? "table-row" : "none";
+  document.getElementById("row-enc-3").style.display = is4WD ? "table-row" : "none";
+  document.getElementById("row-enc-4").style.display = is4WD ? "table-row" : "none";
+
+  // WiFi & Serial Baudrate Settings
+  const mcuVal = document.getElementById("cfg-mcu") ? document.getElementById("cfg-mcu").value : "";
+  const isWifiMcu = mcuVal.includes("W") || mcuVal.includes("ESP32") || mcuVal === "GENDRV";
+  const wifiTelemetry = document.getElementById("cfg-wifi-telemetry") ? document.getElementById("cfg-wifi-telemetry").checked : false;
+  document.getElementById("wifi-config-box").style.display = (transport === "WIFI_UDP" || (isWifiMcu && wifiTelemetry)) ? "block" : "none";
+  if (document.getElementById("group-serial-baudrate")) {
+    document.getElementById("group-serial-baudrate").style.display = transport === "SERIAL" ? "block" : "none";
+  }
+  // Console serial monitor baud follows the firmware BAUDRATE until the user
+  // picks one explicitly (override for bootloader / MicroPython / other boards).
+  // "followedValue" is the last value we pushed; if the select no longer holds
+  // it, the user changed it by hand -> stop following.
+  const _cfgBaud = document.getElementById("cfg-baudrate");
+  const _monBaud = document.getElementById("serial-baud-select");
+  if (_cfgBaud && _monBaud) {
+    const _followed = _monBaud.dataset.followedValue;
+    if (_monBaud.dataset.autoManaged !== "false" &&
+        (_followed === undefined || _followed === _monBaud.value)) {
+      if ([..._monBaud.options].some((o) => o.value === _cfgBaud.value)) {
+        _monBaud.value = _cfgBaud.value;
+      }
+      _monBaud.dataset.followedValue = _monBaud.value;
+    } else {
+      _monBaud.dataset.autoManaged = "false";
+    }
+  }
+
+  // Watchdog Timeout Group
+  const wdtEnable = document.getElementById("cfg-wdt-enable") ? document.getElementById("cfg-wdt-enable").checked : false;
+  const wdtTimeoutGroup = document.getElementById("group-wdt-timeout");
+  if (wdtTimeoutGroup) wdtTimeoutGroup.style.display = wdtEnable ? "flex" : "none";
+
+  // Serial Interface for S2/S3
+  const mcu = document.getElementById("cfg-mcu").value;
+  const isS2S3 = (mcu === "ESP32S2" || mcu === "ESP32S3") && transport === "SERIAL";
+  const ifaceGroup = document.getElementById("group-serial-interface");
+  if (ifaceGroup) ifaceGroup.style.display = isS2S3 ? "flex" : "none";
+
+  // Battery ADC
+  document.getElementById("box-battery-pin").style.display = batteryType === "ADC_DIVIDER" ? "flex" : "none";
+
+  // DAC pin selector + ADC Calibration Studio availability.
+  // The hardware DAC (and therefore adc_calibrate) only exists on ESP32 /
+  // ESP32-S2 / GENDRV; on every other MCU the studio is greyed out and the
+  // adc_calibrate build target is disabled.
+  const hasDac = mcuHasDac(mcu);
+  const dacSel = document.getElementById("cfg-dac-pin");
+  if (dacSel) {
+    const allowed = dacPinsForMcu(mcu).map(String);
+    [...dacSel.options].forEach((o) => { o.hidden = !allowed.includes(o.value); });
+    if (!allowed.includes(dacSel.value)) dacSel.value = allowed[0];
+    // Gated on hasDac alone, matching "Run Hardware Calibration" itself —
+    // adc_calibrate is a standalone diagnostic and doesn't require
+    // battery_monitor to be set to ADC_DIVIDER. Requiring that too meant the
+    // pin selector could be invisible while the Run button sat right there
+    // enabled, silently sweeping whatever pin was last selected.
+    const dacRow = document.getElementById("adc-dacpin-row");
+    if (dacRow) dacRow.style.display = hasDac ? "flex" : "none";
+    // Keep the schematic label + status line in sync with the chosen pin.
+    const _dacFamily = mcu === "ESP32S2" ? "ESP32-S2 DAC" : "ESP32 DAC";
+    const svgDac = document.getElementById("cad-svg-dac-pin");
+    if (svgDac) svgDac.textContent = `${_dacFamily} (GPIO ${dacSel.value})`;
+    const st = document.getElementById("adc-status-text");
+    if (st && /Ready for calibration/.test(st.textContent)) {
+      st.textContent = `Ready for calibration. GPIO ${dacSel.value} (DAC) -> battery ADC pin.`;
+    }
+  }
+  const adcCard = document.getElementById("adc-studio-card");
+  if (adcCard) adcCard.classList.toggle("is-disabled", !hasDac);
+  const noDacNote = document.getElementById("adc-nodac-note");
+  if (noDacNote) noDacNote.style.display = hasDac ? "none" : "block";
+  const btnRunCal = document.getElementById("btn-adc-run-cal");
+  if (btnRunCal) { btnRunCal.disabled = !hasDac; btnRunCal.classList.toggle("is-disabled", !hasDac); }
+  // The "Upload adc_calibrate" 1-click button is hidden outright (like the
+  // Target Firmware Binary option) on MCUs without a hardware DAC.
+  const btnUploadAdc = document.getElementById("btn-upload-adc");
+  if (btnUploadAdc) {
+    btnUploadAdc.style.display = hasDac ? "" : "none";
+    btnUploadAdc.disabled = !hasDac;
+  }
+  const adcTargetOpt = document.querySelector('#auto-flash-target option[value="adc_calibrate"]');
+  if (adcTargetOpt) {
+    // Hide the adc_calibrate target entirely on MCUs without a hardware DAC.
+    adcTargetOpt.hidden = !hasDac;
+    adcTargetOpt.disabled = !hasDac;
+    const tgtSel = document.getElementById("auto-flash-target");
+    if (!hasDac && tgtSel && tgtSel.value === "adc_calibrate") tgtSel.value = "firmware";
+  }
+
+  // Sonar
+  document.getElementById("box-sonar-trig").style.display = sonarActive ? "flex" : "none";
+  document.getElementById("box-sonar-echo").style.display = sonarActive ? "flex" : "none";
+
+  // Motor pin matrix: header + how many of the 3 pin columns the driver
+  // actually uses. Columns beyond that are hidden, and any blank value in
+  // them is parked at -1 ("no connection") so it never reads as GPIO 0.
+  // A value the user has typed into a hidden column is left untouched.
+  const headerEl = document.getElementById("motor-pin-headers");
+  const invTh = `<th title="Invert this motor's spin direction">Invert</th>`;
+  let pinTh, activePins;
+  if (driverType === "BTS7960") {
+    pinTh = `<th>RPWM &rarr; IN_A</th><th>LPWM &rarr; IN_B</th>`;
+    activePins = 2;
+  } else if (driverType === "GENERIC_2_IN") {
+    pinTh = `<th>PWM (Speed)</th><th>IN_A (Dir 1)</th><th>IN_B (Dir 2)</th>`;
+    activePins = 3;
+  } else if (driverType === "GENERIC_1_IN") {
+    pinTh = `<th>PWM (Speed)</th><th>DIR (Direction)</th>`;
+    activePins = 2;
+  } else { // ESC
+    pinTh = `<th>PWM Signal</th>`;
+    activePins = 1;
+  }
+  headerEl.innerHTML = `<th>Motor</th>` + pinTh + invTh;
+  for (let i = 1; i <= 4; i++) {
+    for (let c = 1; c <= 3; c++) {
+      const el = document.getElementById(`pin-m${i}-p${c}`);
+      if (!el) continue;
+      const used = c <= activePins;
+      const cell = el.closest("td");
+      if (cell) cell.style.display = used ? "" : "none";
+      if (!used && el.value.trim() === "") el.value = "-1";
+    }
+  }
+
+  // HUD Tag
+  const baseTag = document.getElementById("hud-base-tag");
+  if (kinematics === "DIFFERENTIAL_DRIVE") baseTag.innerText = "2WD Differential";
+  else if (kinematics === "SKID_STEER") baseTag.innerText = "4WD Skid Steer";
+  else baseTag.innerText = "4WD Mecanum";
+}
+
+// Master Recompute & Render
+function recomputeAll() {
+  currentSpec = readSpecFromForm();
+
+  // 1. Validate Rules
+  const validation = validateRobotSpec(currentSpec);
+  renderSafetyInspector(validation);
+
+  // 2. Compute Kinematics & Update HUD
+  renderKinematicsHUD(validation.stats);
+
+  // 3. Update Automation Previews
+  updateAutomationPreviews();
+
+  // 4. Update ADC Voltage Calculations & CAD Vector Schematic
+  updateAdcVoltageCalculations(currentSpec);
+
+  // 5. Render Active Code Viewer
+  renderActiveCode();
+
+  // 6. Auto-persist workflow and board setup
+  if (typeof saveWorkflowAndBoardSetup === "function") {
+    saveWorkflowAndBoardSetup();
+  }
+}
+
+// Hardware & Electrical Rule Validation Engine
+function validateRobotSpec(spec) {
+  const errors = [];
+  const stats = {};
+
+  const mcu = (spec.mcu || "").toUpperCase();
+  const kinematics = spec.kinematics;
+  const geom = spec.geometry || {};
+  const motors = spec.motors || {};
+  const pins = spec.pins || {};
+  const sensors = spec.sensors || {};
+
+  const wheelD = geom.wheel_diameter || 0;
+  const trackW = geom.track_width || 0;
+  const maxRpm = motors.max_rpm || 0;
+  const cpr = motors.cpr || 0;
+
+  if (wheelD <= 0) errors.push({ level: "ERROR", field: "geometry.wheel_diameter", message: "Wheel diameter must be > 0 m" });
+  if (trackW <= 0) errors.push({ level: "ERROR", field: "geometry.track_width", message: "Track width must be > 0 m" });
+  if (maxRpm <= 0) errors.push({ level: "ERROR", field: "motors.max_rpm", message: "Motor RPM must be > 0" });
+  if (cpr <= 0) errors.push({ level: "ERROR", field: "motors.cpr", message: "Encoder CPR must be > 0" });
+
+  if (wheelD > 0 && maxRpm > 0 && cpr > 0) {
+    const wheelCirc = Math.PI * wheelD;
+    const maxLinearSpeed = (wheelCirc * maxRpm / 60.0) * 0.85; // 85% headroom
+    const maxAngularSpeed = trackW > 0 ? (2.0 * maxLinearSpeed) / trackW : 0;
+    const ticksPerMeter = cpr / wheelCirc;
+
+    stats.wheel_circumference_m = wheelCirc;
+    stats.max_linear_speed_m_s = maxLinearSpeed;
+    stats.max_angular_speed_rad_s = maxAngularSpeed;
+    stats.ticks_per_meter = ticksPerMeter;
+  }
+
+  // Pin Conflict Checking
+  const assignedPins = {};
+  function registerPin(pin, name, isOutput = false) {
+    if (pin === undefined || pin === null || isNaN(pin) || pin === "") return;
+    const p = parseInt(pin, 10);
+    // A negative value means "no connection / pin not assigned" — skip conflict
+    // detection and MCU-specific GPIO range checks for unassigned slots.
+    if (p < 0) return;
+    if (!assignedPins[p]) assignedPins[p] = [];
+    assignedPins[p].push(name);
+
+    // MCU Rules
+    if (mcu === "ESP32" || mcu === "GENDRV") {
+      if (ESP32_FLASH_PINS.includes(p)) {
+        errors.push({ level: "ERROR", field: name, message: `GPIO ${p} is connected to internal SPI Flash! Strictly forbidden.` });
+      }
+      if (isOutput && ESP32_INPUT_ONLY_PINS.includes(p)) {
+        errors.push({ level: "ERROR", field: name, message: `GPIO ${p} is an INPUT-ONLY pin and cannot output PWM/DIR signals!` });
+      }
+      if (!isOutput && ESP32_STRAPPING_PINS.includes(p)) {
+        errors.push({ level: "WARNING", field: name, message: `GPIO ${p} is an ESP32 strapping pin. May interfere with boot if pulled LOW.` });
+      }
+    } else if (mcu === "ESP32S3") {
+      if (!isOutput && ESP32S3_STRAPPING_PINS.includes(p)) {
+        errors.push({ level: "WARNING", field: name, message: `GPIO ${p} is an ESP32-S3 strapping pin.` });
+      }
+    } else if (["PICO", "PICO2", "PICOW", "PICO2W"].includes(mcu)) {
+      if (p < 0 || p > 29) {
+        errors.push({ level: "ERROR", field: name, message: `GP${p} is out of range for RP2040/RP2350 (0-29).` });
+      }
+      if (["PICOW", "PICO2W"].includes(mcu) && [23, 24, 25, 29].includes(p)) {
+        errors.push({ level: "WARNING", field: name, message: `GP${p} is connected to the CYW43439 WiFi chip on Pico W / Pico 2 W.` });
+      }
+    }
+  }
+
+  // Check Motors
+  const numMotors = kinematics === "DIFFERENTIAL_DRIVE" ? 2 : 4;
+  const driverType = motors.driver_type;
+
+  for (let i = 1; i <= numMotors; i++) {
+    const m = pins[`motor${i}`] || {};
+    if (driverType === "BTS7960") {
+      registerPin(m.in_a !== undefined ? m.in_a : m.pwm_l, `Motor ${i} RPWM (IN_A)`, true);
+      registerPin(m.in_b !== undefined ? m.in_b : m.en, `Motor ${i} LPWM (IN_B)`, true);
+    } else if (driverType === "GENERIC_2_IN") {
+      registerPin(m.pwm, `Motor ${i} PWM`, true);
+      registerPin(m.in_a, `Motor ${i} IN_A`, true);
+      registerPin(m.in_b, `Motor ${i} IN_B`, true);
+    } else if (driverType === "GENERIC_1_IN") {
+      registerPin(m.pwm, `Motor ${i} PWM`, true);
+      registerPin(m.dir, `Motor ${i} DIR`, true);
+    } else {
+      registerPin(m.pwm, `Motor ${i} PWM`, true);
+    }
+  }
+
+  // Check Encoders
+  const enc = pins.encoders || {};
+  for (let i = 1; i <= numMotors; i++) {
+    registerPin(enc[`m${i}_a`], `Encoder ${i} A`, false);
+    registerPin(enc[`m${i}_b`], `Encoder ${i} B`, false);
+  }
+
+  // Check LED
+  registerPin(pins.led, "Status LED", true);
+
+  // Check I2C
+  if (pins.i2c) {
+    registerPin(pins.i2c.sda, "I2C SDA", false);
+    registerPin(pins.i2c.scl, "I2C SCL", false);
+  }
+
+  // Check Battery
+  if (sensors.battery_monitor === "ADC_DIVIDER" && pins.battery_pin !== undefined) {
+    registerPin(pins.battery_pin, "Battery ADC", false);
+    if ((mcu === "PICO" || mcu === "PICO2") && !RP2040_ADC_PINS.includes(parseInt(pins.battery_pin, 10))) {
+      errors.push({ level: "ERROR", field: "Battery ADC", message: `GP${pins.battery_pin} is not an analog ADC pin on Pico/Pico2 (Must be GP26, GP27, or GP28).` });
+    }
+  }
+
+  // Check Battery Voltage & ADC Resistor Divider Safety (Limit <= 3.0V)
+  if (sensors.battery_monitor === "ADC_DIVIDER") {
+    const r1 = parseFloat(sensors.battery_r1 || 30000);
+    const r2 = parseFloat(sensors.battery_r2 || 7500);
+    const maxV = parseFloat(sensors.battery_max_voltage || 12.6);
+    if (r1 > 0 && r2 > 0 && maxV > 0) {
+      const totalR = r1 + r2;
+      const ratio = r2 / totalR;
+      const adcMaxV = maxV * ratio;
+      stats.adc_voltage_max_v = adcMaxV;
+      stats.adc_divider_ratio = ratio;
+      if (adcMaxV > 3.0) {
+        errors.push({
+          level: "WARNING",
+          field: "ADC Resistor Divider",
+          message: `ADC pin voltage will reach ${adcMaxV.toFixed(2)}V at full charge (${maxV.toFixed(1)}V), exceeding the 3.0V safe limit! Increase R1 or reduce R2.`
+        });
+      }
+    }
+  }
+
+  // Check Sonar
+  if (sensors.sonar && pins.sonar) {
+    registerPin(pins.sonar.trig, "Sonar Trigger", true);
+    registerPin(pins.sonar.echo, "Sonar Echo", false);
+  }
+
+  // Duplicate Pin Detection
+  for (const [pinNum, names] of Object.entries(assignedPins)) {
+    if (names.length > 1) {
+      errors.push({ level: "ERROR", field: `Pin ${pinNum}`, message: `Pin ${pinNum} assigned to multiple functions: ${names.join(", ")}` });
+    }
+  }
+
+  const isValid = !errors.some(e => e.level === "ERROR");
+  return { isValid, errors, stats };
+}
+
+// Update ADC Calculations & CAD Vector Circuit Schematic
+function updateAdcVoltageCalculations(spec) {
+  const s = spec || currentSpec;
+  const sensors = s.sensors || {};
+  const r1 = parseFloat(sensors.battery_r1 !== undefined ? sensors.battery_r1 : (document.getElementById("cfg-bat-r1")?.value || 30000));
+  const r2 = parseFloat(sensors.battery_r2 !== undefined ? sensors.battery_r2 : (document.getElementById("cfg-bat-r2")?.value || 7500));
+  const cap = parseFloat(sensors.battery_adc_cap !== undefined ? sensors.battery_adc_cap : (document.getElementById("cfg-bat-cap-val")?.value || 1000));
+  const maxV = parseFloat(sensors.battery_max_voltage !== undefined ? sensors.battery_max_voltage : (document.getElementById("cfg-bat-max")?.value || 12.6));
+  const nomV = parseFloat(sensors.battery_nominal_voltage !== undefined ? sensors.battery_nominal_voltage : (document.getElementById("cfg-bat-nom")?.value || 11.1));
+  const batPin = s.pins?.battery_pin !== undefined ? s.pins.battery_pin : (document.getElementById("pin-battery")?.value || 33);
+  const mcu = s.mcu || "ESP32";
+
+  const totalR = r1 + r2;
+  const ratio = totalR > 0 ? (r2 / totalR) : 0.2;
+  const adcMaxV = maxV * ratio;
+  const adcNomV = nomV * ratio;
+  const isSafe = adcMaxV <= 3.0;
+
+  // 1. Update Tab 3 Battery Safety Banner
+  const safetyBanner = document.getElementById("bat-adc-safety-banner");
+  const iconEl = document.getElementById("safety-banner-icon");
+  const titleEl = document.getElementById("safety-banner-title");
+  const descEl = document.getElementById("safety-banner-desc");
+  const ratioLbl = document.getElementById("lbl-divider-ratio");
+  const maxVLbl = document.getElementById("lbl-adc-max-v");
+
+  if (safetyBanner) {
+    safetyBanner.className = `adc-safety-banner ${isSafe ? 'safe' : 'warning'}`;
+    if (iconEl) iconEl.innerText = isSafe ? "🛡️" : "⚠️";
+    if (titleEl) titleEl.innerText = isSafe ? "ADC Input Voltage: Safe (≤ 3.0V)" : "HIGH VOLTAGE WARNING: Exceeds 3.0V Maximum ADC Limit!";
+    if (ratioLbl) ratioLbl.innerText = `${ratio.toFixed(4)} (1:${(1 / ratio).toFixed(1)})`;
+    if (maxVLbl) maxVLbl.innerText = `${adcMaxV.toFixed(2)} V`;
+    if (descEl) {
+      if (isSafe) {
+        descEl.innerHTML = `Divider Ratio: <code>${ratio.toFixed(4)} (1:${(1 / ratio).toFixed(1)})</code> | Max ADC Pin Voltage: <code>${adcMaxV.toFixed(2)} V</code> at full charge (${maxV.toFixed(1)}V). Nominal: <code>${adcNomV.toFixed(2)} V</code>. Filter Cap: <code>${cap} pF</code>.`;
+      } else {
+        descEl.innerHTML = `⚠️ ADC input voltage reaches <code>${adcMaxV.toFixed(2)} V</code> at full charge (${maxV.toFixed(1)}V), exceeding the 3.0V safe linear limit! Risk of saturation or non-linearity. Increase R1 or decrease R2.`;
+      }
+    }
+  }
+
+  // 2. Update CAD Vector Schematic (SVG)
+  const svgR1 = document.getElementById("cad-svg-r1");
+  if (svgR1) svgR1.textContent = `R1: ${(r1 / 1000).toFixed(1)} kΩ`;
+
+  const svgR2 = document.getElementById("cad-svg-r2-val");
+  if (svgR2) svgR2.textContent = `${(r2 / 1000).toFixed(1)} kΩ`;
+
+  const svgCap = document.getElementById("cad-svg-cap");
+  if (svgCap) svgCap.textContent = `C: ${cap} pF (${(cap / 1000).toFixed(1)}nF)`;
+
+  const svgVbat = document.getElementById("cad-svg-vbat");
+  if (svgVbat) svgVbat.textContent = `${maxV.toFixed(1)} V (Full)`;
+
+  const svgAdcPin = document.getElementById("cad-svg-adc-pin");
+  if (svgAdcPin) svgAdcPin.textContent = `${isESP32(mcu) ? 'ESP32 ADC' : 'MCU ADC'} (GPIO ${batPin || 33})`;
+
+  const svgVadcRead = document.getElementById("cad-svg-vadc-read");
+  if (svgVadcRead) svgVadcRead.textContent = `V_ADC = ${adcMaxV.toFixed(2)} V (Max)`;
+
+  const cadBadgeRatio = document.getElementById("cad-badge-ratio");
+  if (cadBadgeRatio) cadBadgeRatio.textContent = `Ratio: ${ratio.toFixed(4)} (1:${(1 / ratio).toFixed(1)})`;
+
+  const cadBadgeSafety = document.getElementById("cad-badge-safety");
+  if (cadBadgeSafety) {
+    cadBadgeSafety.className = `schematic-badge ${isSafe ? 'badge-safe' : 'badge-warning'}`;
+    cadBadgeSafety.textContent = isSafe ? `🛡️ V_ADC: ${adcMaxV.toFixed(2)}V ≤ 3.0V` : `⚠️ V_ADC: ${adcMaxV.toFixed(2)}V > 3.0V (Exceeds Limit!)`;
+  }
+
+  const cadWarnBox = document.getElementById("cad-svg-warning-box");
+  if (cadWarnBox) {
+    cadWarnBox.style.display = isSafe ? "none" : "inline";
+    const cadWarnText = document.getElementById("cad-svg-warning-text");
+    if (cadWarnText) cadWarnText.textContent = `Max ${adcMaxV.toFixed(2)}V exceeds 3.0V limit`;
+  }
+}
+
+// Render Safety Inspector Results
+function renderSafetyInspector({ isValid, errors }) {
+  const dot = document.getElementById("safety-status-dot");
+  const title = document.getElementById("safety-status-title");
+  const badge = document.getElementById("safety-status-badge");
+  const list = document.getElementById("safety-messages-list");
+
+  const errCount = errors.filter(e => e.level === "ERROR").length;
+  const warnCount = errors.filter(e => e.level === "WARNING").length;
+
+  if (errCount > 0) {
+    dot.className = "status-dot status-err";
+    title.innerText = "Hardware Safety Rules: FAILED";
+    badge.className = "safety-badge badge-err";
+    badge.innerText = `${errCount} Error${errCount > 1 ? "s" : ""}`;
+  } else if (warnCount > 0) {
+    dot.className = "status-dot status-warn";
+    title.innerText = "Hardware Safety Rules: WARNINGS";
+    badge.className = "safety-badge badge-warn";
+    badge.innerText = `${warnCount} Warning${warnCount > 1 ? "s" : ""}`;
+  } else {
+    dot.className = "status-dot status-ok";
+    title.innerText = "Hardware Safety Rules: PASSED";
+    badge.className = "safety-badge badge-ok";
+    badge.innerText = "0 Errors";
+  }
+
+  if (errors.length === 0) {
+    list.innerHTML = `
+      <div class="safety-item item-ok">
+        <span class="item-icon">✅</span>
+        <span>All pin assignments, electrical constraints, and kinematics are 100% verified.</span>
+      </div>
+    `;
+  } else {
+    list.innerHTML = errors.map(err => `
+      <div class="safety-item ${err.level === 'ERROR' ? 'item-err' : 'item-warn'}">
+        <span class="item-icon">${err.level === 'ERROR' ? '❌' : '⚠️'}</span>
+        <span><strong>${err.field}:</strong> ${err.message}</span>
+      </div>
+    `).join("");
+  }
+}
+
+// Render Kinematics Metrics HUD
+function renderKinematicsHUD(stats) {
+  const speedMs = stats.max_linear_speed_m_s || 0;
+  const speedKmh = speedMs * 3.6;
+  const rads = stats.max_angular_speed_rad_s || 0;
+  const degs = rads * (180 / Math.PI);
+  const ticks = stats.ticks_per_meter || 0;
+  const circ = stats.wheel_circumference_m || 0;
+
+  document.getElementById("val-speed-ms").innerText = speedMs.toFixed(2);
+  document.getElementById("val-speed-kmh").innerText = `${speedKmh.toFixed(2)} km/h (85% Headroom)`;
+
+  document.getElementById("val-speed-rads").innerText = rads.toFixed(2);
+  document.getElementById("val-speed-degs").innerText = `${degs.toFixed(1)} deg/s`;
+
+  document.getElementById("val-ticks-m").innerText = Math.round(ticks).toLocaleString();
+  document.getElementById("val-wheel-circ").innerText = `Circumference: ${circ.toFixed(3)} m`;
+
+  if (document.getElementById("val-max-accel") && stats.max_accel_m_s2 !== undefined) {
+    document.getElementById("val-max-accel").innerText = stats.max_accel_m_s2.toFixed(2);
+    document.getElementById("val-thrust-sub").innerText = `Thrust: ${(stats.total_thrust_n || 0).toFixed(2)} N @ ${(stats.weight_kg || 3.5).toFixed(1)} kg`;
+  }
+}
+
+// Code Generators
+function generateCppHeader(spec) {
+  const name = spec.robot_name || "my_robot";
+  const nameUpper = name.toUpperCase();
+  const kinematics = spec.kinematics || "DIFFERENTIAL_DRIVE";
+  const mcu = (spec.mcu || "PICO2").toUpperCase();
+  const geom = spec.geometry || {};
+  const motors = spec.motors || {};
+  const sensors = spec.sensors || {};
+  const pins = spec.pins || {};
+  const driver = motors.driver_type || "GENERIC_2_IN";
+  const is4WD = kinematics !== "DIFFERENTIAL_DRIVE";
+
+  const lines = [
+    `// =============================================================================`,
+    `// Auto-generated Linorobot2 Configuration for ${name}`,
+    `// Microcontroller: ${mcu} | Kinematics: ${kinematics}`,
+    `// =============================================================================`,
+    `#ifndef ${nameUpper}_CONFIG_H`,
+    `#define ${nameUpper}_CONFIG_H`,
+    ``,
+    `#define LINO_BASE ${kinematics}`,
+    `#define USE_${driver}_MOTOR_DRIVER`,
+    ``,
+    `// Kinematics & Wheel Geometry`,
+    `#define WHEEL_DIAMETER ${geom.wheel_diameter || 0.08} // meters`,
+    `#define LR_WHEELS_DISTANCE ${geom.track_width || 0.22} // meters`
+  ];
+
+  if (is4WD && geom.wheelbase) {
+    lines.push(`#define FR_WHEELS_DISTANCE ${geom.wheelbase} // meters`);
+  }
+
+  lines.push(
+    ``,
+    `// Motor & Encoder Parameters`,
+    `#define MOTOR_MAX_RPM ${motors.max_rpm || 330}`,
+    `#define MAX_RPM_RATIO 0.85`,
+    `#define MOTOR_OPERATING_VOLTAGE ${motors.operating_voltage || 12.0}`,
+    `#define MOTOR_POWER_MAX_VOLTAGE ${motors.operating_voltage || 12.0}`,
+    `#define PWM_FREQUENCY 20000`,
+    `#define PWM_BITS 10`,
+    ``,
+    `#define COUNTS_PER_REV1 ${motors.cpr || 1440}`,
+    `#define COUNTS_PER_REV2 ${motors.cpr || 1440}`,
+    `#define COUNTS_PER_REV3 ${motors.cpr || 1440}`,
+    `#define COUNTS_PER_REV4 ${motors.cpr || 1440}`,
+    ``,
+    `#define MOTOR1_INV ${!!motors.motor1_inv}`,
+    `#define MOTOR2_INV ${!!motors.motor2_inv}`,
+    `#define MOTOR3_INV ${!!motors.motor3_inv}`,
+    `#define MOTOR4_INV ${!!motors.motor4_inv}`,
+    `#define MOTOR1_ENCODER_INV ${!!(pins?.encoders?.m1_inv)}`,
+    `#define MOTOR2_ENCODER_INV ${!!(pins?.encoders?.m2_inv)}`,
+    `#define MOTOR3_ENCODER_INV ${!!(pins?.encoders?.m3_inv)}`,
+    `#define MOTOR4_ENCODER_INV ${!!(pins?.encoders?.m4_inv)}`,
+    ``,
+    `// Velocity PID Tuning Constants`,
+    `#define K_P ${spec.pid?.kp ?? 0.6}`,
+    `#define K_I ${spec.pid?.ki ?? 0.8}`,
+    `#define K_D ${spec.pid?.kd ?? 0.5}`,
+    ``,
+    `// Pin Assignments`,
+    `#define LED_PIN ${pins.led !== undefined ? pins.led : (["PICOW", "PICO2W"].includes(mcu) ? "LED_BUILTIN" : (mcu.includes("PICO") ? 25 : 2))}`
+  );
+
+  // ENCODER PINS (all 4, unconditional -- matches the hand-written headers)
+  const enc = pins.encoders || {};
+  const pinVal = (v) => (v !== undefined && v !== null && v !== "") ? v : -1;
+  lines.push(``, `// ENCODER PINS`);
+  for (let i = 1; i <= 4; i++) {
+    lines.push(`#define MOTOR${i}_ENCODER_A ${pinVal(enc[`m${i}_a`])}`);
+    lines.push(`#define MOTOR${i}_ENCODER_B ${pinVal(enc[`m${i}_b`])}`);
+  }
+
+  // MOTOR PINS -- firmware.ino reads MOTORx_PWM / MOTORx_IN_A / MOTORx_IN_B for
+  // EVERY driver (see firmware/src/firmware.ino motorN_controller(...) and
+  // firmware/lib/motor/default_motor.h). Keep this identical to generator.py.
+  lines.push(``, `// MOTOR PINS`);
+  lines.push(`#ifdef USE_${driver}_MOTOR_DRIVER`);
+  for (let i = 1; i <= 4; i++) {
+    const m = pins[`motor${i}`] || {};
+    if (driver === "BTS7960") {
+      // BTS7960 uses two outputs only: IN_A = RPWM, IN_B = LPWM.
+      // MOTORx_PWM is an unused arg in the driver class -> fixed placeholder.
+      lines.push(`  #define MOTOR${i}_PWM -1 //DON'T TOUCH THIS! This is just a placeholder`);
+      lines.push(`  #define MOTOR${i}_IN_A ${pinVal(m.in_a !== undefined ? m.in_a : m.pwm_l)}`);
+      lines.push(`  #define MOTOR${i}_IN_B ${pinVal(m.in_b !== undefined ? m.in_b : m.en)}`);
+    } else if (driver === "GENERIC_1_IN") {
+      lines.push(`  #define MOTOR${i}_PWM ${pinVal(m.pwm)}`);
+      lines.push(`  #define MOTOR${i}_IN_A ${pinVal(m.dir !== undefined ? m.dir : m.in_a)}`);
+      lines.push(`  #define MOTOR${i}_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder`);
+    } else if (driver === "ESC") {
+      lines.push(`  #define MOTOR${i}_PWM ${pinVal(m.pwm)}`);
+      lines.push(`  #define MOTOR${i}_IN_A -1 //DON'T TOUCH THIS! This is just a placeholder`);
+      lines.push(`  #define MOTOR${i}_IN_B -1 //DON'T TOUCH THIS! This is just a placeholder`);
+    } else {
+      // GENERIC_2_IN (default)
+      lines.push(`  #define MOTOR${i}_PWM ${pinVal(m.pwm)}`);
+      lines.push(`  #define MOTOR${i}_IN_A ${pinVal(m.in_a)}`);
+      lines.push(`  #define MOTOR${i}_IN_B ${pinVal(m.in_b)}`);
+    }
+  }
+  lines.push(`  #define PWM_MAX pow(2, PWM_BITS) - 1`);
+  lines.push(`  #define PWM_MIN -PWM_MAX`);
+  lines.push(`#endif`);
+
+  lines.push(``, `// Sensor Configurations`);
+  if (sensors.imu === "FAKE" || sensors.imu === "FAKE_IMU") {
+    lines.push(`#define USE_FAKE_IMU`);
+  } else if (sensors.imu && sensors.imu !== "NONE") {
+    lines.push(`#define USE_${sensors.imu}_IMU`);
+  }
+  if (sensors.mag && sensors.mag !== "NONE") {
+    lines.push(`#define USE_${sensors.mag}_MAG`);
+  } else {
+    lines.push(`#define USE_FAKE_MAG`);
+  }
+
+  // IMU / magnetometer tuning — MAG_BIAS is #ifdef-gated in firmware.ino;
+  // ACCEL_COV / GYRO_COV / ORI_COV are #ifndef-gated in imu_interface.h.
+  const tune = spec.imu_tuning || {};
+  if (Array.isArray(tune.mag_bias) && tune.mag_bias.length === 3) {
+    lines.push(`#define MAG_BIAS { ${tune.mag_bias.map(Number).join(", ")} }`);
+  }
+  const covLine = (macro, v, n = 3) => {
+    if (v == null || v === "") return;
+    let t;
+    if (Array.isArray(v)) t = v.map(Number);
+    else {
+      const s = String(v).trim();
+      t = s.includes(",") ? s.split(",").map((x) => Number(x.trim()))
+                          : Array(n).fill(Number(s));
+    }
+    if (t.some((x) => Number.isNaN(x))) return;
+    lines.push(`#define ${macro} { ${t.join(", ")} }`);
+  };
+  covLine("ACCEL_COV", tune.accel_cov);
+  covLine("GYRO_COV", tune.gyro_cov);
+  covLine("ORI_COV", tune.ori_cov);
+  covLine("MAG_COV", tune.mag_cov);
+  covLine("POSE_COV", tune.pose_cov, 6);
+  covLine("TWIST_COV", tune.twist_cov, 6);
+  covLine("ENV_COV", tune.env_cov, 3);   // { pressure, temperature, humidity } variance
+
+  if (sensors.battery_monitor === "ADC_DIVIDER") {
+    const numFmt = (x) => { const f = Number(x); return Number.isInteger(f) ? String(f) : String(f).replace(/0+$/,"").replace(/\.$/,""); };
+    const r1k = numFmt((sensors.battery_r1 || 30000) / 1000);
+    const r2k = numFmt((sensors.battery_r2 || 7500) / 1000);
+    const isRp2 = mcu.includes("PICO") || mcu.includes("RP2");
+    lines.push(`#define BATTERY_PIN ${pins.battery_pin ?? 26}`);
+    // DAC output pin for the adc_calibrate sweep — hardware DAC only exists on
+    // ESP32 / ESP32-S2 / GENDRV.
+    const _dacPin = pins.dac_pin ?? sensors.dac_pin;
+    if (mcuHasDac(mcu) && _dacPin != null && Number(_dacPin) >= 0) {
+      lines.push(`#define DAC_PIN ${Number(_dacPin)}`);
+    }
+    // firmware/lib/battery/battery.cpp calls BATTERY_ADJUST(reading) with no
+    // #ifndef fallback — an ADC battery config MUST define it. ESP32
+    // analogReadMilliVolts() returns mV; RP2040 analogRead() returns 12-bit counts.
+    if (spec.adc_lut || sensors.adc_lut) {
+      lines.push(
+        `#define USE_ADC_LUT`,
+        formatAdcLutArray(spec.adc_lut || sensors.adc_lut),
+        `#define BATTERY_ADJUST(v) (ADC_LUT[v] * (3.3 / 4096 * (${r1k} + ${r2k}) / ${r2k}))`
+      );
+    } else if (isRp2) {
+      lines.push(`#define BATTERY_ADJUST(v) ((v) * (3.3 / 4096 * (${r1k} + ${r2k}) / ${r2k}))`);
+    } else {
+      lines.push(`#define BATTERY_ADJUST(v) ((v) * ((${r1k} + ${r2k}) / ${r2k}) / 1000.0)`);
+    }
+    if (sensors.battery_min_voltage != null) lines.push(`#define BATTERY_MIN ${numFmt(sensors.battery_min_voltage)}`);
+    if (sensors.battery_max_voltage != null) lines.push(`#define BATTERY_MAX ${numFmt(sensors.battery_max_voltage)}`);
+    if (sensors.battery_capacity != null)    lines.push(`#define BATTERY_CAP ${numFmt(sensors.battery_capacity)}`);
+    if (sensors.battery_dip != null)         lines.push(`#define BATTERY_DIP ${numFmt(sensors.battery_dip)}`);
+  } else if (sensors.battery_monitor === "INA219") {
+    lines.push(`#define USE_INA219`);
+  }
+
+  // Environmental barometer — BMP280 & BME280 share the macro; the driver
+  // reads the chip id at runtime and only publishes /humidity for a BME280.
+  if (sensors.env && sensors.env !== "NONE") {
+    lines.push(`#define USE_BMP280`);
+  }
+
+  if (sensors.sonar && pins.sonar) {
+    lines.push(
+      `#define USE_SONAR`,
+      `#define TRIG_PIN ${pins.sonar.trig || 0}`,
+      `#define ECHO_PIN ${pins.sonar.echo || 0}`
+    );
+  }
+
+  // I2C bus + BOARD_INIT. SDA_PIN/SCL_PIN are ONLY consulted through the
+  // BOARD_INIT macro (firmware.ino: `#ifdef BOARD_INIT ... #else Wire.begin();
+  // #endif` — firmware is never touched for this). BOARD_INIT is synthesised
+  // only when the user has defined I2C pins; a bare module leaves SDA/SCL
+  // unset and no BOARD_INIT is emitted (default Wire.begin() applies).
+  const i2c = pins.i2c || {};
+  const i2cUsed = (sensors.imu && sensors.imu !== "FAKE" && sensors.imu !== "FAKE_IMU" && sensors.imu !== "NONE")
+               || (sensors.mag && sensors.mag !== "NONE")
+               || sensors.battery_monitor === "INA219"
+               || (sensors.env && sensors.env !== "NONE");
+  const sda = i2c.sda, scl = i2c.scl;
+  if (i2cUsed && sda !== undefined && scl !== undefined && sda >= 0 && scl >= 0) {
+    lines.push(``, `// I2C Bus`, `#define SDA_PIN ${sda}`, `#define SCL_PIN ${scl}`);
+    const bi = [`#define BOARD_INIT { \\`];
+    bi.push(`    Wire.begin(SDA_PIN, SCL_PIN); \\`);
+    bi.push(`    Wire.setClock(400000); \\`);
+    bi.push(`}`);
+    lines.push(...bi);
+  }
+
+  // Communication & Network Settings
+  const transport = (spec.transport || "SERIAL").toUpperCase();
+  const wifi = spec.wifi_settings || {};
+  const isWifiTransport = transport.includes("WIFI") || transport.includes("UDP");
+  const enableWifiNet = isWifiTransport || !!spec.enable_ota_syslog;
+
+  if (!isWifiTransport) {
+    const baudrate = spec.baudrate || spec.telemetry?.baudrate || (mcu === "GENDRV" ? 1500000 : 921600);
+    lines.push(
+      ``,
+      `// Serial Communication Settings`,
+      `#define BAUDRATE ${baudrate}`
+    );
+  }
+
+  // ROS 2 topic namespace prefix (firmware.ino concatenates it onto each
+  // topic string literal; #ifndef-gated so blank == bare topic names).
+  const topicPrefix = (spec.advanced?.topic_prefix || "").trim();
+  if (topicPrefix) {
+    const tp = topicPrefix.endsWith("/") ? topicPrefix : topicPrefix + "/";
+    lines.push(``, `// ROS 2 Topic Namespace`, `#define TOPIC_PREFIX "${tp}"`);
+  }
+
+  // Hardware Task Watchdog (WDT)
+  if (spec.watchdog && (spec.watchdog.enabled || spec.watchdog > 0)) {
+    const to = spec.watchdog.timeout_sec || (typeof spec.watchdog === "number" ? spec.watchdog : 60);
+    lines.push(``, `// Hardware Task Watchdog`, `#define WDT_TIMEOUT ${to} // Seconds`);
+  } else {
+    lines.push(``, `// #define WDT_TIMEOUT 60 // Hardware Task Watchdog disabled`);
+  }
+
+
+  // IPv4 "a.b.c.d" -> C brace-init `{ a, b, c, d }` (the form every stock
+  // header uses; converts cleanly to IPAddress for AGENT_IP / SYSLOG_SERVER
+  // / LIDAR_SERVER).
+  const ipC = (s, fb) => {
+    const p = String(s || fb || "192.168.1.100").split(".").map(x => x.trim());
+    return p.length === 4 && p.every(x => /^\d+$/.test(x)) ? `{ ${p.join(", ")} }` : "{ 192, 168, 1, 100 }";
+  };
+  const adv = spec.advanced || {};
+
+  // Never emit WIFI_AP_LIST with a placeholder SSID — initWifis() blocks at
+  // boot until it joins, so a placeholder would brick a bare board.
+  const _haveRealSsid = wifi.ssid && wifi.ssid.trim() && wifi.ssid.trim() !== "YOUR_WIFI_SSID";
+
+  // For a WiFi-UDP transport the PlatformIO env pins board_microros_transport =
+  // wifi, so firmware.ino compiles `set_microros_net_transports(AGENT_IP,
+  // AGENT_PORT)` unconditionally — those two macros MUST exist even before the
+  // user fills in credentials. They are not secrets: emit compile-safe
+  // #ifndef-guarded defaults here, and let the git-ignored wifi_config.h
+  // override them once real values are entered.
+  if (isWifiTransport) {
+    const agentIp = adv.agent_ip || wifi.agent_ip || "192.168.1.100";
+    lines.push(
+      ``,
+      `// micro-ROS WiFi transport (credentials & host IPs -> git-ignored wifi_config.h)`,
+      `#if __has_include("wifi_config.h")`,
+      `  #include "wifi_config.h"`,
+      `#endif`,
+      `#define USE_WIFI`,
+      `#ifndef AGENT_IP`,
+      `  #define AGENT_IP ${ipC(agentIp)}`,
+      `#endif`,
+      `#ifndef AGENT_PORT`,
+      `  #define AGENT_PORT ${wifi.agent_port || 8888}`,
+      `#endif`
+    );
+  }
+
+  if (enableWifiNet && _haveRealSsid) {
+    // Secrets (WIFI_AP_LIST, AGENT_IP, SYSLOG_SERVER, LIDAR_SERVER, OTA_PASSWORD)
+    // live ONLY in the git-ignored config/custom/wifi_config.h — this tracked
+    // header carries the non-secret feature flags and pulls the rest in.
+    if (!isWifiTransport) {
+      lines.push(
+        ``,
+        `// Background WiFi (OTA & Syslog telemetry while micro-ROS runs on Serial)`,
+        `// Credentials & host IPs are in the git-ignored config/custom/wifi_config.h`,
+        `// (regenerated by the deploy from your form; template: wifi_config.h.template).`,
+        `#if __has_include("wifi_config.h")`,
+        `  #include "wifi_config.h"`,
+        `#endif`
+      );
+    }
+    lines.push(`#define USE_ARDUINO_OTA`);
+    lines.push(`#define OTA_HOSTNAME "${adv.ota_hostname || spec.robot_name || "linorobot2"}"`);
+    lines.push(
+      `#define USE_SYSLOG`,
+      `#define SYSLOG_PORT ${adv.syslog_port || 514}`,
+      `#define DEVICE_HOSTNAME "${spec.robot_name || "robot"}"`,
+      `#define APP_NAME "hardware"`
+    );
+    if (adv.wifi_monitor && adv.wifi_monitor > 0) {
+      lines.push(`#define WIFI_MONITOR ${adv.wifi_monitor} // min. period to send WiFi RSSI to syslog`);
+    }
+    // LiDAR-over-UDP forwarding — only when the user ticked "Forward LiDAR
+    // over UDP" (a non-blank IP field default must NOT enable it; USE_LIDAR_UDP
+    // pulls in ESP32-only HardwareSerial APIs that break the Pico build).
+    if (spec.telemetry?.use_lidar_udp) {
+      lines.push(
+        `#define USE_LIDAR_UDP`,
+        `#define LIDAR_PORT ${adv.lidar_port || 8889}`,
+        `#define LIDAR_BAUDRATE ${adv.lidar_baudrate || 230400}`,
+        `#define LIDAR_SERIAL ${adv.lidar_serial != null ? adv.lidar_serial : 1} // UART number`,
+        `#define LIDAR_RXD ${adv.lidar_rxd != null ? adv.lidar_rxd : -1}`
+      );
+    }
+  }
+
+  // Simulation and the dual-core control task do not mix: the fake LiDAR
+  // touches the simulated pose and its UART from the loop while the control
+  // task drives the same pose from the other core, with no lock between them,
+  // and the board crash-loops. Simulation wins -- it is the whole point of
+  // this config -- so the second core is left alone here.
+  const simEnabled = !!(spec.simulation?.fake_wheel || spec.simulation?.fake_ld19);
+  if (spec.dual_core !== false && !simEnabled) {
+    lines.push(
+      ``,
+      `// Dual-Core Task Allocation (Strict 50Hz Real-Time PID on Core 1)`,
+      `#define USE_DUAL_CORE`
+    );
+  }
+
+  // Simulation & Fake Hardware Modes
+  const sim = spec.simulation || {};
+  // Mirror the warning the Python generator emits: a simulated config is
+  // indistinguishable from a real one at a glance, and publishes plausible
+  // topics, so a wired robot flashed with it sits still while /odom claims
+  // otherwise. Keep it above the defines it refers to.
+  if (sim.fake_wheel || sim.fake_ld19) {
+    lines.push(
+      ``,
+      `// ===========================================================================`,
+      `// SIMULATION MODE IS ENABLED -- THIS IS NOT A REAL ROBOT CONFIG`,
+      `// Comment out the USE_FAKE_* defines below before flashing a robot whose`,
+      `// motors, encoders or LiDAR are actually wired, or they will be ignored.`,
+      `// ===========================================================================`
+    );
+  }
+  if (sim.fake_wheel) {
+    lines.push(
+      ``,
+      `// Drivetrain Simulation (Bare Module Mode)`,
+      `// Simulates DC motor back-EMF, inertia, and encoders on-board.`,
+      `#define USE_FAKE_WHEEL`
+    );
+    if (sim.robot_mass != null) {
+      lines.push(`#define ROBOT_WEIGHT ${sim.robot_mass}`);
+    }
+    if (sim.wheel_noise_rpm != null) {
+      lines.push(`#define FAKE_WHEEL_NOISE_RPM ${sim.wheel_noise_rpm}`);
+    }
+  }
+
+  // The emulated scan leaves the board either over the LiDAR UART pin or over
+  // WiFi UDP. With neither, there is nowhere for it to go, so the emulator is
+  // not enabled at all: turning it on would burn the loop building packets and
+  // writing them into an unconnected pad, while the board reported success and
+  // no scan ever reached ROS. The pin is unset by default because on a stock
+  // board nothing is wired to it -- wire it, set the pin, and this switches on.
+  const lidarRxd = spec.pins?.lidar_rxd ?? spec.advanced?.lidar_rxd;
+  // A negative pin is "not wired", not a pin number.
+  const lidarPinWired = lidarRxd != null && lidarRxd >= 0;
+  const lidarOverUdp = !!spec.telemetry?.use_lidar_udp;
+  const ld19Routed = lidarPinWired || lidarOverUdp;
+
+  if (sim.fake_ld19 && !ld19Routed) {
+    lines.push(
+      ``,
+      `// Fake LD19 requested but NOT enabled: no LiDAR UART pin is wired and`,
+      `// LiDAR-over-UDP is off, so the simulated scan would have no route out.`,
+      `// Any route over the serial pin needs a physical wire: fake LD19`,
+      `// transmits the scan on it, and a real LD19 forwarded over UDP must`,
+      `// be wired into it, since UDP only carries what the board receives.`,
+      `// Fake LD19 over WiFi UDP is the one option needing no wire at all.`,
+      `// Wire IO4 (gendrv) and set the pin, or turn on LiDAR over WiFi UDP.`
+    );
+  }
+
+  if (sim.fake_ld19 && ld19Routed) {
+    lines.push(
+      ``,
+      `// Fake LD19 LiDAR Simulation Mode`,
+      `// Embeds a real-time 2D raycast LD19 emulator inside the firmware.`,
+      `// Outputs standard 47-byte packets @ 230400 baud on LIDAR_RXD / UDP.`,
+      `#define USE_FAKE_LD19`
+    );
+    if (lidarPinWired) {
+      lines.push(`#define LIDAR_RXD ${lidarRxd}`);
+    }
+    if (sim.map_width != null) {
+      lines.push(`#define FAKE_MAP_WIDTH ${sim.map_width}`);
+    }
+    if (sim.map_height != null) {
+      lines.push(`#define FAKE_MAP_HEIGHT ${sim.map_height}`);
+    }
+    if (sim.wall_obstacle) {
+      lines.push(`#define FAKE_WALL_OBSTACLE 1`);
+      if (sim.wall_x1 != null) lines.push(`#define FAKE_WALL_X1 ${sim.wall_x1}`);
+      if (sim.wall_y1 != null) lines.push(`#define FAKE_WALL_Y1 ${sim.wall_y1}`);
+      if (sim.wall_x2 != null) lines.push(`#define FAKE_WALL_X2 ${sim.wall_x2}`);
+      if (sim.wall_y2 != null) lines.push(`#define FAKE_WALL_Y2 ${sim.wall_y2}`);
+    }
+    if (sim.fake_sonar !== false) {
+      lines.push(
+        ``,
+        `// Simulated forward sonar, taken from the nearest return in a cone of`,
+        `// the same raycast that feeds the scan -- no pins, no wiring.`,
+        `#define USE_FAKE_SONAR`,
+        `// Firmware-side hazard stop: blocks forward motion inside`,
+        `// SAFETY_STOP_RANGE and publishes the state on /safety_stop. Reverse is`,
+        `// left available so the robot can back out of what it stopped for.`,
+        `#define USE_SAFETY_STOP`
+      );
+    }
+  }
+
+  lines.push(``, `#endif // ${nameUpper}_CONFIG_H`, ``);
+  return lines.join("\n");
+}
+
+// Secrets file — WiFi credentials + host IPs. Written to config/custom/wifi_config.h,
+// which is git-ignored, so `git add config/` never commits them. Empty string
+// when the spec has no real WiFi SSID (nothing to write).
+function generateWifiConfig(spec) {
+  const wifi = spec.wifi_settings || {};
+  const adv = spec.advanced || {};
+  const ssid = (wifi.ssid || "").trim();
+  if (!ssid || ssid === "YOUR_WIFI_SSID") return "";
+  const transport = (spec.transport || "SERIAL").toUpperCase();
+  const isWifiTransport = /WIFI|UDP/.test(transport);
+  const enableWifiNet = isWifiTransport || !!spec.enable_ota_syslog;
+  if (!enableWifiNet) return "";
+  const password = wifi.password || "";
+  const ipC = (s, fb) => {
+    const p = String(s || fb || "192.168.1.100").split(".").map(x => x.trim());
+    return p.length === 4 && p.every(x => /^\d+$/.test(x)) ? `{ ${p.join(", ")} }` : "{ 192, 168, 1, 100 }";
+  };
+  const agentIpStr = adv.agent_ip || wifi.agent_ip || "192.168.1.100";
+  const L = [
+    `// config/custom/wifi_config.h  —  generated by the Robot Configuration Engine`,
+    `// GIT-IGNORED: your WiFi credentials and host IPs are never committed.`,
+    `// Delete this file to let the studio regenerate it, or edit it by hand`,
+    `// (multiple APs, static IPs, …). Template: wifi_config.h.template.`,
+    ``,
+    `#define WIFI_AP_LIST { { "${ssid}", "${password}" }, { NULL, NULL } }`,
+  ];
+  if (isWifiTransport) L.push(`#define AGENT_IP ${ipC(agentIpStr)}`);
+  L.push(`#define SYSLOG_SERVER ${ipC(adv.syslog_ip, agentIpStr)}`);
+  if (spec.telemetry?.use_lidar_udp) L.push(`#define LIDAR_SERVER ${ipC(adv.lidar_ip, agentIpStr)}`);
+  if (adv.ota_password) L.push(`#define OTA_PASSWORD "${adv.ota_password}"`);
+  L.push(``);
+  return L.join("\n");
+}
+
+function generatePlatformioEnv(spec) {
+  const name = spec.robot_name || "my_robot";
+  const mcu = (spec.mcu || "PICO2").toUpperCase();
+  const cfgMacro = `USE_${name.toUpperCase()}_CONFIG`;
+  const isWifi = /WIFI|UDP/i.test(spec.transport || "");
+  const wifiTransportLine = isWifi ? "board_microros_transport = wifi\n" : "";
+  const wifiFlag = isWifi ? "\n    -D USE_STAY_CONNECTED" : "";
+
+  if (mcu === "PICO" || mcu === "PICO2" || mcu === "PICOW" || mcu === "PICO2W") {
+    const boardMap = { PICO: "rpipico", PICO2: "rpipico2", PICOW: "rpipicow", PICO2W: "rpipico2w" };
+    const board = boardMap[mcu] || "rpipico";
+    const picoMacro = (mcu === "PICOW" || mcu === "PICO2W") ? `    -D ${mcu}\n` : "";
+    return `[env:${name}]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = ${board}
+monitor_port = /dev/ttyACM0
+upload_port = /dev/ttyACM0
+upload_protocol = picotool
+board_microros_user_meta = atomic.meta
+${wifiTransportLine}lib_deps =
+    \${env.lib_deps}
+    https://github.com/gbr1/rp2040-encoder-library.git
+build_flags =
+    -I ../config
+    -D PICO
+${picoMacro}    -D ${cfgMacro}${wifiFlag}
+`;
+  } else if (mcu === "ESP32" || mcu === "GENDRV") {
+    const otaIp = (spec.advanced?.ota_enable && spec.advanced?.ota_ip) ? spec.advanced.ota_ip : "";
+    const upl = otaIp
+      ? `monitor_port = /dev/ttyUSB0\nupload_port = ${otaIp}\nupload_protocol = espota`
+      : `monitor_port = /dev/ttyUSB0\nupload_port = /dev/ttyUSB0\nupload_protocol = esptool`;
+    return `[env:${name}]
+platform = espressif32
+board = nodemcu-32s
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
+board_build.partitions = min_spiffs.csv
+monitor_speed = ${firmwareBaud(spec)}
+${upl}
+${wifiTransportLine}lib_deps =
+    \${env.lib_deps}
+    madhephaestus/ESP32Servo
+    madhephaestus/ESP32Encoder
+build_flags =
+    -I ../config
+    -D __PGMSPACE_H_
+    -D ${cfgMacro}${wifiFlag}
+`;
+  } else if (mcu === "ESP32S3") {
+    const isBridge = (spec.serial_interface || "CDC") === "BRIDGE";
+    const port = isBridge ? "/dev/ttyUSB0" : "/dev/ttyACM0";
+    const cdcFlag = isBridge ? "" : "\n    -D ARDUINO_USB_CDC_ON_BOOT";
+    return `[env:${name}]
+platform = espressif32
+board = esp32-s3-devkitc-1
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
+monitor_speed = ${firmwareBaud(spec)}
+monitor_port = ${port}
+upload_port = ${port}
+upload_protocol = esptool
+${wifiTransportLine}lib_deps =
+    \${env.lib_deps}
+    madhephaestus/ESP32Servo
+    madhephaestus/ESP32Encoder
+build_flags =
+    -I ../config${cdcFlag}
+    -D __PGMSPACE_H_
+    -D ${cfgMacro}${wifiFlag}
+`;
+  } else if (mcu === "ESP32S2") {
+    const isBridge = (spec.serial_interface || "CDC") === "BRIDGE";
+    const port = isBridge ? "/dev/ttyUSB0" : "/dev/ttyACM0";
+    const cdcFlag = isBridge ? "" : "\n    -D ARDUINO_USB_CDC_ON_BOOT";
+    return `[env:${name}]
+platform = espressif32
+board = esp32-s2-saola-1
+monitor_speed = ${firmwareBaud(spec)}
+monitor_port = ${port}
+upload_port = ${port}
+upload_protocol = esptool
+${wifiTransportLine}lib_deps =
+    \${env.lib_deps}
+    madhephaestus/ESP32Servo
+    madhephaestus/ESP32Encoder
+build_flags =
+    -I ../config${cdcFlag}
+    -D __PGMSPACE_H_
+    -D ${cfgMacro}${wifiFlag}
+`;
+  }
+  return "";
+}
+
+function generateUrdfXacro(spec) {
+  const geom = spec.geometry || {};
+  const wheelD = geom.wheel_diameter || 0.08;
+  const wheelR = wheelD / 2.0;
+  const trackW = geom.track_width || 0.22;
+  const wheelPosY = trackW / 2.0;
+
+  return `<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:property name="wheel_radius" value="${wheelR.toFixed(4)}" />
+  <xacro:property name="wheel_width" value="0.026" />
+  <xacro:property name="wheel_pos_x" value="0.0" />
+  <xacro:property name="wheel_pos_y" value="${wheelPosY.toFixed(4)}" />
+  <xacro:property name="wheel_pos_z" value="-0.010" />
+  <xacro:property name="wheel_mass" value="0.05" />
+
+  <xacro:property name="base_length" value="${(trackW * 1.2).toFixed(3)}" />
+  <xacro:property name="base_width" value="${(trackW * 0.9).toFixed(3)}" />
+  <xacro:property name="base_height" value="0.070" />
+  <xacro:property name="base_mass" value="1.2" />
+
+  <xacro:property name="laser_pose">
+    <origin xyz="0.05 0 0.08" rpy="0 0 0"/>
+  </xacro:property>
+</robot>
+`;
+}
+
+function generateWiringTable(spec) {
+  const mcu = spec.mcu;
+  const pins = spec.pins || {};
+  const driver = spec.motors?.driver_type || "GENERIC_2_IN";
+  const is4WD = spec.kinematics !== "DIFFERENTIAL_DRIVE";
+
+  const rows = [
+    `# 🔌 Wiring & Pinout Chart for ${spec.robot_name}`,
+    `**Microcontroller**: ${mcu} | **Kinematics**: ${spec.kinematics} | **Driver**: ${driver}`,
+    ``,
+    `| Function | MCU Pin (GPIO) | Target Peripheral / Signal | Wire Color / Notes |`,
+    `| :--- | :---: | :--- | :--- |`,
+    `| **Status LED** | \`GPIO ${pins.led}\` | Onboard or External LED | Status Blinker |`
+  ];
+
+  const numMotors = is4WD ? 4 : 2;
+  for (let i = 1; i <= numMotors; i++) {
+    const m = pins[`motor${i}`] || {};
+    if (driver === "BTS7960") {
+      const inA = m.in_a !== undefined ? m.in_a : m.pwm_l;
+      const inB = m.in_b !== undefined ? m.in_b : m.en;
+      rows.push(`| **Motor ${i} RPWM** | \`GPIO ${inA}\` | BTS7960 RPWM -> MOTOR${i}_IN_A | Forward PWM |`);
+      rows.push(`| **Motor ${i} LPWM** | \`GPIO ${inB}\` | BTS7960 LPWM -> MOTOR${i}_IN_B | Reverse PWM |`);
+    } else {
+      rows.push(`| **Motor ${i} PWM** | \`GPIO ${m.pwm}\` | Driver PWM / ENA | Speed Control |`);
+      rows.push(`| **Motor ${i} IN_A** | \`GPIO ${m.in_a}\` | Driver IN1 / DIR | Direction Line A |`);
+      rows.push(`| **Motor ${i} IN_B** | \`GPIO ${m.in_b}\` | Driver IN2 | Direction Line B |`);
+    }
+  }
+
+  const enc = pins.encoders || {};
+  for (let i = 1; i <= numMotors; i++) {
+    rows.push(`| **Encoder ${i} Phase A** | \`GPIO ${enc[`m${i}_a`]}\` | Wheel ${i} Encoder A | Hardware Interrupt |`);
+    rows.push(`| **Encoder ${i} Phase B** | \`GPIO ${enc[`m${i}_b`]}\` | Wheel ${i} Encoder B | Direction Read |`);
+  }
+
+  if (pins.i2c) {
+    rows.push(`| **I2C SDA** | \`GPIO ${pins.i2c.sda}\` | IMU / Mag / INA219 SDA | I2C Data Line (4.7kΩ Pullup) |`);
+    rows.push(`| **I2C SCL** | \`GPIO ${pins.i2c.scl}\` | IMU / Mag / INA219 SCL | I2C Clock Line (4.7kΩ Pullup) |`);
+  }
+
+  if (spec.sensors?.battery_monitor === "ADC_DIVIDER" && pins.battery_pin !== undefined) {
+    rows.push(`| **Battery Divider** | \`GPIO ${pins.battery_pin}\` | Voltage Divider Center | 30kΩ/7.5kΩ Divider to V_BAT |`);
+  }
+
+  if (spec.sensors?.sonar && pins.sonar) {
+    rows.push(`| **Sonar Trigger** | \`GPIO ${pins.sonar.trig}\` | HC-SR04 Trig | 10us Output Pulse |`);
+    rows.push(`| **Sonar Echo** | \`GPIO ${pins.sonar.echo}\` | HC-SR04 Echo | 5V->3.3V Voltage Divider Recommended |`);
+  }
+
+  return rows.join("\n");
+}
+
+// Render the Active Code Tab
+function renderActiveCode() {
+  const display = document.getElementById("code-display");
+  let code = "";
+
+  if (activeArtifact === "tab-code-header") {
+    code = generateCppHeader(currentSpec);
+    display.className = "language-cpp";
+  } else if (activeArtifact === "tab-code-pio") {
+    code = generatePlatformioEnv(currentSpec);
+    display.className = "language-ini";
+  } else if (activeArtifact === "tab-code-urdf") {
+    code = generateUrdfXacro(currentSpec);
+    display.className = "language-xml";
+  } else if (activeArtifact === "tab-code-wiring") {
+    code = generateWiringTable(currentSpec);
+    display.className = "language-markdown";
+  } else if (activeArtifact === "tab-code-deploy") {
+    code = generateDeployScript(currentSpec, readAutomationOptions());
+    display.className = "language-bash";
+  } else if (activeArtifact === "tab-code-json") {
+    code = JSON.stringify(currentSpec, null, 2);
+    display.className = "language-json";
+  }
+
+  display.innerText = code;
+}
+
+// Smart Auto-Assign Pinout Algorithm
+function autoAssignPins() {
+  const mcu = currentSpec.mcu;
+  const is4WD = currentSpec.kinematics !== "DIFFERENTIAL_DRIVE";
+  const driver = currentSpec.motors?.driver_type || "GENERIC_2_IN";
+
+  if (mcu === "PICO" || mcu === "PICO2" || mcu === "PICOW" || mcu === "PICO2W") {
+    document.getElementById("pin-led").value = (mcu === "PICOW" || mcu === "PICO2W") ? 32 : 25;
+    document.getElementById("pin-i2c-sda").value = 0;
+    document.getElementById("pin-i2c-scl").value = 1;
+    document.getElementById("pin-battery").value = 26;
+    document.getElementById("pin-sonar-trig").value = 22;
+    document.getElementById("pin-sonar-echo").value = 27;
+
+    document.getElementById("pin-m1-p1").value = 10;
+    document.getElementById("pin-m1-p2").value = 11;
+    document.getElementById("pin-m1-p3").value = 12;
+
+    document.getElementById("pin-m2-p1").value = 13;
+    document.getElementById("pin-m2-p2").value = 14;
+    document.getElementById("pin-m2-p3").value = 15;
+
+    document.getElementById("pin-enc-1a").value = 2;
+    document.getElementById("pin-enc-1b").value = 3;
+    document.getElementById("pin-enc-2a").value = 4;
+    document.getElementById("pin-enc-2b").value = 5;
+
+    if (is4WD) {
+      document.getElementById("pin-m3-p1").value = 16;
+      document.getElementById("pin-m3-p2").value = 17;
+      document.getElementById("pin-m3-p3").value = 18;
+      document.getElementById("pin-m4-p1").value = 19;
+      document.getElementById("pin-m4-p2").value = 20;
+      document.getElementById("pin-m4-p3").value = 21;
+      document.getElementById("pin-enc-3a").value = 6;
+      document.getElementById("pin-enc-3b").value = 7;
+      document.getElementById("pin-enc-4a").value = 8;
+      document.getElementById("pin-enc-4b").value = 9;
+    }
+  } else if (mcu === "ESP32" || mcu === "GENDRV") {
+    document.getElementById("pin-led").value = 2;
+    document.getElementById("pin-i2c-sda").value = 21;
+    document.getElementById("pin-i2c-scl").value = 22;
+    document.getElementById("pin-battery").value = 36;
+    document.getElementById("pin-sonar-trig").value = 5;
+    document.getElementById("pin-sonar-echo").value = 17;
+
+    document.getElementById("pin-m1-p1").value = 13;
+    document.getElementById("pin-m1-p2").value = 14;
+    document.getElementById("pin-m1-p3").value = 27;
+
+    document.getElementById("pin-m2-p1").value = 25;
+    document.getElementById("pin-m2-p2").value = 26;
+    document.getElementById("pin-m2-p3").value = 33;
+
+    document.getElementById("pin-enc-1a").value = 4;
+    document.getElementById("pin-enc-1b").value = 32;
+    document.getElementById("pin-enc-2a").value = 35;
+    document.getElementById("pin-enc-2b").value = 34;
+
+    if (is4WD) {
+      document.getElementById("pin-m3-p1").value = 18;
+      document.getElementById("pin-m3-p2").value = 19;
+      document.getElementById("pin-m3-p3").value = 23;
+      document.getElementById("pin-m4-p1").value = 15;
+      document.getElementById("pin-m4-p2").value = 16;
+      document.getElementById("pin-m4-p3").value = 17;
+      document.getElementById("pin-enc-1a").value = 34;
+      document.getElementById("pin-enc-1b").value = 35;
+      document.getElementById("pin-enc-2a").value = 36;
+      document.getElementById("pin-enc-2b").value = 39;
+      document.getElementById("pin-enc-3a").value = 4;
+      document.getElementById("pin-enc-3b").value = 32;
+      document.getElementById("pin-enc-4a").value = 5;
+      document.getElementById("pin-enc-4b").value = 12;
+    }
+  } else if (mcu === "ESP32S3") {
+    document.getElementById("pin-led").value = 48;
+    document.getElementById("pin-i2c-sda").value = 41;
+    document.getElementById("pin-i2c-scl").value = 42;
+    document.getElementById("pin-battery").value = 3;
+    document.getElementById("pin-sonar-trig").value = 47;
+    document.getElementById("pin-sonar-echo").value = 40;
+
+    document.getElementById("pin-m1-p1").value = 1;
+    document.getElementById("pin-m1-p2").value = 2;
+    document.getElementById("pin-m1-p3").value = 4;
+
+    document.getElementById("pin-m2-p1").value = 5;
+    document.getElementById("pin-m2-p2").value = 6;
+    document.getElementById("pin-m2-p3").value = 7;
+
+    document.getElementById("pin-enc-1a").value = 14;
+    document.getElementById("pin-enc-1b").value = 15;
+    document.getElementById("pin-enc-2a").value = 16;
+    document.getElementById("pin-enc-2b").value = 17;
+
+    if (is4WD) {
+      document.getElementById("pin-m3-p1").value = 8;
+      document.getElementById("pin-m3-p2").value = 9;
+      document.getElementById("pin-m3-p3").value = 10;
+      document.getElementById("pin-m4-p1").value = 11;
+      document.getElementById("pin-m4-p2").value = 12;
+      document.getElementById("pin-m4-p3").value = 13;
+      document.getElementById("pin-enc-3a").value = 18;
+      document.getElementById("pin-enc-3b").value = 21;
+      document.getElementById("pin-enc-4a").value = 38;
+      document.getElementById("pin-enc-4b").value = 39;
+    }
+  }
+
+  showToast("⚡ Conflict-free pins auto-allocated!");
+  recomputeAll();
+}
+
+// Copy Code to Clipboard
+function copyActiveCode() {
+  const code = document.getElementById("code-display").innerText;
+  navigator.clipboard.writeText(code).then(() => {
+    const btnText = document.getElementById("copy-btn-text");
+    btnText.innerText = "Copied!";
+    showToast("📋 Code copied to clipboard!");
+    setTimeout(() => { btnText.innerText = "Copy"; }, 2000);
+  }).catch(err => {
+    showToast("❌ Failed to copy: " + err);
+  });
+}
+
+// Download Active Artifact File
+function downloadActiveArtifact() {
+  let content = "";
+  let filename = "";
+  const name = currentSpec.robot_name || "robot";
+
+  if (activeArtifact === "tab-code-header") {
+    content = generateCppHeader(currentSpec);
+    filename = `${name}_config.h`;
+  } else if (activeArtifact === "tab-code-pio") {
+    content = generatePlatformioEnv(currentSpec);
+    filename = "platformio_section.ini";
+  } else if (activeArtifact === "tab-code-urdf") {
+    content = generateUrdfXacro(currentSpec);
+    filename = `${name}_properties.urdf.xacro`;
+  } else if (activeArtifact === "tab-code-wiring") {
+    content = generateWiringTable(currentSpec);
+    filename = `${name}_wiring_table.md`;
+  } else if (activeArtifact === "tab-code-deploy") {
+    content = generateDeployScript(currentSpec, readAutomationOptions());
+    filename = `deploy_${name}.sh`;
+  } else if (activeArtifact === "tab-code-json") {
+    content = JSON.stringify(currentSpec, null, 2);
+    filename = `${name}_spec.json`;
+  }
+
+  triggerDownload(filename, content, "text/plain");
+}
+
+// Export Spec JSON
+function exportSpecJson() {
+  const jsonStr = JSON.stringify(currentSpec, null, 2);
+  const filename = `${currentSpec.robot_name || "robot"}_spec.json`;
+  triggerDownload(filename, jsonStr, "application/json");
+  showToast("📥 Specification exported!");
+}
+
+// JSON Import File Handler (for saved spec JSON files)
+async function handleImportFile(e) {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = async (event) => {
+    try {
+      const content = event.target.result;
+      const imported = JSON.parse(content);
+      baseConfigSpec = JSON.parse(JSON.stringify(imported));
+      currentSpec = imported;
+      populateFormFromSpec(currentSpec);
+      recomputeAll();
+      showToast(`✅ Successfully imported '${imported.robot_name || file.name}'!`);
+    } catch (err) {
+      alert('Error importing JSON: ' + err.message);
+    }
+  };
+  reader.readAsText(file);
+}
+
+// ─── Board Config Selector (reads firmware/platformio.ini via server) ───────
+
+let boardList = [];
+
+async function openBoardSelector() {
+  const modal = document.getElementById('modal-board-select');
+  const sel = document.getElementById('board-select');
+  const info = document.getElementById('board-select-info');
+  const confirmBtn = document.getElementById('btn-board-confirm');
+
+  modal.style.display = 'flex';
+  sel.innerHTML = '<option value="">Loading…</option>';
+  confirmBtn.disabled = true;
+  info.textContent = '';
+
+  try {
+    const res = await fetch('/api/boards');
+    const data = await res.json();
+    boardList = (data.boards || []).filter(b => b.config_exists);
+
+    if (boardList.length === 0) {
+      sel.innerHTML = '<option value="">No board configs found</option>';
+      info.textContent = 'No *_config.h files found in config/custom/. Check your repository.';
+      return;
+    }
+
+    sel.innerHTML = '<option value="">— Select a board environment —</option>' +
+      boardList.map(b => {
+        const desc = (b.display_name && b.display_name !== b.env) ? ` — ${b.display_name}` : '';
+        return `<option value="${b.env}">${b.env}${desc}  [${b.transport}]</option>`;
+      }).join('');
+
+    sel.addEventListener('change', () => {
+      const chosen = boardList.find(b => b.env === sel.value);
+      if (chosen) {
+        const speed = chosen.monitor_speed ? ` · ${chosen.monitor_speed} baud` : '';
+        const wifi  = chosen.wifi ? ' · WiFi transport' : ' · Serial transport';
+        info.innerHTML = `<b>[env:${chosen.env}]</b>${chosen.display_name && chosen.display_name !== chosen.env ? ` · ${chosen.display_name}` : ''}${speed}${wifi}<br>
+          <span style="opacity:.7;">Config: <code>${chosen.config_file}</code></span>`;
+        confirmBtn.disabled = false;
+      } else {
+        info.textContent = '';
+        confirmBtn.disabled = true;
+      }
+    });
+  } catch (err) {
+    sel.innerHTML = '<option value="">Error loading boards</option>';
+    info.textContent = 'Could not reach /api/boards — is the server running?';
+  }
+}
+
+async function loadBoardConfig(envName) {
+  try {
+    showToast('⏳ Loading board configuration…');
+    const res = await fetch('/api/load_board_config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ env: envName })
+    });
+    const data = await res.json();
+    if (data.status === 'ok' && data.spec) {
+      baseConfigSpec = JSON.parse(JSON.stringify(data.spec));
+      currentSpec = data.spec;
+      populateFormFromSpec(currentSpec);
+      recomputeAll();
+      const board = data.board || {};
+      showToast(`✅ Loaded '${envName}' (${board.display_name || envName})`);
+    } else {
+      throw new Error(data.error || 'Failed to load board config');
+    }
+  } catch (err) {
+    alert('Error loading board config: ' + err.message);
+  }
+}
+
+// Trigger Client-Side File Download
+function triggerDownload(filename, text, mimeType) {
+  const blob = new Blob([text], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// Show Toast Notification
+function showToast(message) {
+  const toast = document.getElementById("toast");
+  toast.innerText = message;
+  toast.classList.add("show");
+  setTimeout(() => {
+    toast.classList.remove("show");
+  }, 2500);
+}
+
+
+// =============================================================================
+// Automation Hub, OS Detection, Deploy Script Generator & Web Serial Console
+// =============================================================================
+
+// Web Serial Global State
+let serialPort = null;
+let serialReader = null;
+let isSerialReading = false;
+
+// Robot Host SBC Environment Auto-Detection (Execution Destination)
+function syncRobotHostInfo(data) {
+  if (!data) return;
+
+  const node = data.node || "Robot Computer";
+  const arch = data.machine || "aarch64";
+  const distroId = (data.distro_id || "").toLowerCase();
+  const distroName = data.distro_name || data.os || "Linux";
+  const ports = data.serial_ports || [];
+  const rosDistros = data.installed_ros_distros || [];
+
+  // Update Header Badges
+  const headerIcon = document.getElementById("header-os-icon");
+  const headerText = document.getElementById("header-os-text");
+  if (headerIcon) headerIcon.innerText = "🤖";
+  if (headerText) headerText.innerText = `Robot Host: ${node} (${arch})`;
+
+  // Update Banner in Tab 5
+  const bannerIcon = document.getElementById("os-banner-icon");
+  const bannerText = document.getElementById("os-banner-detected-text");
+  const bannerArch = document.getElementById("os-banner-arch");
+  const bannerPorts = document.getElementById("os-banner-ports");
+  const bannerStatus = document.getElementById("os-banner-status");
+
+  if (bannerIcon) bannerIcon.innerText = "🤖";
+  if (bannerText) bannerText.innerText = `Target Robot Computer: ${node} (${distroName})`;
+  if (bannerArch) bannerArch.innerText = arch;
+  if (bannerPorts) {
+    bannerPorts.innerText = ports.length > 0 ? ports.join(", ") : "No USB serial MCUs detected (plug in Pico / ESP32)";
+    bannerPorts.style.color = ports.length > 0 ? "var(--success)" : "var(--text-dim)";
+  }
+  if (bannerStatus) {
+    bannerStatus.innerText = data.has_pio ? "PlatformIO Ready" : (isRunnerOnline ? "Runner Online" : "Disconnected");
+    bannerStatus.className = `badge-pill ${data.has_pio || isRunnerOnline ? "badge-ok" : "badge-warn"}`;
+  }
+
+  // Set Default Dropdowns if not manually touched
+  const osSelect = document.getElementById("auto-os-select");
+  if (osSelect && !osSelect.dataset.userModified) {
+    if (distroId.includes("ubuntu")) {
+      if (data.release && data.release.includes("26.04")) osSelect.value = "ubuntu_2604";
+      else if (data.release && data.release.includes("22.04")) osSelect.value = "ubuntu_2204";
+      else osSelect.value = "ubuntu_2404";
+    } else if (distroId.includes("debian")) {
+      osSelect.value = "debian";
+    } else if (distroId.includes("fedora") || distroId.includes("bluefin")) {
+      osSelect.value = "fedora";
+    }
+  }
+
+  const archSelect = document.getElementById("auto-arch-select");
+  if (archSelect && !archSelect.dataset.userModified) {
+    archSelect.value = arch.includes("arm") || arch.includes("aarch64") ? "aarch64" : "x86_64";
+  }
+
+  const rosSelect = document.getElementById("auto-ros-distro");
+  if (rosSelect && !rosSelect.dataset.userModified && rosDistros.length > 0) {
+    if (rosDistros.includes("jazzy")) rosSelect.value = "jazzy";
+    else if (rosDistros.includes("lyrical")) rosSelect.value = "lyrical";
+    else if (rosDistros.includes("rolling")) rosSelect.value = "rolling";
+  }
+
+  // Auto-populate detected serial port into flash / agent controls with USB VID:PID & chip info
+  const chipsContainer = document.getElementById("flash-port-chips");
+  if (chipsContainer) {
+    const portDetails = data.port_details || [];
+    if (ports.length > 0) {
+      chipsContainer.innerHTML = `<span class="chips-label">Detected USB Devices:</span> ` + ports.map(p => {
+        const detail = portDetails.find(d => d.port === p) || {};
+        const isBootsel = !!detail.is_bootsel;
+        const isOk = detail.accessible !== false;
+        const vidPid = detail.vid && detail.pid ? `[${detail.vid}:${detail.pid}]` : "";
+        const chip = detail.chip || (detail.product ? detail.product : (isBootsel ? "RP2 Bootloader" : "USB Serial"));
+        const icon = isBootsel ? "⚡📦" : (isOk ? "⚡" : "⚠️");
+        const badgeClass = isBootsel ? "port-chip port-chip-bootsel" : (isOk ? "port-chip" : "port-chip port-chip-warn");
+        const title = `${p} ${vidPid} - ${chip} | Read/Write: ${isOk ? "Granted" : "Denied (dialout required)"}`;
+        return `<button type="button" class="${badgeClass}" data-port="${p}" title="${title}">
+          <span class="chip-icon">${icon}</span>
+          <span class="chip-port">${p}</span>
+          ${vidPid ? `<span class="chip-vidpid">${vidPid}</span>` : ""}
+          <span class="chip-desc">${chip}</span>
+          ${!isOk ? `<span class="chip-lock">[No RW Access]</span>` : ""}
+        </button>`;
+      }).join(" ");
+
+      chipsContainer.querySelectorAll(".port-chip").forEach(btn => {
+        btn.addEventListener("click", () => {
+          const p = btn.dataset.port;
+          const flashPortInput = document.getElementById("auto-flash-port");
+          if (flashPortInput) {
+            flashPortInput.value = p;
+            flashPortInput.dataset.autoManaged = "false";
+          }
+          const detail = (data.port_details || []).find(d => d.port === p);
+          const guessed = guessMcuFromUsbDetail(detail);
+          if (guessed) {
+            applyDetectedChipToBaudUi(guessed);
+            defaultSimulationForDetectedModule(guessed.chipName);
+            const mcuSelect = document.getElementById("cfg-mcu");
+            if (mcuSelect && mcuSelect.value !== guessed.mcu) {
+              mcuSelect.value = guessed.mcu;
+              mcuSelect.dispatchEvent(new Event("change"));
+            }
+            applyMcuRobotName(guessed.mcu);
+            showToast(`⚡ Selected ${p} (${guessed.chipName}) — Target MCU: ${guessed.mcu}`);
+          } else {
+            showToast(`🔌 Selected upload port: ${p}`);
+          }
+          updateAutomationPreviews();
+        });
+      });
+    } else {
+      chipsContainer.innerHTML = `<span class="chips-empty">No USB ports detected. You can type any serial path above.</span>`;
+    }
+  }
+
+  if (ports.length > 0) {
+    const flashPortInput = document.getElementById("auto-flash-port");
+    if (flashPortInput && (!flashPortInput.value || flashPortInput.dataset.autoManaged === "true")) {
+      flashPortInput.value = ports[0];
+    }
+    const multiInput = document.getElementById("auto-agent-multiserial-ports");
+    if (multiInput && (!multiInput.value || multiInput.dataset.autoManaged === "true")) {
+      multiInput.value = ports.join(" ");
+    }
+
+    // Hardware USB Auto-Detection & Bare Module Preset Adaptation
+    if (!window.hasAutoDetectedHardware && data.port_details && data.port_details.length > 0) {
+      window.hasAutoDetectedHardware = true;
+      const primaryDetail = data.port_details[0];
+      const guessed = guessMcuFromUsbDetail(primaryDetail);
+      if (guessed) {
+        // Load the all-pins-(-1) bare-module template so nothing is driven on a
+        // freshly plugged board, then stamp the detected MCU + a unique name.
+        loadPreset("bare");
+        const mcuSelect = document.getElementById("cfg-mcu");
+        if (mcuSelect) {
+          mcuSelect.value = guessed.mcu;
+          mcuSelect.dispatchEvent(new Event("change"));
+        }
+        applyMcuRobotName(guessed.mcu);
+        applyDetectedChipToBaudUi(guessed);
+            defaultSimulationForDetectedModule(guessed.chipName);
+        recomputeAll();
+        showToast(`⚡ Auto-detected Hardware: ${guessed.chipName} on ${ports[0]} (Bare Module Default Loaded — all pins N/C)`);
+      }
+    }
+  }
+
+  updateAutomationPreviews();
+}
+
+function detectClientOS() {
+  checkServerRunnerStatus();
+}
+
+// Read All Automation Configuration Options
+function readAutomationOptions() {
+  const rosDistro = document.getElementById("hdr-ros-distro")?.value || document.getElementById("auto-ros-distro")?.value || "jazzy";
+  const buildEngine = document.getElementById("hdr-build-engine")?.value || (document.getElementById("chk-docker-builder")?.checked ? "docker" : "native");
+  const agentEngine = document.getElementById("hdr-agent-engine")?.value || "docker";
+  const regMode = document.getElementById("hdr-container-registry")?.value || "auto";
+  const customReg = (document.getElementById("hdr-custom-registry")?.value || "").trim();
+  const containerRegistry = (regMode === "custom" && customReg) ? customReg : regMode;
+  const remoteFlashTarget = (document.getElementById("hdr-remote-flash")?.value || document.getElementById("remote-ssh-host")?.value || "").trim();
+
+  return {
+    os: document.getElementById("auto-os-select")?.value || "ubuntu_2404",
+    env: document.getElementById("auto-env-select")?.value || "native",
+    arch: document.getElementById("auto-arch-select")?.value || "x86_64",
+    installPio: document.getElementById("chk-install-pio")?.checked ?? true,
+    installUdev: document.getElementById("chk-install-udev")?.checked ?? true,
+    installDialout: document.getElementById("chk-install-dialout")?.checked ?? true,
+    installBuildTools: document.getElementById("chk-install-buildtools")?.checked ?? true,
+    rosDistro: rosDistro,
+    buildEngine: buildEngine,
+    agentEngine: agentEngine,
+    containerRegistry: containerRegistry,
+    customRegistry: customReg,
+    remoteFlashTarget: remoteFlashTarget,
+    rosType: document.getElementById("auto-ros-type")?.value || "desktop",
+    buildMicrorosAgent: document.getElementById("chk-build-microros-agent")?.checked ?? true,
+    gitBranch: document.getElementById("auto-git-branch")?.value.trim() || "",
+    gitCommitMsg: document.getElementById("auto-git-commit-msg")?.value.trim() || `feat(config): add configuration for ${currentSpec.robot_name || "robot"}`,
+    mergeHeader: document.getElementById("chk-merge-header")?.checked ?? true,
+    mergePioFirmware: document.getElementById("chk-merge-pio-firmware")?.checked ?? true,
+    mergeUrdf: document.getElementById("chk-merge-urdf")?.checked ?? true,
+    autoCommit: document.getElementById("chk-auto-commit")?.checked ?? true,
+    flashTarget: document.getElementById("auto-flash-target")?.value || "firmware",
+    flashPort: (() => {
+      const otaOn = document.getElementById("cfg-ota-enable")?.checked;
+      const otaIp = (document.getElementById("cfg-ota-ip")?.value || "").trim();
+      if (otaOn && otaIp) return otaIp;   // espota target
+      return document.getElementById("auto-flash-port")?.value.trim() || "/dev/ttyACM0";
+    })(),
+    otaFlash: !!document.getElementById("cfg-ota-enable")?.checked &&
+              !!(document.getElementById("cfg-ota-ip")?.value || "").trim(),
+    otaPass: (document.getElementById("cfg-ota-password")?.value || "").trim()
+  };
+}
+
+// The firmware serial BAUDRATE chosen on Tab 1 (#cfg-baudrate). Single source
+// of truth for the micro-ROS agent -b flag and the console serial monitor.
+function firmwareBaud(spec) {
+  spec = spec || (typeof currentSpec !== "undefined" ? currentSpec : null) || {};
+  return spec.baudrate
+    || spec.telemetry?.baudrate
+    || ((spec.mcu || "").toUpperCase() === "GENDRV" ? 1500000 : 921600);
+}
+
+// Update Dynamic Previews across Tab 5
+function updateAutomationPreviews() {
+  const opts = readAutomationOptions();
+  const spec = currentSpec;
+  const robotName = spec.robot_name || "scout_pico2";
+
+  // The git branch field tracks the Robot SBC's current branch (see
+  // applyCurrentBranch), not the robot name — do not overwrite it here.
+  const gitCommitInput = document.getElementById("auto-git-commit-msg");
+  if (gitCommitInput && (!gitCommitInput.value || gitCommitInput.dataset.autoManaged === "true")) {
+    gitCommitInput.value = `feat(config): add configuration for ${robotName}`;
+    gitCommitInput.dataset.autoManaged = "true";
+  }
+
+  // OTA mDNS hostname mirrors the robot name until the user edits it
+  const otaHostInput = document.getElementById("cfg-ota-hostname");
+  if (otaHostInput && (!otaHostInput.value || otaHostInput.dataset.autoManaged === "true")) {
+    otaHostInput.value = robotName;
+    otaHostInput.dataset.autoManaged = "true";
+  }
+
+  // Set default port based on MCU
+  const mcu = (spec.mcu || "PICO2").toUpperCase();
+  const portInput = document.getElementById("auto-flash-port");
+  if (portInput && (!portInput.value || portInput.dataset.autoManaged === "true")) {
+    if (mcu === "PICO" || mcu === "PICO2" || mcu === "ESP32S3") {
+      portInput.value = "/dev/ttyACM0";
+    } else {
+      portInput.value = "/dev/ttyUSB0";
+    }
+    portInput.dataset.autoManaged = "true";
+  }
+
+  // 1. Toolchain Preview
+  const toolCmdEl = document.getElementById("preview-tool-cmd");
+  if (toolCmdEl) {
+    toolCmdEl.innerText = getToolchainInstallCmd(opts);
+  }
+
+  // 2. ROS 2 Preview & Visibility
+  const rosDistroBox = document.getElementById("box-ros-cmd");
+  const rosTypeGroup = document.getElementById("group-ros-install-type");
+  const microrosGroup = document.getElementById("group-microros-agent");
+  const isRosActive = opts.rosDistro !== "none";
+
+  if (rosDistroBox) rosDistroBox.style.display = isRosActive ? "block" : "none";
+  if (rosTypeGroup) rosTypeGroup.style.display = isRosActive ? "flex" : "none";
+  if (microrosGroup) microrosGroup.style.display = isRosActive ? "grid" : "none";
+
+  const rosCmdEl = document.getElementById("preview-ros-cmd");
+  if (rosCmdEl && isRosActive) {
+    rosCmdEl.innerText = getRos2InstallCmd(opts);
+  }
+
+  // 3. Merge & Commit Preview
+  const mergeCmdEl = document.getElementById("preview-merge-cmd");
+  if (mergeCmdEl) {
+    mergeCmdEl.innerText = getMergeAndCommitCmd(spec, opts);
+  }
+
+  // 4. micro-ROS Agent Preview
+  const agentCmdEl = document.getElementById("preview-agent-cmd");
+  if (agentCmdEl) {
+    const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
+    const port = document.getElementById("auto-flash-port")?.value || (isESP32(spec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
+    const multiPorts = document.getElementById("auto-agent-multiserial-ports")?.value.trim() || "/dev/ttyACM0 /dev/ttyUSB0";
+    // Agent -b always matches the firmware BAUDRATE chosen on Tab 1.
+    const baud = firmwareBaud(spec);
+    const isWiFi = /WIFI|UDP/i.test(spec.transport || "");
+    const agentEngine = document.getElementById("hdr-agent-engine")?.value || "docker";
+    agentCmdEl.innerText = microRosAgentCmd(isWiFi ? "udp" : "serial", { distro, port, baud, agentEngine });
+  }
+
+  // If Deploy Script tab is active, re-render code display
+  if (activeArtifact === "tab-code-deploy") {
+    renderActiveCode();
+  }
+}
+
+// Generate Toolchain Install Commands
+function getToolchainInstallCmd(opts) {
+  const lines = [];
+  const isDebianUbuntu = ["ubuntu_2404", "ubuntu_2604", "ubuntu_2204", "debian", "windows_wsl"].includes(opts.os);
+  const isMac = opts.os === "macos";
+  const isFedora = opts.os === "fedora";
+
+  if (isDebianUbuntu) {
+    lines.push("sudo dpkg --configure -a 2>/dev/null || true");
+    if (opts.installBuildTools) {
+      lines.push("sudo apt-get update && sudo apt-get install -y git cmake ninja-build python3-pip python3-venv udev");
+    }
+    if (opts.installPio) {
+      lines.push("curl -fsSL -o /tmp/get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py && python3 /tmp/get-platformio.py && export PATH=\"$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH\"");
+    }
+    if (opts.installUdev) {
+      lines.push("curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/system/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules > /dev/null");
+      lines.push("sudo udevadm control --reload-rules && sudo udevadm trigger");
+    }
+    if (opts.installDialout) {
+      lines.push("sudo usermod -a -G dialout,plugdev $USER || true");
+    }
+  } else if (isMac) {
+    if (opts.installBuildTools) lines.push("brew install git cmake ninja python3");
+    if (opts.installPio) lines.push("brew install platformio || pip3 install platformio");
+  } else if (isFedora) {
+    if (opts.installBuildTools) lines.push("sudo dnf install -y git cmake ninja-build python3-pip systemd-udev || true");
+    if (opts.installPio) lines.push("curl -fsSL -o /tmp/get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py && python3 /tmp/get-platformio.py && export PATH=\"$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH\"");
+    if (opts.installUdev) {
+      lines.push("curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/system/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules > /dev/null || true");
+      lines.push("sudo udevadm control --reload-rules && sudo udevadm trigger || true");
+    }
+    if (opts.installDialout) lines.push("sudo usermod -a -G dialout $USER 2>/dev/null || true");
+  }
+
+  return lines.length > 0 ? lines.join(" && \\\n") : "# No toolchain installations selected";
+}
+
+// Idempotent shell snippet that GUARANTEES a working `pio` on PATH, installing
+// PlatformIO Core (and the few OS packages its installer needs) the first time.
+// Standalone actions — I2C auto-detect, ADC calibrate — otherwise just run a bare
+// `pio ...` and die with "command not found" (exit 127) on a fresh SBC / distrobox
+// that has never run a Full Deploy. Mirrors Phase 1 of generateDeployScript.
+// Meant to be the first lines of a command passed to executeCommandInTerminal().
+function ensurePioToolchainSnippet() {
+  return [
+    `export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"`,
+    `_pio_ok() { command -v pio >/dev/null 2>&1 && pio --version >/dev/null 2>&1; }`,
+    `if ! _pio_ok; then`,
+    `  echo ">>> PlatformIO not found - installing build toolchain (first run only, ~1-2 min)..."`,
+    `  if command -v pio >/dev/null 2>&1; then echo ">>> (removing a broken PlatformIO venv)"; rm -rf "$HOME/.platformio/penv"; hash -r; fi`,
+    `  if ! python3 -c "import venv, ensurepip" >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then`,
+    `    if command -v apt-get >/dev/null 2>&1; then`,
+    `      (sudo -n apt-get update -y 2>/dev/null || sudo apt-get update -y) || true`,
+    `      sudo -n apt-get install -y python3 python3-venv python3-pip curl git 2>/dev/null || sudo apt-get install -y python3 python3-venv python3-pip curl git || true`,
+    `    elif command -v dnf >/dev/null 2>&1; then`,
+    `      (sudo -n dnf install -y python3 python3-pip curl git 2>/dev/null || sudo dnf install -y python3 python3-pip curl git) || true`,
+    `    else`,
+    `      echo ">>> WARN: no apt-get/dnf - assuming python3+curl already present"`,
+    `    fi`,
+    `  fi`,
+    `  curl -fsSL -o /tmp/get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py || { echo "ERROR: cannot download the PlatformIO installer (network?)"; exit 1; }`,
+    `  python3 /tmp/get-platformio.py || { echo "ERROR: PlatformIO Core installation failed"; exit 1; }`,
+    `  export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"; hash -r`,
+    `fi`,
+    `_pio_ok || { echo "ERROR: PlatformIO Core still not working ('pio --version' fails)"; exit 1; }`,
+    `echo ">>> PlatformIO ready: $(pio --version 2>/dev/null || echo installed)"`,
+  ].join("\n");
+}
+
+// micro-ROS agent launch with graceful degradation:
+//   native `ros2 run micro_ros_agent`  (from /opt/ros or ~/uros_ws)
+//   -> apt `ros-<distro>-micro-ros-agent`  (if the ROS 2 apt repo is present)
+//   -> docker / podman `microros/micro-ros-agent:<distro>`  (-> :rolling tag)
+//   -> clear error pointing at the "Install ROS 2" button.
+// mode: "serial" | "multiserial" | "udp".
+// The container registry is a user preference (header dropdown / Automation
+// tab), never a hardcoded host: a LAN or cluster registry is site specific, so
+// there is no sensible default to ship. Returns the hosts to probe, empty when
+// the user picked Docker Hub or left the custom host blank.
+function configuredRegistryHosts(opt) {
+  opt = opt || {};
+  const mode = opt.containerRegistry
+    || document.getElementById("hdr-container-registry")?.value
+    || "auto";
+  if (mode === "dockerhub") return [];
+  const host = (opt.customRegistry
+    || document.getElementById("hdr-custom-registry")?.value
+    || "").trim();
+  if (mode === "cluster" || mode === "custom" || mode === "auto") {
+    return host ? [host] : [];
+  }
+  // anything else in the field is itself a registry host
+  return [mode];
+}
+
+function microRosAgentCmd(mode, opt) {
+  const distro   = opt.distro || "jazzy";
+  const baud     = opt.baud || 921600;
+  const udpPort  = opt.udpPort || 8888;
+  const port     = (opt.port || "/dev/ttyUSB0").trim();
+  const ports    = (opt.ports || "/dev/ttyACM0 /dev/ttyUSB0").trim();
+
+  let agentArgs, deviceFlags, permPorts;
+  if (mode === "multiserial") {
+    agentArgs = `multiserial --devs "${ports}" -b ${baud}`;
+    deviceFlags = ports.split(/\s+/).filter(Boolean).map(d => `--device ${d}`).join(" ");
+    permPorts = ports;
+  } else if (mode === "udp") {
+    agentArgs = `udp4 --port ${udpPort}`;
+    deviceFlags = "";
+    permPorts = "";
+  } else { // serial
+    agentArgs = `serial --dev ${port} -b ${baud}`;
+    deviceFlags = `--device ${port}`;
+    permPorts = port;
+  }
+
+  const argsEcho = agentArgs.replace(/"/g, '\\"');   // safe inside a "…" echo
+  const preflightScript = mode === "udp"
+    ? `echo ">>> Checking if micro-ROS UDP port ${udpPort} is in use..."\n` +
+      `_PIDS=$(fuser "${udpPort}/udp" 2>/dev/null || true)\n` +
+      `_CONT_DK=$(command -v docker >/dev/null 2>&1 && docker ps --filter "name=uros_agent_${mode}" --filter "name=microros_agent" -q 2>/dev/null || true)\n` +
+      `_CONT_PM=$(command -v podman >/dev/null 2>&1 && podman ps --filter "name=uros_agent_${mode}" --filter "name=microros_agent" -q 2>/dev/null || true)\n` +
+      `if [ -n "$_PIDS" ] || [ -n "$_CONT_DK" ] || [ -n "$_CONT_PM" ]; then\n` +
+      `  echo ">>> [Port Conflict] micro-ROS UDP :${udpPort} in use (PIDs: \${_PIDS:-none}). Releasing..."\n` +
+      `  [ -n "$_CONT_DK" ] && docker stop $_CONT_DK >/dev/null 2>&1 || true\n` +
+      `  [ -n "$_CONT_PM" ] && podman stop $_CONT_PM >/dev/null 2>&1 || true\n` +
+      `  [ -n "$_PIDS" ] && kill -TERM $_PIDS 2>/dev/null || true\n` +
+      `  pkill -f "[m]icro_ros_agent.*udp.*${udpPort}" 2>/dev/null || true\n` +
+      `  sleep 0.5\n` +
+      `fi`
+    : `for _chk_port in ${permPorts}; do\n` +
+      `  if [ -e "$_chk_port" ]; then\n` +
+      `    _PIDS=$(fuser "$_chk_port" 2>/dev/null || true)\n` +
+      `    _CONT_DK=$(command -v docker >/dev/null 2>&1 && docker ps --filter "name=uros_agent" --filter "name=microros_agent" -q 2>/dev/null || true)\n` +
+      `    _CONT_PM=$(command -v podman >/dev/null 2>&1 && podman ps --filter "name=uros_agent" --filter "name=microros_agent" -q 2>/dev/null || true)\n` +
+      `    if [ -n "$_PIDS" ] || [ -n "$_CONT_DK" ] || [ -n "$_CONT_PM" ]; then\n` +
+      `      echo ">>> [Port Conflict] Serial port '$_chk_port' occupied (PIDs: \${_PIDS:-none}). Releasing..."\n` +
+      `      [ -n "$_CONT_DK" ] && docker stop $_CONT_DK >/dev/null 2>&1 || true\n` +
+      `      [ -n "$_CONT_PM" ] && podman stop $_CONT_PM >/dev/null 2>&1 || true\n` +
+      `      if [ -n "$_PIDS" ]; then\n` +
+      `        fuser -k -TERM "$_chk_port" 2>/dev/null || true\n` +
+      `        sleep 0.5\n` +
+      `        fuser -k -KILL "$_chk_port" 2>/dev/null || true\n` +
+      `      fi\n` +
+      `      pkill -f "[m]icro_ros_agent.*\${_chk_port##*/}" 2>/dev/null || true\n` +
+      `      pkill -f "[m]initerm.*\${_chk_port##*/}" 2>/dev/null || true\n` +
+      `      pkill -f "[s]creen.*\${_chk_port##*/}" 2>/dev/null || true\n` +
+      `      sleep 0.5\n` +
+      `    fi\n` +
+      `  fi\n` +
+      `done`;
+
+  return [
+    `DISTRO="${distro}"`,
+    `# 0. Pre-flight Port Conflict Check & Automatic Release`,
+    preflightScript,
+    permPorts
+      ? `for _d in ${permPorts}; do [ -e "$_d" ] && [ ! -w "$_d" ] && sudo chmod a+rw "$_d" 2>/dev/null || true; done`
+      : `# udp transport - no serial port to free`,
+    ``,
+    `# 1. Native ROS 2 agent (from /opt/ros/<distro> or ~/uros_ws)`,
+    `if [ -f "/opt/ros/$DISTRO/setup.bash" ]; then`,
+    `  source "/opt/ros/$DISTRO/setup.bash"`,
+    `  [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"`,
+    `  if ros2 pkg prefix micro_ros_agent >/dev/null 2>&1; then`,
+    `    echo ">>> micro-ROS agent: native 'ros2 run' (ROS 2 $DISTRO)"`,
+    `    exec ros2 run micro_ros_agent micro_ros_agent ${agentArgs}`,
+    `  fi`,
+    `  if command -v apt-get >/dev/null 2>&1; then`,
+    `    echo ">>> micro_ros_agent package missing - trying apt install ros-$DISTRO-micro-ros-agent ..."`,
+    `    if sudo -n apt-get install -y "ros-$DISTRO-micro-ros-agent" 2>/dev/null || sudo apt-get install -y "ros-$DISTRO-micro-ros-agent"; then`,
+    `      source "/opt/ros/$DISTRO/setup.bash"`,
+    `      if ros2 pkg prefix micro_ros_agent >/dev/null 2>&1; then`,
+    `        echo ">>> micro-ROS agent: native 'ros2 run' (apt-installed)"`,
+    `        exec ros2 run micro_ros_agent micro_ros_agent ${agentArgs}`,
+    `      fi`,
+    `    fi`,
+    `  fi`,
+    `fi`,
+    ``,
+    `# 2. Containerized Execution (Docker / Podman / Podman+systemd)`,
+    `_ENGINE="${opt.agentEngine || 'docker'}"`,
+    `# Registry hosts the user configured, most preferred first. Empty means`,
+    `# "go straight to Docker Hub" -- there is no default LAN host to ship.`,
+    `_REGS="${configuredRegistryHosts(opt).join(" ")}"`,
+    `# Resolve the agent image: the configured registry first (so a LAN cache`,
+    `# serves it and the pull stays local), then Docker Hub, and each of those`,
+    `# for the running distro before falling back to the :rolling tag.`,
+    `_resolve_agent_img() {`,
+    `  local eng="$1" reg tag`,
+    `  for reg in $_REGS ""; do`,
+    `    for tag in "$DISTRO" rolling; do`,
+    `      IMG="microros/micro-ros-agent:$tag"`,
+    `      [ -n "$reg" ] && IMG="$reg/$IMG"`,
+    `      $eng pull "$IMG" >/dev/null 2>&1 && return 0`,
+    `    done`,
+    `  done`,
+    `  # nothing pulled; name it anyway so the run reports the real error`,
+    `  IMG="microros/micro-ros-agent:$DISTRO"`,
+    `  return 1`,
+    `}`,
+    `if [ "$_ENGINE" = "podman_systemd" ]; then`,
+    `  echo ">>> micro-ROS agent: Podman + systemd user service ($DISTRO)"`,
+    `  _resolve_agent_img podman || true`,
+    `  podman run -d --replace --name "microros_agent_${mode}" --net=host ${deviceFlags} "$IMG" ${agentArgs}`,
+    `  mkdir -p "$HOME/.config/systemd/user"`,
+    `  podman generate systemd --new --name "microros_agent_${mode}" > "$HOME/.config/systemd/user/microros-agent.service" 2>/dev/null || true`,
+    `  systemctl --user daemon-reload 2>/dev/null || true`,
+    `  systemctl --user enable --now microros-agent.service 2>/dev/null || true`,
+    `  loginctl enable-linger "$USER" 2>/dev/null || true`,
+    `  echo ">>> micro-ROS agent running as persistent systemd user service: microros-agent.service"`,
+    `  exit 0`,
+    `elif [ "$_ENGINE" = "podman" ]; then`,
+    `  echo ">>> micro-ROS agent: Podman rootless container ($DISTRO)"`,
+    `  _resolve_agent_img podman || true`,
+    `  exec podman run --rm --replace -it --name "uros_agent_${mode}" --net=host ${deviceFlags} "$IMG" ${agentArgs}`,
+    `else`,
+    `  _DK=""`,
+    `  command -v docker >/dev/null 2>&1 && _DK=docker`,
+    `  [ -z "$_DK" ] && command -v podman >/dev/null 2>&1 && _DK=podman`,
+    `  if [ -n "$_DK" ]; then`,
+    `    echo ">>> micro-ROS agent: $_DK container ($DISTRO)"`,
+    `    _resolve_agent_img "$_DK" || true`,
+    `    echo ">>> image: $IMG"`,
+    `    $_DK rm -f "uros_agent_${mode}" 2>/dev/null || true`,
+    `    exec $_DK run --rm --net=host --name "uros_agent_${mode}" ${deviceFlags} "$IMG" ${agentArgs}`,
+    `  fi`,
+    `fi`,
+    ``,
+    `echo "ERROR: no micro-ROS agent available (no ROS 2 $DISTRO, no docker/podman)."`,
+    `echo "  fix: click 'Install ROS 2 Distribution & Packages' above, or install Docker, then retry."`,
+    `echo "  manual: docker run --rm --net=host ${deviceFlags} microros/micro-ros-agent:$DISTRO ${argsEcho}"`,
+    `exit 1`,
+  ].join("\n");
+}
+
+// Generate ROS 2 Install Commands
+function getRos2InstallCmd(opts) {
+  const distro = opts.rosDistro;
+  if (distro === "none") return "# ROS 2 Installation skipped (Standalone Firmware mode)";
+
+  const pkgName = opts.rosType === "desktop" ? `ros-${distro}-desktop` : `ros-${distro}-ros-base`;
+  const lines = [
+    `set -e`,
+    `sudo dpkg --configure -a 2>/dev/null || true`,
+    ``,
+    `# 1. Setup ROS 2 ${distro.toUpperCase()} Official Repository`,
+    `if command -v apt-get &>/dev/null; then`,
+    `    sudo apt-get update -qq && sudo apt-get install -y -qq software-properties-common curl gnupg`,
+    `    sudo add-apt-repository -y universe`,
+    `    sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg`,
+    `    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null`,
+    `    sudo apt-get update -qq && sudo apt-get install -y -qq ${pkgName} ros-${distro}-ros-workspace python3-catkin-pkg-modules python3-colcon-common-extensions python3-rosdep`,
+    `elif command -v distrobox &>/dev/null; then`,
+    `    distrobox create -n ${distro} -i docker.io/library/ubuntu:24.04 2>/dev/null || true`,
+    `    distrobox enter ${distro} -- bash -c "sudo apt-get update && sudo apt-get install -y ${pkgName} ros-${distro}-ros-workspace python3-catkin-pkg-modules python3-colcon-common-extensions python3-rosdep"`,
+    `else`,
+    `    echo "Package manager apt-get not found. Ensure ROS 2 ${distro} is installed on host/container."`,
+    `    exit 1`,
+    `fi`
+  ];
+
+  if (opts.buildMicrorosAgent) {
+    lines.push(
+      ``,
+      `# 2. Build micro-ROS Agent Workspace (micro-ROS-Agent + micro_ros_msgs)`,
+      `if [ -f "/opt/ros/${distro}/setup.bash" ]; then`,
+      `    source /opt/ros/${distro}/setup.bash`,
+      `    mkdir -p ~/uros_ws/src && cd ~/uros_ws`,
+      `    if [ ! -d "src/micro_ros_agent" ]; then`,
+      `        git clone -b ${distro} https://github.com/micro-ROS/micro-ROS-Agent.git src/micro_ros_agent || git clone -b rolling https://github.com/micro-ROS/micro-ROS-Agent.git src/micro_ros_agent`,
+      `    fi`,
+      `    if [ ! -d "src/micro_ros_msgs" ]; then`,
+      `        git clone -b ${distro} https://github.com/micro-ROS/micro_ros_msgs.git src/micro_ros_msgs || git clone -b rolling https://github.com/micro-ROS/micro_ros_msgs.git src/micro_ros_msgs`,
+      `    fi`,
+      `    colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3`,
+      `    grep -q "source /opt/ros/${distro}/setup.bash" ~/.bashrc || echo "source /opt/ros/${distro}/setup.bash" >> ~/.bashrc`,
+      `    grep -q "source \$HOME/uros_ws/install/setup.bash" ~/.bashrc || echo "source \$HOME/uros_ws/install/setup.bash" >> ~/.bashrc`,
+      `else`,
+      `    echo "❌ Error: ROS 2 setup not found at /opt/ros/${distro}/setup.bash"`,
+      `    exit 1`,
+      `fi`
+    );
+  }
+
+  return lines.join("\n");
+}
+
+// Generate Merge & Commit Commands
+// Search-and-merge, never overwrite: every place that writes
+// config/custom/<name>_config.h ships the current spec as JSON and has the
+// Robot SBC merge it — via the SAME parser.py/generator.py the test suite is
+// built on — into whatever is already on disk (overlay/web-UI values win for
+// anything they model; hand-edited or not-yet-modeled #defines on disk, and
+// e.g. a previously calibrated ADC_LUT the current form doesn't carry, are
+// left alone). A brand-new robot name just gets the fresh header — there is
+// nothing to merge with yet.
+function getConfigSyncScript(spec, name) {
+  const specJson = JSON.stringify(spec);
+  return [
+    `mkdir -p config/custom urdf`,
+    `cat << 'EOF_SPEC' > "/tmp/lr_spec_${name}.json"`,
+    specJson,
+    `EOF_SPEC`,
+    `LR_ROBOT_NAME="${name}" LR_SPEC_JSON="/tmp/lr_spec_${name}.json" python3 << 'EOF_MERGE_PY'`,
+    `import sys, json, os`,
+    `sys.path.insert(0, "tools/robot_config_engine")`,
+    `from parser import parse_header_to_spec, merge_configurations`,
+    `from generator import generate_config_header`,
+    `name = os.environ["LR_ROBOT_NAME"]`,
+    `path = f"config/custom/{name}_config.h"`,
+    `with open(os.environ["LR_SPEC_JSON"]) as f:`,
+    `    overlay = json.load(f)`,
+    `if os.path.exists(path):`,
+    `    with open(path) as f:`,
+    `        base = parse_header_to_spec(f.read())`,
+    `    merged, changes = merge_configurations(base, overlay)`,
+    `    if changes:`,
+    `        print(f"[config-sync] merged {len(changes)} field(s) into existing {path}")`,
+    `    else:`,
+    `        print(f"[config-sync] {path} already matches — no changes")`,
+    `else:`,
+    `    merged = overlay`,
+    `    print(f"[config-sync] creating new {path}")`,
+    `header = generate_config_header(merged)`,
+    `with open(path, "w") as f:`,
+    `    f.write(header)`,
+    `EOF_MERGE_PY`,
+    `rm -f "/tmp/lr_spec_${name}.json"`,
+  ];
+}
+
+function getMergeAndCommitCmd(spec, opts) {
+  const name = spec.robot_name || "my_robot";
+  const nameUpper = name.toUpperCase();
+  const branch = (opts.gitBranch || "").trim();
+  const commitMsg = opts.gitCommitMsg || `feat(config): add configuration for ${name}`;
+  const pioSection = generatePlatformioEnv(spec);
+  const urdfContent = generateUrdfXacro(spec);
+
+  const lines = [
+    `set -e`,
+    ...(branch ? [
+      `# 1. Switch to (or create) the target branch`,
+      `if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then`,
+      `    git checkout -b "${branch}" 2>/dev/null || git checkout "${branch}"`,
+      `fi`,
+      ``,
+    ] : []),
+    `# 2. Ingest Custom Header (search-and-merge with any existing file)`,
+    ...getConfigSyncScript(spec, name),
+    ``,
+    `# Register in config/config.h`,
+    `if [ -f "config/config.h" ]; then`,
+    `    if ! grep -F -q "USE_${nameUpper}_CONFIG" config/config.h; then`,
+    `        sed -i '/\\/\\/ add user configurations above this line/i #ifdef USE_${nameUpper}_CONFIG\\n    #include "custom/${name}_config.h"\\n#endif\\n' config/config.h`,
+    `    fi`,
+    `fi`,
+    ``,
+    `# 3. Append PlatformIO Target Environment`,
+    `if [ -f "firmware/platformio.ini" ]; then`,
+    `    if ! grep -F -q "[env:${name}]" "firmware/platformio.ini"; then`,
+    `        echo "" >> "firmware/platformio.ini"`,
+    `        cat << 'EOF_PIO' >> "firmware/platformio.ini"`,
+    `${pioSection}`,
+    `EOF_PIO`,
+    `    fi`,
+    `fi`,
+    ``,
+    `# 4. Ingest URDF Description`,
+    `cat << 'EOF_URDF' > "urdf/${name}_properties.urdf.xacro"`,
+    `${urdfContent}`,
+    `EOF_URDF`,
+    ``,
+    `# 5. Stage & Create Git Commit`,
+    `git add config/ firmware/platformio.ini urdf/ 2>/dev/null || true`,
+    `if ! git diff --cached --quiet; then`,
+    `    git commit -m "${commitMsg}"`,
+    `else`,
+    `    echo "Configuration files already up to date on branch $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')."`,
+    `fi`
+  ];
+
+  return lines.join("\n");
+}
+
+// Full All-In-One Bash Deploy Script Generator
+function generateDeployScript(spec, opts) {
+  const name = spec.robot_name || "my_robot";
+  const nameUpper = name.toUpperCase();
+  const mcu = (spec.mcu || "PICO2").toUpperCase();
+  const commitMsg = opts.gitCommitMsg || `feat(config): add configuration for ${name}`;
+  const target = opts.flashTarget || "firmware";
+  const port = opts.flashPort || "/dev/ttyACM0";
+  const otaAuth = (opts.otaFlash && opts.otaPass) ? ` --upload-flags "--auth=${opts.otaPass}"` : "";
+  const wifiConfigContent = generateWifiConfig(spec);
+  const pioSection = generatePlatformioEnv(spec);
+  const urdfContent = generateUrdfXacro(spec);
+  // Escape a value for safe interpolation inside a double-quoted bash string
+  const shDq = (s) => String(s).replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/`/g, "\\`").replace(/\$/g, "\\$");
+  const commitMsgEsc = shDq(commitMsg);
+  const rosPkg = opts.rosType === "desktop" ? `ros-${opts.rosDistro}-desktop` : `ros-${opts.rosDistro}-ros-base`;
+  const isContainerBuild = opts.buildEngine === "docker" || opts.buildEngine === "podman";
+  const buildRegistryProbeList = () =>
+    configuredRegistryHosts(opts).map(h => `"${h}"`);
+  const regListStr = buildRegistryProbeList().join(" ");
+
+  const script = `#!/usr/bin/env bash
+# =============================================================================
+# Automated Linorobot2 Setup, Merge, Build & Flash Script for '${name}'
+# Generated by Linorobot2 Robot Configuration Engine
+# Target MCU: ${mcu} | Kinematics: ${spec.kinematics} | Target: ${target}
+# =============================================================================
+
+set -e
+
+# ANSI Styling
+C_RESET='\\033[0m'
+C_CYAN='\\033[1;36m'
+C_GREEN='\\033[1;32m'
+C_YELLOW='\\033[1;33m'
+C_RED='\\033[1;31m'
+
+info()    { echo -e "\${C_CYAN}[INFO]\${C_RESET} \$*"; }
+success() { echo -e "\${C_GREEN}[SUCCESS]\${C_RESET} \$*"; }
+warn()    { echo -e "\${C_YELLOW}[WARN]\${C_RESET} \$*"; }
+err()     { echo -e "\${C_RED}[ERROR]\${C_RESET} \$*" >&2; }
+
+# Grant read/write on USB serial devices when no udev rule / 'dialout' group does.
+# Keeps flashing and the micro-ROS agent working on a fresh SBC without a reboot.
+ensure_serial_rw() {
+    local want="\$1" d
+    for d in /dev/ttyUSB* /dev/ttyACM*; do
+        [ -e "\$d" ] || continue
+        [ -w "\$d" ] && continue
+        warn "No write access to \$d (missing udev rule?) - running 'sudo chmod a+rw \$d'"
+        sudo chmod a+rw "\$d" 2>/dev/null || true
+    done
+    if [ -n "\$want" ] && [ "\$want" != "AUTO" ] && [ "\$want" != "BOOTSEL" ] && [ -e "\$want" ] && [ ! -w "\$want" ]; then
+        sudo chmod a+rw "\$want" 2>/dev/null || true
+    fi
+}
+
+# Cap build parallelism on low-memory hosts (Raspberry Pi 4/5 4 GB, etc.) so the
+# first libmicroros / micro-ROS-Agent compile does not OOM. 6 GB+ builds at full speed.
+_MEM_KB=\$(awk '/MemTotal/{print \$2}' /proc/meminfo 2>/dev/null || echo 8000000)
+if [ "\${_MEM_KB:-8000000}" -lt 6000000 ]; then
+    export MAKEFLAGS="-j2"
+    export PLATFORMIO_BUILD_JOBS=2
+    COLCON_JOBS="--parallel-workers 2"
+    info "Low memory (\$((_MEM_KB/1024)) MB) detected - capping builds at 2 parallel jobs to avoid OOM."
+else
+    COLCON_JOBS=""
+fi
+
+info "========================================================="
+info "  Linorobot2 Deployment Engine: ${name}"
+info "  Target MCU: ${mcu} | Mode: ${target}"
+info "========================================================="
+
+# -----------------------------------------------------------------------------
+# Phase 1: Toolchain & Dependency Verification
+# -----------------------------------------------------------------------------
+info "Step 1/9: Checking build toolchains and dependencies..."
+${(opts.buildEngine === "docker" || opts.agentEngine === "docker") ? `
+if ! command -v docker >/dev/null 2>&1; then
+    if command -v distrobox-host-exec >/dev/null 2>&1 && distrobox-host-exec docker --version >/dev/null 2>&1; then
+        docker() { distrobox-host-exec docker "$@"; }
+    elif command -v apt-get >/dev/null 2>&1; then
+        info "Installing docker CLI via apt-get..."
+        sudo apt-get update -qq && sudo apt-get install -y -qq docker.io || warn "Could not install docker.io package."
+    fi
+fi
+if [ -z "$DOCKER_HOST" ] && [ -S "/run/user/$(id -u)/docker.sock" ]; then
+    export DOCKER_HOST="unix:///run/user/$(id -u)/docker.sock"
+fi
+` : ""}
+${(opts.buildEngine === "podman" || opts.agentEngine === "podman" || opts.agentEngine === "podman_systemd") ? `
+if ! command -v podman >/dev/null 2>&1; then
+    if command -v distrobox-host-exec >/dev/null 2>&1 && distrobox-host-exec podman --version >/dev/null 2>&1; then
+        podman() { distrobox-host-exec podman "$@"; }
+    fi
+fi
+` : ""}
+${isContainerBuild ? `
+info "Containerized build engine selected (${opts.buildEngine}). Host PlatformIO installation skipped."
+${opts.buildEngine === "docker" ? `
+if ! docker image inspect linorobot2-builder:latest >/dev/null 2>&1; then
+    REG_PULLED=0
+    ${buildRegistryProbeList().length > 0 ? `
+    for reg in ${regListStr}; do
+        if curl -fsSL -m 2 "https://${reg}/v2/" >/dev/null 2>&1 || curl -fsSL -m 2 "http://${reg}/v2/" >/dev/null 2>&1; then
+            info "Registry active at ${reg}. Pulling linorobot2-builder:latest..."
+            if docker pull "${reg}/linorobot2-builder:latest" >/dev/null 2>&1; then
+                docker tag "${reg}/linorobot2-builder:latest" linorobot2-builder:latest
+                REG_PULLED=1
+                break
+            fi
+        fi
+    done
+    ` : `info "Docker Hub / direct build selected for builder image."`}
+    if [ "$REG_PULLED" -eq 0 ] && [ -f "tools/robot_config_engine/docker/Dockerfile.builder" ]; then
+        info "Building linorobot2-builder:latest container image locally..."
+        docker build -t linorobot2-builder:latest -f tools/robot_config_engine/docker/Dockerfile.builder tools/robot_config_engine/docker/
+    fi
+fi
+` : `
+if ! podman image exists linorobot2-builder:latest >/dev/null 2>&1; then
+    REG_PULLED=0
+    ${buildRegistryProbeList().length > 0 ? `
+    for reg in ${regListStr}; do
+        if curl -fsSL -m 2 "https://${reg}/v2/" >/dev/null 2>&1 || curl -fsSL -m 2 "http://${reg}/v2/" >/dev/null 2>&1; then
+            info "Registry active at ${reg}. Pulling linorobot2-builder:latest with podman..."
+            if podman pull "${reg}/linorobot2-builder:latest" >/dev/null 2>&1; then
+                podman tag "${reg}/linorobot2-builder:latest" linorobot2-builder:latest
+                REG_PULLED=1
+                break
+            fi
+        fi
+    done
+    ` : `info "Docker Hub / direct build selected for builder image with podman."`}
+    if [ "$REG_PULLED" -eq 0 ] && [ -f "tools/robot_config_engine/docker/Dockerfile.builder" ]; then
+        info "Building linorobot2-builder:latest container image with podman..."
+        podman build -t linorobot2-builder:latest -f tools/robot_config_engine/docker/Dockerfile.builder tools/robot_config_engine/docker/
+    fi
+fi
+`}
+` : `
+${opts.installBuildTools ? `if ! command -v pio &>/dev/null || ! command -v cmake &>/dev/null || ! command -v git &>/dev/null; then
+    if command -v apt-get &>/dev/null; then
+        info "First-time setup: installing missing build tools (apt-get update)..."
+        if [ "$EUID" -eq 0 ]; then
+            apt-get update -y
+            info "Installing build packages: git, cmake, ninja-build, python3-pip, python3-venv, udev..."
+            apt-get install -y git cmake ninja-build python3-pip python3-venv udev
+        elif sudo -n true 2>/dev/null || [ -t 0 ]; then
+            sudo apt-get update -y
+            info "Installing build packages: git, cmake, ninja-build, python3-pip, python3-venv, udev..."
+            sudo apt-get install -y git cmake ninja-build python3-pip python3-venv udev
+        else
+            warn "Running in non-interactive environment: attempting passwordless package install..."
+            sudo -n apt-get update -y 2>/dev/null || true
+            sudo -n apt-get install -y git cmake ninja-build python3-pip python3-venv udev 2>/dev/null || warn "Please ensure build dependencies are installed."
+        fi
+    elif command -v dnf &>/dev/null; then
+        info "Installing build packages via dnf..."
+        if [ "$EUID" -eq 0 ]; then
+            dnf install -y git cmake ninja-build python3-pip systemd-udev || true
+        else
+            sudo dnf install -y git cmake ninja-build python3-pip systemd-udev || true
+        fi
+    fi
+else
+    info "Build toolchains already installed (pio, cmake, git ready). Skipping redundant package updates."
+fi` : "# Build tools check skipped"}
+
+${opts.installPio ? `export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"
+# "pio on PATH" is not enough — a stale/half-installed penv leaves a \`pio\`
+# entry-point that can no longer import platformio. Test that it actually runs.
+pio_ok() { command -v pio >/dev/null 2>&1 && pio --version >/dev/null 2>&1; }
+if ! pio_ok; then
+    if command -v pio >/dev/null 2>&1; then
+        warn "PlatformIO on PATH is broken (cannot import 'platformio') — rebuilding a clean venv..."
+        rm -rf "$HOME/.platformio/penv"
+        hash -r
+    fi
+    info "Installing PlatformIO Core..."
+    if ! curl -fsSL -o /tmp/get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py; then
+        err "Could not download the PlatformIO installer (raw.githubusercontent.com unreachable)."
+        exit 1
+    fi
+    if ! python3 /tmp/get-platformio.py; then
+        err "PlatformIO Core installation failed."
+        exit 1
+    fi
+    export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"
+    hash -r
+fi
+if ! pio_ok; then
+    err "PlatformIO Core is not working after installation ('pio --version' fails)."
+    exit 1
+fi
+# The penv sometimes ships pip \`cmake\` / \`colcon\` shims that shadow the
+# working system tool but can't import their own modules — drop the dead ones.
+for _t in cmake colcon; do
+    _p="$HOME/.platformio/penv/bin/$_t"
+    if [ -e "$_p" ] && ! "$_p" --version >/dev/null 2>&1; then
+        warn "Removing broken PlatformIO penv shim: $_p"
+        rm -f "$_p"
+    fi
+done
+hash -r
+success "PlatformIO Core active: $(pio --version 2>/dev/null || echo 'Installed')"
+` : "# PlatformIO install skipped"}
+`}
+
+${opts.installUdev ? `if [ -d "/etc/udev/rules.d" ]; then
+    info "Installing PlatformIO hardware udev rules..."
+    curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/system/99-platformio-udev.rules | sudo tee /etc/udev/rules.d/99-platformio-udev.rules > /dev/null || true
+    sudo udevadm control --reload-rules && sudo udevadm trigger || true
+fi` : "# udev rules skipped"}
+
+${opts.installDialout ? `if command -v usermod &>/dev/null; then
+    sudo usermod -a -G dialout,plugdev "$USER" 2>/dev/null || true
+fi` : "# dialout group skipped"}
+
+# -----------------------------------------------------------------------------
+# Phase 2: Optional ROS 2 Distribution Setup
+# -----------------------------------------------------------------------------
+${(opts.agentEngine !== "native" && opts.agentEngine !== "none") ? `info "Step 2: Containerized micro-ROS Agent selected (${opts.agentEngine}). Skipping host ROS 2 & ~/uros_ws installation."` :
+(opts.rosDistro !== "none" ? `info "Step 2: Verifying ROS 2 ${opts.rosDistro.toUpperCase()} environment..."
+if [ ! -d "/opt/ros/${opts.rosDistro}" ]; then
+    if command -v apt-get &>/dev/null; then
+        warn "ROS 2 ${opts.rosDistro} not found in /opt/ros/${opts.rosDistro}. Installing via apt..."
+        sudo apt-get update -qq || warn "apt-get update reported errors; continuing."
+        sudo apt-get install -y -qq curl gnupg software-properties-common || warn "Could not install apt prerequisites."
+        sudo add-apt-repository -y universe || warn "Could not enable the 'universe' repository."
+        if [ ! -f /usr/share/keyrings/ros-archive-keyring.gpg ]; then
+            sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg || warn "Could not download the ROS 2 archive key."
+        fi
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+        sudo apt-get update -qq || warn "apt-get update failed after adding the ROS 2 repository."
+        sudo apt-get install -y -qq ${rosPkg} || err "Failed to install ${rosPkg}."
+        sudo apt-get install -y -qq ros-${opts.rosDistro}-ros-workspace python3-catkin-pkg-modules python3-colcon-common-extensions python3-rosdep || warn "Some ROS 2 build helper packages are unavailable; continuing."
+    elif command -v distrobox &>/dev/null; then
+        info "Running on immutable/container host: ensuring distrobox container '${opts.rosDistro}' is configured..."
+        distrobox create -n ${opts.rosDistro} -i docker.io/library/ubuntu:24.04 2>/dev/null || true
+    else
+        warn "Package manager 'apt-get' not found on this host. Skipping apt install."
+    fi
+fi
+
+if [ ! -f "/opt/ros/${opts.rosDistro}/setup.bash" ]; then
+    err "ROS 2 ${opts.rosDistro} is not available at /opt/ros/${opts.rosDistro}/setup.bash."
+    err "Install it manually, or set ROS Distro to 'none' to build and flash firmware only."
+    exit 1
+fi
+success "ROS 2 ${opts.rosDistro} available at /opt/ros/${opts.rosDistro}"
+
+${opts.buildMicrorosAgent ? `# A failing agent-workspace build is NON-FATAL: the config merge/commit and the
+# firmware build + flash below do not need it. Only Phase 9 (agent handshake +
+# topic discovery) is skipped. AGENT_WS_OK tracks whether the agent is usable.
+AGENT_WS_OK=1
+UROS_AGENT_BIN="$HOME/uros_ws/install/micro_ros_agent/lib/micro_ros_agent/micro_ros_agent"
+# Rebuild if the agent binary is absent — colcon writes install/setup.bash even
+# when a package fails to compile, so that file alone is not proof of a build.
+if [ -d "/opt/ros/${opts.rosDistro}" ] && [ ! -x "$UROS_AGENT_BIN" ]; then
+    info "Building micro_ros_agent workspace at ~/uros_ws..."
+    if ! command -v colcon >/dev/null 2>&1; then
+        info "Installing colcon build tooling..."
+        if command -v apt-get &>/dev/null; then
+            sudo apt-get install -y -qq python3-colcon-common-extensions python3-rosdep || warn "Could not install colcon tooling via apt."
+        fi
+    fi
+    if ! command -v colcon >/dev/null 2>&1; then
+        warn "colcon is not available — skipping the micro-ROS agent build (firmware still builds & flashes)."
+        AGENT_WS_OK=0
+    else
+        mkdir -p "$HOME/uros_ws/src"
+        pushd "$HOME/uros_ws" >/dev/null
+        # micro-ROS cuts a branch per ROS distro, but newer distros (e.g. lyrical)
+        # land in ROS before micro-ROS tags them — fall back to 'rolling', which
+        # builds fine against the current ROS headers.
+        uros_clone() {
+            local repo="\$1" dest="\$2"
+            git clone -b "${opts.rosDistro}" "\$repo" "\$dest" 2>/dev/null && return 0
+            warn "No '${opts.rosDistro}' branch for \$(basename \$repo .git); trying 'rolling'..."
+            git clone -b rolling "\$repo" "\$dest" 2>/dev/null && return 0
+            git clone "\$repo" "\$dest" 2>/dev/null && return 0
+            warn "Could not clone \$repo"
+            return 1
+        }
+        [ -d "src/micro_ros_agent" ] || uros_clone https://github.com/micro-ROS/micro-ROS-Agent.git src/micro_ros_agent
+        [ -d "src/micro_ros_msgs" ]  || uros_clone https://github.com/micro-ROS/micro_ros_msgs.git src/micro_ros_msgs
+        if [ ! -d "src/micro_ros_agent" ] || [ ! -d "src/micro_ros_msgs" ]; then
+            warn "micro-ROS agent sources are missing — skipping the agent build."
+            AGENT_WS_OK=0
+        else
+            set +e
+            source "/opt/ros/${opts.rosDistro}/setup.bash"
+            colcon build --symlink-install \${COLCON_JOBS} --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+            COLCON_RC=\$?
+            set -e
+        fi
+        popd >/dev/null
+        if [ "\$AGENT_WS_OK" = "1" ] && { [ "\${COLCON_RC:-1}" -ne 0 ] || [ ! -x "$UROS_AGENT_BIN" ]; }; then
+            warn "micro-ROS agent workspace build FAILED at $HOME/uros_ws — micro-ROS-Agent may not support ROS 2 ${opts.rosDistro} yet (vendored spdlog vs system libfmt / GCC on newer distros)."
+            warn "Continuing anyway: config merge, git commit, firmware build and flash below are unaffected."
+            warn "To bridge the board afterwards, run an agent from a container, e.g.:  docker run --rm --net=host --privileged -v /dev:/dev microros/micro-ros-agent:${opts.rosDistro} serial --dev ${port} -b ${spec.baudrate || 921600}"
+            AGENT_WS_OK=0
+        fi
+        [ "\$AGENT_WS_OK" = "1" ] && success "micro-ROS agent workspace ready at $HOME/uros_ws"
+    fi
+fi` : "AGENT_WS_OK=0  # agent build not requested"}
+` : `# ROS 2 Host setup skipped (Standalone Firmware mode)`)}
+
+# -----------------------------------------------------------------------------
+# Phase 3: Git Branch
+# -----------------------------------------------------------------------------
+# Full Deploy runs on whatever branch is checked out. To land the config on a
+# different branch, set it in the studio's "Git Branch Name" field and use
+# "Run Merge & Commit" (which checks that branch out first).
+${`if git rev-parse --is-inside-work-tree &>/dev/null; then info "Working on Git branch '$(git rev-parse --abbrev-ref HEAD)'."; fi`}
+
+# -----------------------------------------------------------------------------
+# Phase 4: Ingest Custom C++ Header
+# -----------------------------------------------------------------------------
+${opts.mergeHeader ? `info "Step 4: Merging C++ configuration header into config/custom/${name}_config.h (search-and-merge with any existing file)..."
+${getConfigSyncScript(spec, name).join("\n")}
+success "Synced config/custom/${name}_config.h"
+${wifiConfigContent ? `
+# WiFi credentials go to the git-ignored config/custom/wifi_config.h, never
+# into the tracked robot header. An existing file is left untouched.
+if [ ! -f "config/custom/wifi_config.h" ]; then
+    info "Writing config/custom/wifi_config.h (git-ignored — holds your WiFi credentials)..."
+    cat << 'EOF_WIFI_CFG' > "config/custom/wifi_config.h"
+${wifiConfigContent}
+EOF_WIFI_CFG
+    success "Wrote config/custom/wifi_config.h (not tracked by git)"
+else
+    info "Keeping existing config/custom/wifi_config.h (delete it to regenerate)"
+fi
+` : ""}
+# Register in config/config.h if not already present
+if [ -f "config/config.h" ]; then
+    if ! grep -F -q "USE_${nameUpper}_CONFIG" config/config.h; then
+        info "Registering USE_${nameUpper}_CONFIG in config/config.h..."
+        sed -i '/\\/\\/ add user configurations above this line/i #ifdef USE_${nameUpper}_CONFIG\\n    #include "custom/${name}_config.h"\\n#endif\\n' config/config.h
+        success "Registered in config/config.h"
+    else
+        info "USE_${nameUpper}_CONFIG already registered in config/config.h"
+    fi
+fi
+` : "# Header merge skipped"}
+
+# -----------------------------------------------------------------------------
+# Phase 5: Ingest PlatformIO Target Environment
+# (test_motors and test_sensors automatically inherit firmware/platformio.ini)
+# -----------------------------------------------------------------------------
+if [ -f "firmware/platformio.ini" ] && [ "${opts.mergePioFirmware ? "1" : "0"}" = "1" ]; then
+    if ! grep -F -q "[env:${name}]" "firmware/platformio.ini"; then
+        info "Appending [env:${name}] to firmware/platformio.ini..."
+        echo "" >> "firmware/platformio.ini"
+        cat << 'EOF_PIO' >> "firmware/platformio.ini"
+${pioSection}
+EOF_PIO
+        success "Updated firmware/platformio.ini (inherited by test_motors & test_sensors)"
+    else
+        info "[env:${name}] already exists in firmware/platformio.ini"
+    fi
+fi
+
+# -----------------------------------------------------------------------------
+# Phase 6: Ingest URDF Description
+# -----------------------------------------------------------------------------
+${opts.mergeUrdf ? `info "Step 6: Writing URDF description to urdf/${name}_properties.urdf.xacro..."
+mkdir -p urdf
+cat << 'EOF_URDF' > "urdf/${name}_properties.urdf.xacro"
+${urdfContent}
+EOF_URDF
+success "Generated urdf/${name}_properties.urdf.xacro"
+` : "# URDF generation skipped"}
+
+# -----------------------------------------------------------------------------
+# Phase 7: Stage and Commit Changes
+# -----------------------------------------------------------------------------
+${opts.autoCommit ? `if git rev-parse --is-inside-work-tree &>/dev/null; then
+    info "Step 7: Committing generated hardware configuration to Git..."
+    git add config/ firmware/platformio.ini urdf/ 2>/dev/null || true
+    if ! git diff --cached --quiet; then
+        if ! git config user.email >/dev/null 2>&1; then
+            warn "No git identity configured; setting a repository-local placeholder."
+            git config user.email "deploy@linorobot2.local" || true
+            git config user.name "Linorobot2 Deploy Engine" || true
+        fi
+        if git commit -m "${commitMsgEsc}"; then
+            success "Git commit created on branch '$(git rev-parse --abbrev-ref HEAD)'"
+        else
+            warn "git commit failed; the generated configuration remains staged."
+        fi
+    else
+        info "No configuration changes to commit."
+    fi
+fi` : "# Git commit skipped"}
+
+# -----------------------------------------------------------------------------
+# Phase 8: Build and Flash Target Firmware
+# -----------------------------------------------------------------------------
+info "Step 8/9: Building target '${target}' for environment '[env:${name}]'..."
+info "💡 Note: First-time micro-ROS compilation builds IDL packages and may take 2-4 minutes on lower-spec SBCs (e.g. Raspberry Pi). Subsequent builds will be cached and fast."
+if [ -d "${target}" ]; then
+    ${opts.buildEngine === "podman" ? `info "🦭 [Podman Rootless] Compiling inside Podman container..."
+    podman run --rm -v linorobot2_pio_cache:/root/.platformio -v "$(pwd):/workspace:Z" -w /workspace -e ROS_DISTRO=${opts.rosDistro} linorobot2-builder:latest pio run -d "${target}" -e "${name}"` :
+      opts.buildEngine === "docker" ? `info "🐳 [Docker Rootless] Compiling inside Docker container..."
+    docker run --rm -v linorobot2_pio_cache:/root/.platformio -v "$(pwd):/workspace" -w /workspace -e ROS_DISTRO=${opts.rosDistro} linorobot2-builder:latest pio run -d "${target}" -e "${name}"` :
+      `pio run -d "${target}" -e "${name}"`
+    }
+    success "Build SUCCEEDED for '${name}' in ${target}/"
+
+    if [ -n "${port}" ] && [ "${port}" != "AUTO" ]; then
+        ensure_serial_rw "${port}"
+        info "Releasing port '${port}' (closing active micro-ROS agents and serial monitors)..."
+        fuser -k "${port}" 2>/dev/null || true
+        pkill -f "micro_ros_agent.*${port}" 2>/dev/null || true
+        pkill -f "miniterm.*${port}" 2>/dev/null || true
+        pkill -f "screen.*${port}" 2>/dev/null || true
+        sleep 0.8
+
+        info "Uploading firmware to microcontroller on port '${port}'..."
+        ${opts.buildEngine === "docker" ? `docker run --rm --privileged -v /dev:/dev -v linorobot2_pio_cache:/root/.platformio -v "$(pwd):/workspace" -w /workspace -e ROS_DISTRO=${opts.rosDistro} linorobot2-builder:latest pio run -d "${target}" -e "${name}" -t upload --upload-port "${port}"${otaAuth} || {
+            warn "Initial upload attempt exited. Retrying upload after resetting serial port..."
+            fuser -k "${port}" 2>/dev/null || true
+            sleep 1
+            docker run --rm --privileged -v /dev:/dev -v linorobot2_pio_cache:/root/.platformio -v "$(pwd):/workspace" -w /workspace -e ROS_DISTRO=${opts.rosDistro} linorobot2-builder:latest pio run -d "${target}" -e "${name}" -t upload --upload-port "${port}"${otaAuth} || {
+                warn "Attempting fallback auto-upload protocol..."
+                docker run --rm --privileged -v /dev:/dev -v linorobot2_pio_cache:/root/.platformio -v "$(pwd):/workspace" -w /workspace -e ROS_DISTRO=${opts.rosDistro} linorobot2-builder:latest pio run -d "${target}" -e "${name}" -t upload || {
+                    err "All upload attempts failed for port '${port}'."
+                    err "Check the cable, hold BOOT/RESET if the board requires it, and make sure no serial monitor holds the port."
+                    exit 1
+                }
+            }
+        }` :
+        opts.buildEngine === "podman" ? `podman run --rm --privileged -v /dev:/dev -v linorobot2_pio_cache:/root/.platformio -v "$(pwd):/workspace:Z" -w /workspace -e ROS_DISTRO=${opts.rosDistro} linorobot2-builder:latest pio run -d "${target}" -e "${name}" -t upload --upload-port "${port}"${otaAuth} || {
+            warn "Initial upload attempt exited. Retrying upload after resetting serial port..."
+            fuser -k "${port}" 2>/dev/null || true
+            sleep 1
+            podman run --rm --privileged -v /dev:/dev -v linorobot2_pio_cache:/root/.platformio -v "$(pwd):/workspace:Z" -w /workspace -e ROS_DISTRO=${opts.rosDistro} linorobot2-builder:latest pio run -d "${target}" -e "${name}" -t upload --upload-port "${port}"${otaAuth} || {
+                warn "Attempting fallback auto-upload protocol..."
+                podman run --rm --privileged -v /dev:/dev -v linorobot2_pio_cache:/root/.platformio -v "$(pwd):/workspace:Z" -w /workspace -e ROS_DISTRO=${opts.rosDistro} linorobot2-builder:latest pio run -d "${target}" -e "${name}" -t upload || {
+                    err "All upload attempts failed for port '${port}'."
+                    err "Check the cable, hold BOOT/RESET if the board requires it, and make sure no serial monitor holds the port."
+                    exit 1
+                }
+            }
+        }` :
+        `pio run -d "${target}" -e "${name}" -t upload --upload-port "${port}"${otaAuth} || {
+            warn "Initial upload attempt exited. Retrying upload after resetting serial port..."
+            fuser -k "${port}" 2>/dev/null || true
+            sleep 1
+            pio run -d "${target}" -e "${name}" -t upload --upload-port "${port}"${otaAuth} || {
+                warn "Attempting fallback auto-upload protocol..."
+                pio run -d "${target}" -e "${name}" -t upload || {
+                    err "All upload attempts failed for port '${port}'."
+                    err "Check the cable, hold BOOT/RESET if the board requires it, and make sure no serial monitor holds the port."
+                    exit 1
+                }
+            }
+        }`}
+        success "Microcontroller flashing COMPLETE!"
+    fi
+else
+    warn "Target directory '${target}/' not found in current workspace."
+fi
+
+# -----------------------------------------------------------------------------
+# Phase 9: Start micro-ROS Agent & Discover Active ROS 2 Topics (for firmware)
+# -----------------------------------------------------------------------------
+if [ "${target}" = "firmware" ] && [ "${opts.rosDistro}" != "none" ]; then
+    info "Step 9/9: Launching micro-ROS Agent & discovering active ROS 2 topics..."
+    
+    # Terminate any existing micro_ros_agent on this port/protocol
+    pkill -f "micro_ros_agent.*${port}" 2>/dev/null || true
+    pkill -f "micro_ros_agent.*udp4" 2>/dev/null || true
+    ${opts.agentEngine === "docker" ? `docker rm -f microros_agent 2>/dev/null || true` :
+      (opts.agentEngine === "podman" || opts.agentEngine === "podman_systemd") ? `podman rm -f microros_agent 2>/dev/null || true` : ""}
+    sleep 0.5
+    ensure_serial_rw "${port}"
+
+    AGENT_LOG="/tmp/micro_ros_agent_${name}.log"
+
+    # After a BOOTSEL / AUTO flash the board re-enumerates as a CDC device; the
+    # agent must target that, not the literal "BOOTSEL".
+    AGENT_DEV="${port}"
+    if [ "\${AGENT_DEV}" = "BOOTSEL" ] || [ "\${AGENT_DEV}" = "AUTO" ] || [ ! -e "\${AGENT_DEV}" ]; then
+        for _i in $(seq 1 10); do
+            AGENT_DEV=$(ls /dev/ttyACM* /dev/ttyUSB* 2>/dev/null | head -n1)
+            [ -n "\${AGENT_DEV}" ] && break
+            sleep 1
+        done
+        info "Post-flash serial device: \${AGENT_DEV:-<none found>}"
+    fi
+    ensure_serial_rw "\${AGENT_DEV}"
+
+    ${opts.agentEngine === "docker" ? `
+    ${buildRegistryProbeList().length > 0 ? `
+    for reg in ${regListStr}; do
+        if curl -fsSL -m 2 "https://${reg}/v2/" >/dev/null 2>&1 || curl -fsSL -m 2 "http://${reg}/v2/" >/dev/null 2>&1; then
+            if docker pull "${reg}/microros/micro-ros-agent:${opts.rosDistro}" >/dev/null 2>&1; then
+                docker tag "${reg}/microros/micro-ros-agent:${opts.rosDistro}" "microros/micro-ros-agent:${opts.rosDistro}"
+                break
+            fi
+        fi
+    done
+    ` : `info "Pulling micro-ROS agent from upstream Docker Hub..."`}
+    info "Starting micro-ROS agent in Docker container (logging to \${AGENT_LOG})..."
+    ${/WIFI|UDP/i.test(spec.transport || "") ? `
+    docker run -d --name microros_agent --rm --net=host -p 8888:8888/udp microros/micro-ros-agent:${opts.rosDistro} udp4 --port 8888 > "\${AGENT_LOG}" 2>&1
+    ` : `
+    docker run -d --name microros_agent --rm --net=host --privileged -v /dev:/dev microros/micro-ros-agent:${opts.rosDistro} serial --dev "\${AGENT_DEV}" -b "${spec.baudrate || 921600}" > "\${AGENT_LOG}" 2>&1
+    `}
+
+    info "Docker micro-ROS agent container started. Waiting for session handshake from microcontroller..."
+    CONNECTED=0
+    for i in $(seq 1 8); do
+        sleep 1
+        if docker logs microros_agent 2>&1 | grep -qi "session established" || grep -qi "session established" "\${AGENT_LOG}" 2>/dev/null; then
+            CONNECTED=1
+            break
+        fi
+        echo -n "."
+    done
+    echo ""
+    ` :
+    (opts.agentEngine === "podman" || opts.agentEngine === "podman_systemd") ? `
+    ${buildRegistryProbeList().length > 0 ? `
+    for reg in ${regListStr}; do
+        if curl -fsSL -m 2 "https://${reg}/v2/" >/dev/null 2>&1 || curl -fsSL -m 2 "http://${reg}/v2/" >/dev/null 2>&1; then
+            if podman pull "${reg}/microros/micro-ros-agent:${opts.rosDistro}" >/dev/null 2>&1; then
+                podman tag "${reg}/microros/micro-ros-agent:${opts.rosDistro}" "microros/micro-ros-agent:${opts.rosDistro}"
+                break
+            fi
+        fi
+    done
+    ` : `info "Pulling micro-ROS agent from upstream with podman..."`}
+    info "Starting micro-ROS agent in Podman container (logging to \${AGENT_LOG})..."
+    ${/WIFI|UDP/i.test(spec.transport || "") ? `
+    podman run -d --name microros_agent --replace --net=host -p 8888:8888/udp microros/micro-ros-agent:${opts.rosDistro} udp4 --port 8888 > "\${AGENT_LOG}" 2>&1
+    ` : `
+    podman run -d --name microros_agent --replace --net=host --privileged -v /dev:/dev microros/micro-ros-agent:${opts.rosDistro} serial --dev "\${AGENT_DEV}" -b "${spec.baudrate || 921600}" > "\${AGENT_LOG}" 2>&1
+    `}
+
+    info "Podman micro-ROS agent container started. Waiting for session handshake from microcontroller..."
+    CONNECTED=0
+    for i in $(seq 1 8); do
+        sleep 1
+        if podman logs microros_agent 2>&1 | grep -qi "session established" || grep -qi "session established" "\${AGENT_LOG}" 2>/dev/null; then
+            CONNECTED=1
+            break
+        fi
+        echo -n "."
+    done
+    echo ""
+    ` : `
+    # Native ROS 2 Execution
+    set +e
+    [ -f "/opt/ros/${opts.rosDistro}/setup.bash" ] && source "/opt/ros/${opts.rosDistro}/setup.bash"
+    [ -f "$HOME/uros_ws/install/setup.bash" ] && source "$HOME/uros_ws/install/setup.bash"
+    set -e
+
+    if ! ros2 pkg prefix micro_ros_agent >/dev/null 2>&1; then
+        warn "micro_ros_agent is not on the ROS 2 graph — the agent workspace did not build for '${opts.rosDistro}'."
+        warn "Firmware was built and flashed. Bridge the board with an agent from a supported distro/container, e.g.:"
+        warn "  docker run --rm --net=host --privileged -v /dev:/dev microros/micro-ros-agent:${opts.rosDistro} serial --dev ${port} -b ${spec.baudrate || 921600}"
+    else
+        AGENT_LOG="/tmp/micro_ros_agent_${name}.log"
+        info "Starting micro-ROS agent in background (logging to \${AGENT_LOG})..."
+        ${/WIFI|UDP/i.test(spec.transport || "") ? `
+        ros2 run micro_ros_agent micro_ros_agent udp4 --port 8888 > "\${AGENT_LOG}" 2>&1 &
+        AGENT_PID=\$!
+        ` : `
+        ros2 run micro_ros_agent micro_ros_agent serial --dev "\${AGENT_DEV}" -b "${spec.baudrate || 921600}" > "\${AGENT_LOG}" 2>&1 &
+        AGENT_PID=\$!
+        `}
+
+        info "Agent PID: \${AGENT_PID}. Waiting for session handshake from microcontroller..."
+        CONNECTED=0
+        for i in $(seq 1 8); do
+            sleep 1
+            if grep -qi "session established" "\${AGENT_LOG}" 2>/dev/null || ros2 node list 2>/dev/null | grep -q "linorobot2"; then
+                CONNECTED=1
+                break
+            fi
+            echo -n "."
+        done
+        echo ""
+    fi
+    `}
+
+    if [ "\${CONNECTED}" -eq 1 ]; then
+        success "🎉 micro-ROS Agent connected successfully! Active ROS 2 Session Established."
+    else
+        info "micro-ROS Agent active. Querying active ROS 2 graph..."
+    fi
+
+    if command -v ros2 >/dev/null 2>&1; then
+        info "========================================================="
+        info "  Active ROS 2 Nodes on Robot Network:"
+        info "========================================================="
+        ros2 node list 2>/dev/null || echo "  (no nodes discovered yet)"
+        
+        info "========================================================="
+        info "  Active ROS 2 Topics & Message Types:"
+        info "========================================================="
+        ros2 topic list -t 2>/dev/null || echo "  (no topics discovered yet)"
+        info "========================================================="
+    else
+        info "========================================================="
+        info "  micro-ROS Agent active in container."
+        ${opts.agentEngine === "docker" ? `info "  Logs: docker logs -f microros_agent"` : `info "  Logs: podman logs -f microros_agent"`}
+        info "========================================================="
+    fi
+fi
+
+info "========================================================="
+success "All deployment steps completed successfully for '${name}'!"
+info "========================================================="
+`;
+
+  return script;
+}
+
+// Stage the generated deploy script on the Robot SBC and run it. Shared by the
+// header "Run Full Deploy" button and the Automation-tab hero card.
+function runFullDeploy() {
+  const spec = currentSpec;
+  const opts = readAutomationOptions();
+  const name = spec.robot_name || "scout_pico2";
+  const script = generateDeployScript(spec, opts);
+  const safeName = String(name).replace(/[^A-Za-z0-9._-]/g, "_");
+  const cmd = `cat << 'EOF_DEPLOY_SCRIPT_WRAPPER' > "deploy_${safeName}.sh"\n${script}\nEOF_DEPLOY_SCRIPT_WRAPPER\nchmod +x "deploy_${safeName}.sh" && bash "./deploy_${safeName}.sh"`;
+  executeCommandInTerminal(cmd, `Executing Full Deploy Lifecycle for '${name}'`);
+}
+
+// -----------------------------------------------------------------------------
+// Web Serial API Implementation for Chrome / Edge Live Microcontroller Logs
+// -----------------------------------------------------------------------------
+async function toggleWebSerialConnection() {
+  if (serialPort) {
+    await disconnectWebSerial();
+  } else {
+    await connectWebSerial();
+  }
+}
+
+async function connectWebSerial() {
+  const terminalScreen = document.getElementById("serial-terminal-screen");
+  const statusPill = document.getElementById("serial-status-pill");
+  const statusText = document.getElementById("serial-status-text");
+  const btnConnect = document.getElementById("btn-serial-connect");
+  const btnText = document.getElementById("serial-btn-text");
+  const baudSelect = document.getElementById("serial-baud-select");
+  const inputBar = document.getElementById("serial-input-text");
+  const btnSend = document.getElementById("btn-serial-send");
+
+  if (!("serial" in navigator)) {
+    appendTerminalLine("❌ Web Serial API is not supported in this browser. Please use Chrome, Edge, or Opera over HTTPS/localhost.", "err");
+    alert("Web Serial API is not supported in this browser. Please open in Google Chrome or Microsoft Edge.");
+    return;
+  }
+
+  try {
+    const baudRate = parseInt(baudSelect?.value || "115200", 10);
+    appendTerminalLine(`🔌 Requesting serial port access (Baud: ${baudRate})...`, "dim");
+
+    serialPort = await navigator.serial.requestPort();
+    await serialPort.open({ baudRate: baudRate });
+
+    // Update UI Connected State
+    if (statusPill) statusPill.className = "serial-status-pill pill-connected";
+    if (statusText) statusText.innerText = `Connected (${baudRate} baud)`;
+    if (btnText) btnText.innerText = "Disconnect";
+    if (btnConnect) btnConnect.className = "btn btn-sm btn-secondary";
+    if (inputBar) inputBar.disabled = false;
+    if (btnSend) btnSend.disabled = false;
+
+    appendTerminalLine(`✅ Serial port connected at ${baudRate} baud. Streaming output:`, "dim");
+    showToast("🟢 Serial port connected!");
+
+    // Start background reader loop
+    readSerialStream();
+
+  } catch (err) {
+    appendTerminalLine(`❌ Connection failed: ${err.message}`, "err");
+    serialPort = null;
+    if (statusPill) statusPill.className = "serial-status-pill pill-disconnected";
+    if (statusText) statusText.innerText = "Disconnected";
+  }
+}
+
+async function disconnectWebSerial() {
+  const statusPill = document.getElementById("serial-status-pill");
+  const statusText = document.getElementById("serial-status-text");
+  const btnConnect = document.getElementById("btn-serial-connect");
+  const btnText = document.getElementById("serial-btn-text");
+  const inputBar = document.getElementById("serial-input-text");
+  const btnSend = document.getElementById("btn-serial-send");
+
+  isSerialReading = false;
+
+  try {
+    if (serialReader) {
+      await serialReader.cancel();
+      serialReader = null;
+    }
+    if (serialPort) {
+      await serialPort.close();
+      serialPort = null;
+    }
+  } catch (err) {
+    console.error("Error closing serial port:", err);
+  }
+
+  if (statusPill) statusPill.className = "serial-status-pill pill-disconnected";
+  if (statusText) statusText.innerText = "Disconnected";
+  if (btnText) btnText.innerText = "Connect Serial Port";
+  if (btnConnect) btnConnect.className = "btn btn-sm btn-accent";
+  if (inputBar) inputBar.disabled = true;
+  if (btnSend) btnSend.disabled = true;
+
+  appendTerminalLine("🔌 Serial port disconnected.", "dim");
+  showToast("🔌 Serial port disconnected.");
+}
+
+async function readSerialStream() {
+  isSerialReading = true;
+  const decoder = new TextDecoderStream();
+  const inputDone = serialPort.readable.pipeTo(decoder.writable);
+  const inputStream = decoder.readable;
+  serialReader = inputStream.getReader();
+
+  let lineBuffer = "";
+
+  try {
+    while (isSerialReading) {
+      const { value, done } = await serialReader.read();
+      if (done) break;
+      if (value) {
+        lineBuffer += value;
+        const lines = lineBuffer.split(/\r?\n/);
+        lineBuffer = lines.pop(); // Keep partial line in buffer
+
+        for (const line of lines) {
+          if (line.trim().length > 0) {
+            appendTerminalLine(line, "out");
+          }
+        }
+      }
+    }
+  } catch (err) {
+    if (isSerialReading) {
+      appendTerminalLine(`⚠️ Serial stream closed: ${err.message}`, "dim");
+    }
+  } finally {
+    if (serialReader) {
+      serialReader.releaseLock();
+    }
+  }
+}
+
+async function sendSerialCommand() {
+  const inputBar = document.getElementById("serial-input-text");
+  if (!inputBar || !inputBar.value || !serialPort || !serialPort.writable) return;
+
+  const textToSend = inputBar.value + "\n";
+  appendTerminalLine(`> ${inputBar.value}`, "in");
+  inputBar.value = "";
+
+  const encoder = new TextEncoder();
+  const writer = serialPort.writable.getWriter();
+  await writer.write(encoder.encode(textToSend));
+  writer.releaseLock();
+}
+
+// The console (#serial-terminal-screen) is fed by four unbounded streams —
+// /api/exec deploy output, `ros2 topic echo`, the UDP syslog stream and the
+// Web Serial monitor. Without a cap the <div> count grows until the browser
+// tab runs out of memory. Keep at most MAX_TERMINAL_LINES rows and drop the
+// oldest in chunks; autoscroll is coalesced onto one rAF so a fast stream
+// doesn't force a synchronous reflow per line.
+const MAX_TERMINAL_LINES = 4000;
+const TERMINAL_TRIM_CHUNK = 512;
+let _terminalScrollQueued = false;
+
+function _trimTerminal(screen) {
+  const over = screen.childElementCount - MAX_TERMINAL_LINES;
+  if (over <= 0) return;
+  for (let i = 0, n = over + TERMINAL_TRIM_CHUNK; i < n && screen.firstChild; i++) {
+    screen.removeChild(screen.firstChild);
+  }
+}
+
+function _queueTerminalScroll(screen) {
+  const autoScroll = document.getElementById("chk-serial-autoscroll")?.checked ?? true;
+  if (!autoScroll || _terminalScrollQueued) return;
+  _terminalScrollQueued = true;
+  requestAnimationFrame(() => {
+    _terminalScrollQueued = false;
+    screen.scrollTop = screen.scrollHeight;
+  });
+}
+
+function appendTerminalLine(text, type = "out") {
+  const screen = document.getElementById("serial-terminal-screen");
+  if (!screen) return;
+  const lineEl = document.createElement("div");
+  lineEl.className = `terminal-line terminal-${type}`;
+  lineEl.innerText = text;
+  screen.appendChild(lineEl);
+  _trimTerminal(screen);
+  _queueTerminalScroll(screen);
+}
+
+// Like appendTerminalLine but the caller supplies already-escaped innerHTML
+// (the syslog stream renders coloured multi-span rows). Goes through the same
+// line cap.
+function appendTerminalHtml(html, type = "out") {
+  const screen = document.getElementById("serial-terminal-screen");
+  if (!screen) return;
+  const lineEl = document.createElement("div");
+  lineEl.className = `terminal-line terminal-${type}`;
+  lineEl.innerHTML = html;
+  screen.appendChild(lineEl);
+  _trimTerminal(screen);
+  _queueTerminalScroll(screen);
+}
+
+function clearTerminalScreen() {
+  const screen = document.getElementById("serial-terminal-screen");
+  if (screen) {
+    screen.innerHTML = '<div class="terminal-line terminal-dim">[Terminal Cleared]</div>';
+  }
+}
+
+// Robust Direct Upload / Build Command Generator (module scope so the ADC
+// Calibration Studio's runHardwareAdcCalibration() can reuse it too).
+function getDirectUploadOrBuildCmd(target, isUpload = true) {
+  const spec = currentSpec;
+  const name = spec.robot_name || "scout_pico2";
+  const nameUpper = name.toUpperCase();
+  const opts = readAutomationOptions();
+  const rosDistro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
+  const otaOn = document.getElementById("cfg-ota-enable")?.checked;
+  const otaIp = (document.getElementById("cfg-ota-ip")?.value || "").trim();
+  const otaPass = (document.getElementById("cfg-ota-password")?.value || "").trim();
+  const port = (otaOn && otaIp) ? otaIp
+             : (document.getElementById("auto-flash-port")?.value.trim() || (isESP32(spec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0"));
+  const wifiConfigContent = generateWifiConfig(spec);
+  const pioSection = generatePlatformioEnv(spec);
+  const urdfContent = generateUrdfXacro(spec);
+  const targetDir = (target === "i2c_detect") ? "tools/i2c_detect" : target;
+  // test_motors/, test_acc/, test_sensors/ and adc_calibrate/ each carry a
+  // platformio.ini with `extra_configs = ../firmware/platformio.ini`, so they
+  // inherit [env:<robot>] and build with the user's exact config. (The legacy
+  // calibration/ project has its own fixed env list and is not used here.)
+  const buildEnv = name;
+
+  const lines = [
+    `set -e`,
+    `export PATH="$HOME/.platformio/penv/bin:$HOME/.local/bin:$PATH"`,
+    `export ROS_DISTRO=${rosDistro}`,
+    // test_sensors/test_motors/test_acc/adc_calibrate each carry their own
+    // platformio.ini (`extra_configs = ../firmware/platformio.ini`) and so
+    // build against the exact same lib_deps/env as firmware/, incl.
+    // micro_ros_platformio -- test_sensors/test_motors/test_acc genuinely
+    // link it (firmware/lib/imu's message-typed interface calls
+    // micro_ros_string_utilities_set() for frame_id), it's not dead weight.
+    // But each is its own PlatformIO project directory, and by default
+    // PlatformIO downloads+builds every lib_dep separately per project
+    // directory -- so without this, each one redoes micro_ros_platformio's
+    // very slow first-time build (compiles the full micro-ROS static lib)
+    // from scratch, even though it's identical to what firmware/ already
+    // built for the same board/env. Point PLATFORMIO_LIBDEPS_DIR at
+    // firmware/'s own libdeps location (its default, unchanged) so
+    // PlatformIO treats the library as already installed & built there.
+    ...(["test_sensors", "test_motors", "test_acc", "adc_calibrate"].includes(target) ? [
+      `export PLATFORMIO_LIBDEPS_DIR="$(pwd)/firmware/.pio/libdeps"`,
+    ] : []),
+    ``,
+    `echo "=== [1/2] Build tools (PlatformIO) ==============================="`,
+    ensurePioToolchainSnippet(),   // first-run bootstrap so a bare SBC/box doesn't exit 127
+    `echo "=== [2/2] ${isUpload ? "Building & flashing" : "Building"} ${target} ==============="`,
+    `[ "$(awk '/MemTotal/{print $2}' /proc/meminfo 2>/dev/null || echo 8000000)" -lt 6000000 ] && export PLATFORMIO_BUILD_JOBS=2 MAKEFLAGS="-j2" || true`,
+    `if [ -f "/opt/ros/${rosDistro}/setup.bash" ]; then source "/opt/ros/${rosDistro}/setup.bash"; fi`,
+    `if [ -f "$HOME/uros_ws/install/setup.bash" ]; then source "$HOME/uros_ws/install/setup.bash"; fi`,
+    ``,
+    `# 1. Ensure custom robot headers and urdf are synced (search-and-merge with any existing file)`,
+    ...getConfigSyncScript(spec, name),
+    ...(wifiConfigContent ? [
+      `if [ ! -f "config/custom/wifi_config.h" ]; then`,
+      `    cat << 'EOF_WIFI_CFG' > "config/custom/wifi_config.h"   # git-ignored, holds WiFi credentials`,
+      `${wifiConfigContent}`,
+      `EOF_WIFI_CFG`,
+      `fi`,
+    ] : []),
+    ``,
+    `# 2. Ensure USE_${nameUpper}_CONFIG is registered in config/config.h`,
+    `if [ -f "config/config.h" ]; then`,
+    `    if ! grep -F -q "USE_${nameUpper}_CONFIG" config/config.h; then`,
+    `        sed -i '/\\/\\/ add user configurations above this line/i #ifdef USE_${nameUpper}_CONFIG\\n    #include "custom/${name}_config.h"\\n#endif\\n' config/config.h`,
+    `    fi`,
+    `fi`,
+    ``,
+    `# 3. Ensure [env:${name}] is defined in firmware/platformio.ini`,
+    `if [ -f "firmware/platformio.ini" ]; then`,
+    `    if ! grep -F -q "[env:${name}]" "firmware/platformio.ini"; then`,
+    `        echo "" >> "firmware/platformio.ini"`,
+    `        cat << 'EOF_PIO' >> "firmware/platformio.ini"`,
+    `${pioSection}`,
+    `EOF_PIO`,
+    `    fi`,
+    `fi`,
+    ``,
+    `# 4. Ingest URDF Description`,
+    `cat << 'EOF_URDF' > "urdf/${name}_properties.urdf.xacro"`,
+    `${urdfContent}`,
+    `EOF_URDF`,
+    ``,
+    // "Step 4" (the Merge & Commit section) is folded in here so it always
+    // runs before a build/upload/calibration, not just when the user
+    // remembers to click "Run Merge & Commit" separately. Respects the same
+    // "Stage changes and create Git commit automatically" checkbox.
+    ...(opts.autoCommit ? [
+      `# 5. Stage & commit the synced configuration (Step 4's auto-commit)`,
+      `git add config/ firmware/platformio.ini urdf/ 2>/dev/null || true`,
+      `if ! git diff --cached --quiet 2>/dev/null; then`,
+      `    git commit -m "${(opts.gitCommitMsg || `feat(config): add configuration for ${name}`).replace(/"/g, '\\"')}"`,
+      `else`,
+      `    echo "Configuration files already up to date on branch $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')."`,
+      `fi`,
+      ``,
+    ] : []),
+    `# 6. Compile & Upload via PlatformIO`
+  ];
+
+  if (isUpload) {
+    if (remoteConfig.targetMode === "remote") {
+      const host = remoteConfig.remoteHost;
+      const user = remoteConfig.remoteUser;
+      const sshPort = remoteConfig.remotePort || 22;
+      const sshKey = remoteConfig.remoteKey;
+      const sshOpts = `-o StrictHostKeyChecking=no -p ${sshPort}` + (sshKey ? ` -i ${sshKey}` : "");
+      const isPico = !isESP32(spec.mcu);
+      const binExt = isPico ? "uf2" : "bin";
+      const binFile = `${targetDir}/.pio/build/${buildEnv}/firmware.${binExt}`;
+      const remoteDest = `/tmp/${target}_firmware.${binExt}`;
+
+      lines.push(`# 6. Compile locally on Workstation via PlatformIO`);
+      const buildEngine = document.getElementById("hdr-build-engine")?.value || (document.getElementById("chk-docker-builder")?.checked ? "docker" : "native");
+      const dockerImg = document.getElementById("docker-builder-image")?.value.trim() || "linorobot2-builder:latest";
+      if (buildEngine === "docker") {
+        lines.push(`echo "🐳 Compiling inside Docker rootless container (${dockerImg})..."`);
+        lines.push(`docker run --rm -v linorobot2_pio_cache:/root/.platformio -v "$(pwd):/workspace" -w /workspace -e ROS_DISTRO=${rosDistro} ${dockerImg} pio run -d ${targetDir} -e ${buildEnv}`);
+      } else if (buildEngine === "podman") {
+        lines.push(`echo "🦭 Compiling inside Podman container (${dockerImg})..."`);
+        lines.push(`podman run --rm -v linorobot2_pio_cache:/root/.platformio -v "$(pwd):/workspace:Z" -w /workspace -e ROS_DISTRO=${rosDistro} ${dockerImg} pio run -d ${targetDir} -e ${buildEnv}`);
+      } else {
+        lines.push(`pio run -d ${targetDir} -e ${buildEnv}`);
+      }
+      lines.push(``);
+      lines.push(`# 7. Ensure minimal tools on remote Robot PC (${host})`);
+      lines.push(`echo "Checking flash tools on ${user}@${host}..."`);
+      lines.push(`ssh ${sshOpts} ${user}@${host} "which esptool.py >/dev/null 2>&1 || python3 -m esptool version >/dev/null 2>&1 || python3 -m pip install -q --user esptool 2>/dev/null || true"`);
+      lines.push(``);
+      lines.push(`# 8. Stop serial micro-ROS agent & monitors on remote Robot PC`);
+      lines.push(`echo "Releasing remote USB port '${port}' on ${host}..."`);
+      lines.push(`ssh ${sshOpts} ${user}@${host} "docker stop microros_agent 2>/dev/null || true; pkill -f '[m]icro_ros_agent.*serial' 2>/dev/null || true; pkill -f '[m]initerm' 2>/dev/null || true; [ -e '${port}' ] && fuser -k '${port}' 2>/dev/null || true"`);
+      lines.push(``);
+      lines.push(`# 9. Transfer firmware binary to remote Robot PC via SCP`);
+      lines.push(`echo "Transferring ${binFile} -> ${user}@${host}:${remoteDest}..."`);
+      lines.push(`scp ${sshOpts} ${binFile} ${user}@${host}:${remoteDest}`);
+      lines.push(``);
+      lines.push(`# 10. Flash Microcontroller remotely on Robot PC`);
+      if (isPico) {
+        lines.push(`echo "🐳 [Docker Anywhere] Flashing RP2040/RP2350 via picotool Docker container on remote robot..."`);
+        lines.push(`ssh ${sshOpts} ${user}@${host} "docker run --rm --privileged -v /dev:/dev -v /dev/bus/usb:/dev/bus/usb -v /tmp:/tmp linorobot2-flasher:latest -c 'picotool load -f ${remoteDest} -x || picotool load -u -v -x ${remoteDest} || cp ${remoteDest} /media/*/RPI-RP2/ 2>/dev/null || cp ${remoteDest} /mnt/RPI-RP2/ 2>/dev/null' || picotool load -f ${remoteDest} -x || sudo cp ${remoteDest} /media/*/RPI-RP2/ 2>/dev/null"`);
+      } else {
+        lines.push(`echo "🐳 [Docker Anywhere] Flashing ESP32 via esptool Docker container on remote robot..."`);
+        lines.push(`ssh ${sshOpts} ${user}@${host} "docker run --rm --privileged -v /dev:/dev -v /tmp:/tmp linorobot2-flasher:latest -c 'esptool --port ${port} --baud 460800 --before default_reset --after hard_reset write_flash 0x10000 ${remoteDest}' || python3 -m esptool --port ${port} --baud 460800 write_flash 0x10000 ${remoteDest} || esptool.py --port ${port} --baud 460800 write_flash 0x10000 ${remoteDest}"`);
+      }
+    } else {
+      lines.push(`# 7. Stop serial micro-ROS agent & monitors to release shared USB port (WiFi agent kept running)`);
+    lines.push(`echo "Releasing USB port '${port}' (stopping serial micro-ROS agent and serial monitors)..."`);
+    // NOTE the "[m]" / "[s]" first-character classes: this whole script is passed
+    // to `bash -c` as one argument, so a plain `pkill -f "micro_ros_agent.*serial"`
+    // matches the running shell's OWN /proc/<pid>/cmdline and SIGTERMs the deploy
+    // (exit -15). The bracket makes the pattern text non-self-matching while it
+    // still matches a real `micro_ros_agent ... serial` process.
+    lines.push(`pkill -f "[m]icro_ros_agent.*serial" 2>/dev/null || true`);
+    lines.push(`pkill -f "[m]initerm" 2>/dev/null || true`);
+    lines.push(`pkill -f "[s]creen.*${port}" 2>/dev/null || true`);
+    if (port !== "AUTO" && port !== "BOOTSEL" && !(otaOn && otaIp)) {
+      lines.push(`[ -e "${port}" ] && fuser -k "${port}" 2>/dev/null || true`);
+      // Grant r/w when no udev rule / 'dialout' membership does.
+      lines.push(`for _d in /dev/ttyUSB* /dev/ttyACM*; do [ -e "$_d" ] && [ ! -w "$_d" ] && sudo chmod a+rw "$_d" 2>/dev/null || true; done`);
+    }
+    lines.push(`sleep 0.8`);
+    lines.push(``);
+    lines.push(`# 8. Flash Firmware onto Microcontroller`);
+    if (port === "AUTO" || port === "BOOTSEL") {
+      lines.push(`pio run -d ${targetDir} -e ${buildEnv} -t upload`);
+    } else if (otaOn && otaIp) {
+      const authFlag = otaPass ? ` --upload-flags "--auth=${otaPass}"` : "";
+      lines.push(`echo "OTA flashing ${buildEnv} over WiFi -> ${otaIp}"`);
+      lines.push(`pio run -d ${targetDir} -e ${buildEnv} -t upload --upload-port ${otaIp}${authFlag}`);
+    } else {
+      const buildEngine = document.getElementById("hdr-build-engine")?.value || (document.getElementById("chk-docker-builder")?.checked ? "docker" : "native");
+      const dockerImg = document.getElementById("docker-builder-image")?.value.trim() || "linorobot2-builder:latest";
+      if (buildEngine === "docker") {
+        lines.push(`echo "🐳 Compiling & flashing via Docker rootless container (${dockerImg})..."`);
+        lines.push(`docker run --rm --privileged -v /dev:/dev -v linorobot2_pio_cache:/root/.platformio -v "$(pwd):/workspace" -w /workspace -e ROS_DISTRO=${rosDistro} ${dockerImg} pio run -d ${targetDir} -e ${buildEnv} -t upload --upload-port ${port}`);
+      } else if (buildEngine === "podman") {
+        lines.push(`echo "🦭 Compiling & flashing via Podman container (${dockerImg})..."`);
+        lines.push(`podman run --rm --privileged -v /dev:/dev -v linorobot2_pio_cache:/root/.platformio -v "$(pwd):/workspace:Z" -w /workspace -e ROS_DISTRO=${rosDistro} ${dockerImg} pio run -d ${targetDir} -e ${buildEnv} -t upload --upload-port ${port}`);
+      } else {
+        lines.push(`pio run -d ${targetDir} -e ${buildEnv} -t upload --upload-port ${port}`);
+      }
+      }
+    }
+  } else {
+    lines.push(`pio run -d ${targetDir} -e ${buildEnv}`);
+  }
+
+  return lines.join("\n");
+}
+
+// After flashing a diagnostic sketch (test_sensors / test_motors / test_acc),
+// append a read-only serial monitor so its output streams into the console.
+// Dependency-free (stty + cat, like the "Stream SBC Serial" button); runs until
+// the user hits Stop. No-op for BOOTSEL / AUTO ports or non-diagnostic targets.
+function withSerialMonitor(cmd, target, port) {
+  const streamable = ["test_sensors", "test_motors", "test_acc", "adc_calibrate"];
+  if (!streamable.includes(target)) return cmd;
+  if (!port || port.includes("BOOTSEL") || port.includes("AUTO")) return cmd;
+  const baud = firmwareBaud();
+  if (remoteConfig.targetMode === "remote") {
+    const host = remoteConfig.remoteHost;
+    const user = remoteConfig.remoteUser;
+    const sshPort = remoteConfig.remotePort || 22;
+    const sshKey = remoteConfig.remoteKey;
+    const sshOpts = `-o StrictHostKeyChecking=no -p ${sshPort}` + (sshKey ? ` -i ${sshKey}` : "");
+    return cmd + [
+      ``,
+      `echo`,
+      `echo "=== Remote Serial monitor: ${user}@${host}:${port} @ ${baud} — press ⏹ Stop to end ==="`,
+      `sleep 1`,
+      `ssh ${sshOpts} -t ${user}@${host} "stty -F '${port}' ${baud} raw -echo 2>/dev/null || true; exec cat '${port}'"`,
+    ].join("\n");
+  }
+  return cmd + [
+    ``,
+    `echo`,
+    `echo "=== Serial monitor: ${port} @ ${baud} — press ⏹ Stop to end ==="`,
+    `sleep 1`,
+    `stty -F "${port}" ${baud} raw -echo 2>/dev/null || true`,
+    `exec cat "${port}"`,
+  ].join("\n");
+}
+
+
+// Initialize Automation Event Listeners
+
+// =============================================================================
+// 🤖 Remote Target Mode & SSH Management
+// =============================================================================
+let remoteConfig = {
+  targetMode: "local",
+  remoteHost: "192.168.1.100",
+  remoteUser: "ubuntu",
+  remotePort: 22,
+  remoteKey: "",
+  remoteSerialPort: "/dev/ttyUSB0",
+  remoteBaud: 1500000
+};
+
+async function loadRemoteConfig() {
+  try {
+    const res = await fetch("/api/remote/config");
+    if (!res.ok) return;
+    const data = await res.json();
+    if (data.config) {
+      remoteConfig = {
+        targetMode: data.config.target_mode || (data.config.remote_host ? "remote" : "local"),
+        remoteHost: data.config.remote_host || "",
+        remoteUser: data.config.remote_user || "ubuntu",
+        remotePort: data.config.remote_port || 22,
+        remoteKey: data.config.remote_key || "",
+        remoteSerialPort: data.config.remote_serial_port || "/dev/ttyUSB0",
+        remoteBaud: data.config.remote_baud || 1500000
+      };
+      const hostInput = document.getElementById("remote-ssh-host");
+      if (hostInput) hostInput.value = remoteConfig.remoteHost;
+      updateRemoteUI();
+      if (remoteConfig.remoteHost) {
+        testRemoteConnection();
+      } else {
+        detectClientOS();
+      }
+    }
+  } catch (e) {
+    console.warn("Failed to load remote config", e);
+  }
+}
+
+function updateRemoteUI() {
+  const hostInput = document.getElementById("remote-ssh-host");
+  const userInput = document.getElementById("remote-ssh-user");
+  const portInput = document.getElementById("remote-ssh-port");
+  const keyInput = document.getElementById("remote-ssh-key");
+  const badgeTarget = document.getElementById("target-mode-status-badge");
+  const groupUser = document.getElementById("group-ssh-user");
+  const groupPort = document.getElementById("group-ssh-port");
+  const groupKey = document.getElementById("group-ssh-key");
+  const toolsBar = document.getElementById("remote-tools-bar");
+
+  let hostVal = "";
+  if (hostInput) {
+    hostVal = hostInput.value.trim();
+  } else {
+    hostVal = (remoteConfig.remoteHost || "").trim();
+  }
+
+  const isRemote = Boolean(hostVal);
+  remoteConfig.targetMode = isRemote ? "remote" : "local";
+  remoteConfig.remoteHost = hostVal;
+
+  if (userInput) userInput.value = remoteConfig.remoteUser || "ubuntu";
+  if (portInput) portInput.value = remoteConfig.remotePort || 22;
+  if (keyInput) keyInput.value = remoteConfig.remoteKey || "";
+
+  if (groupUser) groupUser.style.display = isRemote ? "block" : "none";
+  if (groupPort) groupPort.style.display = isRemote ? "block" : "none";
+  if (groupKey) groupKey.style.display = isRemote ? "block" : "none";
+  if (toolsBar) toolsBar.style.display = isRemote ? "flex" : "none";
+
+  if (badgeTarget) {
+    if (isRemote) {
+      badgeTarget.className = "badge-pill badge-ok";
+      badgeTarget.textContent = `🤖 Remote: ${hostVal}`;
+    } else {
+      badgeTarget.className = "badge-pill badge-ok";
+      badgeTarget.textContent = "💻 Local Machine";
+    }
+  }
+}
+
+async function saveRemoteConfig() {
+  const hostInput = document.getElementById("remote-ssh-host");
+  const userInput = document.getElementById("remote-ssh-user");
+  const portInput = document.getElementById("remote-ssh-port");
+  const keyInput = document.getElementById("remote-ssh-key");
+
+  if (hostInput) remoteConfig.remoteHost = hostInput.value.trim();
+  if (userInput) remoteConfig.remoteUser = userInput.value.trim();
+  if (portInput) remoteConfig.remotePort = parseInt(portInput.value, 10) || 22;
+  if (keyInput) remoteConfig.remoteKey = keyInput.value.trim();
+
+  try {
+    await fetch("/api/remote/config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        target_mode: remoteConfig.targetMode,
+        remote_host: remoteConfig.remoteHost,
+        remote_user: remoteConfig.remoteUser,
+        remote_port: remoteConfig.remotePort,
+        remote_key: remoteConfig.remoteKey
+      })
+    });
+  } catch (e) {
+    console.warn("Failed to save remote config", e);
+  }
+}
+
+async function testRemoteConnection() {
+  const hostInput = document.getElementById("remote-ssh-host");
+  const hostVal = hostInput ? hostInput.value.trim() : "";
+  if (!hostVal) {
+    remoteConfig.targetMode = "local";
+    remoteConfig.remoteHost = "";
+    await saveRemoteConfig();
+    updateRemoteUI();
+    detectClientOS();
+    return;
+  }
+  remoteConfig.targetMode = "remote";
+  remoteConfig.remoteHost = hostVal;
+  await saveRemoteConfig();
+  updateRemoteUI();
+
+  const badgeSsh = document.getElementById("badge-remote-ssh");
+  const badgeTools = document.getElementById("badge-remote-tools");
+  const badgeDoc = document.getElementById("badge-remote-docker");
+
+  if (badgeSsh) { badgeSsh.className = "badge-pill badge-neutral"; badgeSsh.textContent = `Connecting to ${hostVal}...`; }
+
+  try {
+    const res = await fetch("/api/remote/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        remote_host: remoteConfig.remoteHost,
+        remote_user: remoteConfig.remoteUser,
+        remote_port: remoteConfig.remotePort,
+        remote_key: remoteConfig.remoteKey
+      })
+    });
+    const data = await res.json();
+    if (data.ok) {
+      if (badgeSsh) { badgeSsh.className = "badge-pill badge-ok"; badgeSsh.textContent = `SSH: Connected (${data.os_info || "Linux"})`; }
+      if (badgeTools) {
+        badgeTools.className = "badge-pill badge-ok";
+        badgeTools.textContent = "Minimal Tools: Auto-Ready (esptool/picotool)";
+      }
+      if (badgeDoc) {
+        badgeDoc.className = data.has_docker ? "badge-pill badge-ok" : "badge-pill badge-neutral";
+        badgeDoc.textContent = data.has_docker ? "Docker: Available" : "Docker: Not found";
+      }
+      const badgeRobDoc = document.getElementById("badge-docker-robot");
+      if (badgeRobDoc) {
+        badgeRobDoc.className = data.has_docker ? "badge-pill badge-ok" : "badge-pill badge-warn";
+        badgeRobDoc.textContent = data.has_docker ? "🤖 Robot Docker: Ready" : "🤖 Robot Docker: Installing...";
+      }
+      showToast(`✅ Connected to robot PC: ${hostVal}! Minimal tools verified.`);
+      probeRemotePorts();
+    } else {
+      if (badgeSsh) { badgeSsh.className = "badge-pill badge-error"; badgeSsh.textContent = `SSH Failed: ${data.error || "error"}`; }
+    }
+  } catch (e) {
+    if (badgeSsh) { badgeSsh.className = "badge-pill badge-error"; badgeSsh.textContent = "SSH Network Error"; }
+  }
+}
+
+async function probeRemotePorts() {
+  await saveRemoteConfig();
+  try {
+    const url = `/api/remote/serial_ports?host=${encodeURIComponent(remoteConfig.remoteHost)}&user=${encodeURIComponent(remoteConfig.remoteUser)}&port=${remoteConfig.remotePort}`;
+    const res = await fetch(url);
+    const data = await res.json();
+    if (data.status === "ok" && data.serial_ports) {
+      const portInput = document.getElementById("auto-flash-port");
+      const chipsWrap = document.getElementById("flash-port-chips");
+      if (data.serial_ports.length > 0 && portInput && portInput.dataset.autoManaged !== "false") {
+        portInput.value = data.serial_ports[0];
+      }
+      if (chipsWrap) {
+        chipsWrap.innerHTML = `<span class="chips-label">Remote USB Devices (${remoteConfig.remoteHost}):</span> ` + (data.serial_ports || []).map(p => {
+          const detail = (data.port_details || []).find(d => d.port === p) || {};
+          const vidPid = detail.vid && detail.pid ? `[${detail.vid}:${detail.pid}]` : "";
+          const chip = detail.chip || detail.product || "Serial Device";
+          const icon = "🌐⚡";
+          const badgeClass = "port-chip";
+          const title = `[Remote ${remoteConfig.remoteHost}] ${p} ${vidPid} - ${chip}`;
+          return `<button type="button" class="${badgeClass}" data-port="${p}" title="${title}">
+            <span class="chip-icon">${icon}</span>
+            <span class="chip-port">${p}</span>
+            ${vidPid ? `<span class="chip-vidpid">${vidPid}</span>` : ""}
+            <span class="chip-desc">${chip}</span>
+          </button>`;
+        }).join(" ");
+
+        chipsWrap.querySelectorAll(".port-chip").forEach(btn => {
+          btn.addEventListener("click", () => {
+            const p = btn.dataset.port;
+            if (portInput) portInput.value = p;
+            const detail = (data.port_details || []).find(d => d.port === p);
+            const guessed = guessMcuFromUsbDetail(detail);
+            if (guessed) {
+              applyDetectedChipToBaudUi(guessed);
+            defaultSimulationForDetectedModule(guessed.chipName);
+              const mcuSelect = document.getElementById("cfg-mcu");
+              if (mcuSelect && guessed.mcu && !mcuSelect.dataset.userModified) {
+                mcuSelect.value = guessed.mcu;
+                mcuSelect.dispatchEvent(new Event("change"));
+              }
+            }
+            updateAutomationPreviews();
+          });
+        });
+      }
+
+      // Automatically apply detected chip info from first discovered port from the beginning
+      if (data.port_details && data.port_details.length > 0) {
+        const firstDetail = data.port_details[0];
+        const guessed = guessMcuFromUsbDetail(firstDetail);
+        if (guessed) {
+          applyDetectedChipToBaudUi(guessed);
+            defaultSimulationForDetectedModule(guessed.chipName);
+          const mcuSelect = document.getElementById("cfg-mcu");
+          if (mcuSelect && guessed.mcu && !mcuSelect.dataset.userModified) {
+            mcuSelect.value = guessed.mcu;
+            mcuSelect.dispatchEvent(new Event("change"));
+          }
+        }
+      }
+      updateAutomationPreviews();
+      showToast(`🔍 Discovered ${data.serial_ports.length} remote serial port(s) with Chip IDs on ${remoteConfig.remoteHost}!`);
+    }
+  } catch (e) {
+    console.warn("Failed to probe remote ports", e);
+  }
+}
+
+async function queryRemoteChipId() {
+  const port = document.getElementById("auto-flash-port")?.value.trim() || "/dev/ttyUSB0";
+  const callout = document.getElementById("remote-chip-id-output");
+  if (callout) {
+    callout.style.display = "block";
+    callout.textContent = `Querying chip ID for ${port} over SSH on ${remoteConfig.remoteHost}...`;
+  }
+  try {
+    const url = `/api/remote/chip_id?host=${encodeURIComponent(remoteConfig.remoteHost)}&user=${encodeURIComponent(remoteConfig.remoteUser)}&port=${encodeURIComponent(port)}`;
+    const res = await fetch(url);
+    const data = await res.json();
+    if (callout) {
+      callout.textContent = data.output || data.error || "No response received";
+    }
+  } catch (e) {
+    if (callout) callout.textContent = "Error querying chip ID: " + e.message;
+  }
+}
+
+function installRemoteTools() {
+  const host = remoteConfig.remoteHost;
+  const user = remoteConfig.remoteUser;
+  const port = remoteConfig.remotePort;
+  const key = remoteConfig.remoteKey;
+  const sshOpts = `-o StrictHostKeyChecking=no -p ${port}` + (key ? ` -i ${key}` : "");
+
+  const remoteScript = [
+    `echo "=================================================================="`,
+    `echo " 🤖 Setting up Minimal Tools on Remote Robot PC (${user}@${host})"`,
+    `echo "=================================================================="`,
+    `ssh ${sshOpts} ${user}@${host} 'bash -s' << 'EOF_ROBOT_SETUP'`,
+    `set -e`,
+    `echo "=== [1/4] Ensuring Python & pip on Robot PC ==="`,
+    `if command -v apt-get >/dev/null 2>&1; then`,
+    `    sudo apt-get update -y && sudo apt-get install -y python3-pip python3-serial 2>/dev/null || true`,
+    `fi`,
+    `echo "=== [2/4] Installing / Updating esptool ==="`,
+    `python3 -m pip install -U --user --break-system-packages esptool 2>/dev/null || \\`,
+    `python3 -m pip install -U --user esptool 2>/dev/null || \\`,
+    `sudo apt-get install -y python3-esptool 2>/dev/null || true`,
+    `echo "=== [3/4] Installing / Verifying picotool & udev rules ==="`,
+    `if command -v picotool >/dev/null 2>&1; then`,
+    `    echo "picotool already installed: $(which picotool)"`,
+    `else`,
+    `    sudo apt-get install -y picotool 2>/dev/null || {`,
+    `        echo "Installing picotool from pre-compiled binary..."`,
+    `        ARCH=$(uname -m)`,
+    `        if [ "$ARCH" = "x86_64" ]; then`,
+    `            curl -sSL "https://github.com/raspberrypi/picotool/releases/download/2.0.0/picotool-2.0.0-x86_64.tar.gz" -o /tmp/picotool.tar.gz 2>/dev/null && tar -xzf /tmp/picotool.tar.gz -C /tmp/ 2>/dev/null && sudo mv /tmp/picotool /usr/local/bin/ 2>/dev/null || true`,
+    `        elif [ "$ARCH" = "aarch64" ]; then`,
+    `            curl -sSL "https://github.com/raspberrypi/picotool/releases/download/2.0.0/picotool-2.0.0-aarch64.tar.gz" -o /tmp/picotool.tar.gz 2>/dev/null && tar -xzf /tmp/picotool.tar.gz -C /tmp/ 2>/dev/null && sudo mv /tmp/picotool /usr/local/bin/ 2>/dev/null || true`,
+    `        fi`,
+    `    }`,
+    `fi`,
+    `if [ -d /etc/udev/rules.d ] && [ ! -f /etc/udev/rules.d/99-pico.rules ]; then`,
+    `    echo 'ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="0003", MODE="666", GROUP="dialout"' | sudo tee /etc/udev/rules.d/99-pico.rules >/dev/null 2>&1 || true`,
+    `    echo 'ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000a", MODE="666", GROUP="dialout"' | sudo tee -a /etc/udev/rules.d/99-pico.rules >/dev/null 2>&1 || true`,
+    `    echo 'ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000f", MODE="666", GROUP="dialout"' | sudo tee -a /etc/udev/rules.d/99-pico.rules >/dev/null 2>&1 || true`,
+    `    sudo udevadm control --reload-rules 2>/dev/null || true`,
+    `fi`,
+    `echo "=== [4/4] Configuring serial port & dialout permissions ==="`,
+    `sudo usermod -a -G dialout $USER 2>/dev/null || true`,
+    `for _d in /dev/ttyUSB* /dev/ttyACM*; do [ -e "$_d" ] && sudo chmod a+rw "$_d" 2>/dev/null || true; done`,
+    `echo`,
+    `echo "================================================================"`,
+    `echo "✅ Robot PC minimal tools setup complete!"`,
+    `echo "   Python:   $(python3 --version 2>/dev/null || echo 'not found')"`,
+    `echo "   esptool:  $(which esptool.py 2>/dev/null || python3 -m esptool version 2>/dev/null || echo 'installed')"`,
+    `echo "   picotool: $(which picotool 2>/dev/null || echo 'installed')"`,
+    `echo "   docker:   $(which docker 2>/dev/null || echo 'not installed')"`,
+    `echo "================================================================"`,
+    `EOF_ROBOT_SETUP`
+  ].join("\n");
+
+  executeCommandInTerminal(remoteScript, `⚡ Setting Up Minimal Tools on Robot PC (${host})`).then(() => {
+    testRemoteConnection();
+  });
+}
+
+
+function initAutomationEventListeners() {
+  // Remote Target Mode Listeners
+    // Docker Anywhere Builder Listeners
+  const chkDocker = document.getElementById("chk-docker-builder");
+  const dockerDetails = document.getElementById("docker-builder-details");
+  if (chkDocker) {
+    chkDocker.addEventListener("change", () => {
+      if (dockerDetails) dockerDetails.style.display = chkDocker.checked ? "block" : "none";
+      updateAutomationPreviews();
+      if (chkDocker.checked) {
+        showToast("🐳 Docker Anywhere Builder enabled (compilation will run in container)");
+      }
+    });
+  }
+
+  const btnTestDocker = document.getElementById("btn-test-docker-builder");
+  if (btnTestDocker) {
+    btnTestDocker.addEventListener("click", async () => {
+      try {
+        const res = await fetch("/api/docker/status");
+        const d = await res.json();
+        if (d.has_docker) {
+          showToast(`✅ Docker Engine active! Builder Image: ${d.has_builder_image ? 'Found (linorobot2-builder:latest)' : 'Ready to pull/build'}`);
+        } else {
+          showToast("❌ Docker not found on host. Please install or start Docker Desktop.");
+        }
+      } catch (e) {
+        showToast("❌ Failed to contact Docker API: " + e.message);
+      }
+    });
+  }
+
+  // Seamless Remote Target Mode Listener (setting remote pc name/ip enables remote target mode)
+  const hostInput = document.getElementById("remote-ssh-host");
+  let hostDebounce = null;
+  if (hostInput) {
+    hostInput.addEventListener("input", () => {
+      clearTimeout(hostDebounce);
+      hostDebounce = setTimeout(() => {
+        testRemoteConnection();
+      }, 500);
+    });
+    hostInput.addEventListener("change", () => {
+      testRemoteConnection();
+    });
+  }
+
+  const btnRemoteProbe = document.getElementById("btn-remote-probe-ports");
+  if (btnRemoteProbe) btnRemoteProbe.addEventListener("click", probeRemotePorts);
+
+
+  // Re-detect OS Button
+  const btnRedetect = document.getElementById("btn-redetect-os");
+  if (btnRedetect) {
+    btnRedetect.addEventListener("click", () => {
+      detectClientOS();
+      showToast("🔍 OS re-detected!");
+    });
+  }
+
+  // Dynamic Automation Form Listeners
+  const autoInputs = [
+    "auto-os-select", "auto-env-select", "auto-arch-select",
+    "chk-install-pio", "chk-install-udev", "chk-install-dialout", "chk-install-buildtools",
+    "auto-ros-distro", "auto-ros-type", "chk-build-microros-agent",
+    "auto-git-branch", "auto-git-commit-msg",
+    "chk-merge-header", "chk-merge-pio-firmware", "chk-merge-urdf", "chk-auto-commit",
+    "auto-flash-target", "auto-flash-port"
+  ];
+
+  autoInputs.forEach(id => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.addEventListener("input", () => {
+        if (id === "auto-git-branch" || id === "auto-git-commit-msg" || id === "auto-flash-port") {
+          el.dataset.autoManaged = "false";
+        }
+        updateAutomationPreviews();
+      });
+      el.addEventListener("change", () => {
+        updateAutomationPreviews();
+      });
+    }
+  });
+
+  // Quick Copy Buttons
+  const btnCopyTool = document.getElementById("btn-copy-tool-cmd");
+  if (btnCopyTool) {
+    btnCopyTool.addEventListener("click", () => {
+      const cmd = document.getElementById("preview-tool-cmd")?.innerText || "";
+      navigator.clipboard.writeText(cmd).then(() => showToast("📋 Toolchain command copied!"));
+    });
+  }
+
+  const btnCopyRos = document.getElementById("btn-copy-ros-cmd");
+  if (btnCopyRos) {
+    btnCopyRos.addEventListener("click", () => {
+      const cmd = document.getElementById("preview-ros-cmd")?.innerText || "";
+      navigator.clipboard.writeText(cmd).then(() => showToast("📋 ROS 2 command copied!"));
+    });
+  }
+
+  const btnCopyMerge = document.getElementById("btn-copy-merge-cmd");
+  if (btnCopyMerge) {
+    btnCopyMerge.addEventListener("click", () => {
+      const cmd = document.getElementById("preview-merge-cmd")?.innerText || "";
+      navigator.clipboard.writeText(cmd).then(() => showToast("📋 Merge & Commit command copied!"));
+    });
+  }
+
+  const btnCopyBuild = document.getElementById("btn-copy-build-cmd");
+  if (btnCopyBuild) {
+    btnCopyBuild.addEventListener("click", () => {
+      const target = document.getElementById("auto-flash-target")?.value || "firmware";
+      const name = currentSpec.robot_name || "scout_pico2";
+      const cmd = `pio run -d ${target} -e ${name}`;
+      navigator.clipboard.writeText(cmd).then(() => showToast(`📋 Build command copied: ${cmd}`));
+    });
+  }
+
+  const btnCopyUpload = document.getElementById("btn-copy-upload-cmd");
+  if (btnCopyUpload) {
+    btnCopyUpload.addEventListener("click", () => {
+      const target = document.getElementById("auto-flash-target")?.value || "firmware";
+      const name = currentSpec.robot_name || "scout_pico2";
+      const port = document.getElementById("auto-flash-port")?.value.trim() || "/dev/ttyACM0";
+      const cmd = port === "AUTO" ? `pio run -d ${target} -e ${name} -t upload` : `pio run -d ${target} -e ${name} -t upload --upload-port ${port}`;
+      navigator.clipboard.writeText(cmd).then(() => showToast(`⚡ Upload command copied: ${cmd}`));
+    });
+  }
+
+  // Command Execution Buttons
+  const btnExecTool = document.getElementById("btn-exec-tool-cmd");
+  if (btnExecTool) {
+    btnExecTool.addEventListener("click", () => {
+      const cmd = document.getElementById("preview-tool-cmd")?.innerText || "";
+      executeCommandInTerminal(cmd, "Installing Build Toolchains & Permissions");
+    });
+  }
+
+  const btnExecRos = document.getElementById("btn-exec-ros-cmd");
+  if (btnExecRos) {
+    btnExecRos.addEventListener("click", () => {
+      const cmd = document.getElementById("preview-ros-cmd")?.innerText || "";
+      executeCommandInTerminal(cmd, "Installing ROS 2 Distribution & Packages");
+    });
+  }
+
+  // micro-ROS Agent Quick Actions
+  const btnCopyAgent = document.getElementById("btn-copy-agent-cmd");
+  if (btnCopyAgent) {
+    btnCopyAgent.addEventListener("click", () => {
+      const cmd = document.getElementById("preview-agent-cmd")?.innerText || "";
+      navigator.clipboard.writeText(cmd).then(() => showToast("📋 micro-ROS Agent command copied!"));
+    });
+  }
+
+  const btnExecAgentSerial = document.getElementById("btn-exec-agent-serial");
+  if (btnExecAgentSerial) {
+    btnExecAgentSerial.addEventListener("click", () => {
+      const opts = readAutomationOptions();
+      const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
+      const port = document.getElementById("auto-flash-port")?.value.trim() || "/dev/ttyUSB0";
+      const baud = firmwareBaud();
+      const cmd = microRosAgentCmd("serial", { distro, port, baud });
+      executeCommandInTerminal(cmd, `Launching Single Serial micro-ROS Agent (${port} @ ${baud}) on Robot SBC`);
+    });
+  }
+
+  const btnExecAgentMultiSerial = document.getElementById("btn-exec-agent-multiserial");
+  if (btnExecAgentMultiSerial) {
+    btnExecAgentMultiSerial.addEventListener("click", () => {
+      const opts = readAutomationOptions();
+      const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
+      const multiPorts = document.getElementById("auto-agent-multiserial-ports")?.value.trim() || "/dev/ttyACM0 /dev/ttyUSB0";
+      const baud = firmwareBaud();
+      const cmd = microRosAgentCmd("multiserial", { distro, ports: multiPorts, baud });
+      executeCommandInTerminal(cmd, `Launching Multi-Serial micro-ROS Agent (${multiPorts} @ ${baud}) on Robot SBC`);
+    });
+  }
+
+  const btnExecAgentUdp = document.getElementById("btn-exec-agent-udp");
+  if (btnExecAgentUdp) {
+    btnExecAgentUdp.addEventListener("click", () => {
+      const opts = readAutomationOptions();
+      const distro = opts.rosDistro !== "none" ? opts.rosDistro : "jazzy";
+      const cmd = microRosAgentCmd("udp", { distro, udpPort: 8888 });
+      executeCommandInTerminal(cmd, `Launching UDP WiFi micro-ROS Agent (:8888) on Robot SBC`);
+    });
+  }
+
+  document.getElementById("btn-check-agent-port")?.addEventListener("click", checkAndDisplayAgentPortStatus);
+  document.getElementById("btn-release-agent-port")?.addEventListener("click", releaseAgentPortFromUI);
+
+  // Flash Port & Multi-Serial Input Event Listeners
+  const flashPortElem = document.getElementById("auto-flash-port");
+  if (flashPortElem) {
+    flashPortElem.addEventListener("input", () => {
+      flashPortElem.dataset.autoManaged = "false";
+      updateAutomationPreviews();
+      saveWorkflowAndBoardSetup();
+      if (typeof checkAndDisplayAgentPortStatus === "function") checkAndDisplayAgentPortStatus();
+    });
+  }
+
+  const multiPortsElem = document.getElementById("auto-agent-multiserial-ports");
+  if (multiPortsElem) {
+    multiPortsElem.addEventListener("input", () => {
+      multiPortsElem.dataset.autoManaged = "false";
+      updateAutomationPreviews();
+      saveWorkflowAndBoardSetup();
+    });
+  }
+
+  const btnExecMerge = document.getElementById("btn-exec-merge-cmd");
+  if (btnExecMerge) {
+    btnExecMerge.addEventListener("click", () => {
+      const spec = currentSpec;
+      const opts = readAutomationOptions();
+      const name = spec.robot_name || "scout_pico2";
+      const cmd = getMergeAndCommitCmd(spec, opts);
+      executeCommandInTerminal(cmd, `Merging Headers & Committing '${name}'`);
+    });
+  }
+
+  const btnExecBuild = document.getElementById("btn-exec-build-cmd");
+  if (btnExecBuild) {
+    btnExecBuild.addEventListener("click", () => {
+      const target = document.getElementById("auto-flash-target")?.value || "firmware";
+      const name = currentSpec.robot_name || "scout_pico2";
+      const cmd = getDirectUploadOrBuildCmd(target, false);
+      executeCommandInTerminal(cmd, `Building ${target}/ for [env:${name}]`);
+    });
+  }
+
+  // Direct 1-Click Upload Buttons for test_sensors, test_motors, test_acc, adc_calibrate, firmware
+  const directTargets = [
+    { btnId: "btn-upload-sensors", target: "test_sensors", desc: "Sensor Diagnostics (I2C Scanner)" },
+    { btnId: "btn-upload-motors", target: "test_motors", desc: "Motor Diagnostics (CPR & Direction)" },
+    { btnId: "btn-upload-acc", target: "test_acc", desc: "Dynamic Acceleration Profiler" },
+    { btnId: "btn-upload-adc", target: "adc_calibrate", desc: "ESP32 ADC Calibration & Linearization" },
+    { btnId: "btn-upload-firmware", target: "firmware", desc: "Main Robot Firmware" }
+  ];
+
+  directTargets.forEach(({ btnId, target, desc }) => {
+    const btn = document.getElementById(btnId);
+    if (btn) {
+      btn.addEventListener("click", () => {
+        const targetSel = document.getElementById("auto-flash-target");
+        if (targetSel) targetSel.value = target;
+        updateAutomationPreviews();
+        const port = document.getElementById("auto-flash-port")?.value.trim() || (isESP32(currentSpec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
+        const cmd = withSerialMonitor(getDirectUploadOrBuildCmd(target, true), target, port);
+        executeCommandInTerminal(cmd, `⚡ Uploading ${desc} (${target}/ -> ${port})`);
+      });
+    }
+  });
+
+  const btnExecUpload = document.getElementById("btn-exec-upload-cmd");
+  if (btnExecUpload) {
+    btnExecUpload.addEventListener("click", () => {
+      const target = document.getElementById("auto-flash-target")?.value || "firmware";
+      const port = document.getElementById("auto-flash-port")?.value.trim() || (isESP32(currentSpec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
+      const cmd = withSerialMonitor(getDirectUploadOrBuildCmd(target, true), target, port);
+      executeCommandInTerminal(cmd, `Flashing Microcontroller (${target}/ -> ${port})`);
+    });
+  }
+
+  const btnExecDeploy = document.getElementById("btn-exec-deploy-script");
+  if (btnExecDeploy) {
+    btnExecDeploy.addEventListener("click", runFullDeploy);
+  }
+
+  // Header "Run Full Deploy" — jump to the Automation tab (so its terminal is
+  // visible) and kick off the same deploy. Keeps the first-run path short:
+  // set Robot Name -> "= name" -> Run Full Deploy.
+  const btnHeaderDeploy = document.getElementById("btn-header-deploy");
+  if (btnHeaderDeploy) {
+    btnHeaderDeploy.addEventListener("click", () => {
+      const tab = document.querySelector('[data-tab="tab-automation"]');
+      if (tab) tab.click();
+      runFullDeploy();
+    });
+  }
+
+  const btnCancelExec = document.getElementById("btn-cancel-exec");
+  if (btnCancelExec) {
+    btnCancelExec.addEventListener("click", cancelRunningExecution);
+  }
+
+  const btnDownloadDeploy = document.getElementById("btn-download-deploy-script");
+  if (btnDownloadDeploy) {
+    btnDownloadDeploy.addEventListener("click", () => {
+      const script = generateDeployScript(currentSpec, readAutomationOptions());
+      const filename = `deploy_${currentSpec.robot_name || "robot"}.sh`;
+      triggerDownload(filename, script, "application/x-sh");
+      showToast(`📥 ${filename} downloaded!`);
+    });
+  }
+
+  // Stream SBC Serial Monitor — raw-read the MCU's serial port on the Robot SBC
+  // and pipe its output into the console. Pure coreutils (stty + cat), no
+  // pyserial dependency; press ⏹️ Stop Process to disconnect.
+  const btnSbcMonitor = document.getElementById("btn-sbc-monitor");
+  if (btnSbcMonitor) {
+    btnSbcMonitor.addEventListener("click", () => {
+      const port = document.getElementById("auto-flash-port")?.value.trim() || (isESP32(currentSpec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
+      const baud = document.getElementById("serial-baud-select")?.value || "921600";
+      let cmd;
+      if (remoteConfig.targetMode === "remote") {
+        const host = remoteConfig.remoteHost;
+        const user = remoteConfig.remoteUser;
+        const sshPort = remoteConfig.remotePort || 22;
+        const sshKey = remoteConfig.remoteKey;
+        const sshOpts = `-o StrictHostKeyChecking=no -p ${sshPort}` + (sshKey ? ` -i ${sshKey}` : "");
+        cmd = [
+          `echo "Connecting to remote serial port on ${user}@${host}:${port} @ ${baud} baud..."`,
+          `ssh ${sshOpts} -t ${user}@${host} "stty -F '${port}' ${baud} raw -echo 2>/dev/null || true; exec cat '${port}'"`,
+        ].join("\n");
+        executeCommandInTerminal(cmd, `📡 Streaming Remote Serial (${user}@${host}:${port} @ ${baud} baud)`);
+      } else {
+        cmd = [
+          `if [ ! -e "${port}" ]; then echo "❌ ${port} not present — plug in / flash the board first."; exit 1; fi`,
+          `stty -F "${port}" ${baud} raw -echo 2>/dev/null || true`,
+          `echo "📡 Connected to ${port} @ ${baud} baud. Streaming live microcontroller output (test_sensors / telemetry). Press ⏹️ Stop Process to disconnect."`,
+          `exec cat "${port}"`,
+        ].join("\n");
+        executeCommandInTerminal(cmd, `📡 Streaming Serial Telemetry (${port} @ ${baud} baud)`);
+      }
+    });
+  }
+
+  // Web Serial Event Listeners (Client Browser USB)
+  const btnSerialConnect = document.getElementById("btn-serial-connect");
+  if (btnSerialConnect) {
+    btnSerialConnect.addEventListener("click", toggleWebSerialConnection);
+  }
+
+  // Web Serial is Chromium-only (and needs HTTPS or localhost). On a browser
+  // without it, grey out Connect / the command input / Send so it's clear the
+  // in-browser serial console isn't available here.
+  if (!("serial" in navigator)) {
+    const why = "In-browser serial needs Chrome / Edge / Opera over HTTPS or localhost";
+    [["btn-serial-connect", "serial-btn-text", "Serial N/A"],
+     ["btn-serial-send", null, null],
+     ["serial-input-text", null, null]].forEach(([id, txtId, txt]) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      el.disabled = true;
+      el.classList.add("is-disabled");
+      el.title = why;
+      if (txtId && txt) { const t = document.getElementById(txtId); if (t) t.textContent = txt; }
+      if (id === "serial-input-text") el.placeholder = why;
+    });
+  }
+
+
+  const btnSerialClear = document.getElementById("btn-serial-clear");
+  if (btnSerialClear) {
+    btnSerialClear.addEventListener("click", clearTerminalScreen);
+  }
+
+  const btnSerialSend = document.getElementById("btn-serial-send");
+  if (btnSerialSend) {
+    btnSerialSend.addEventListener("click", sendSerialCommand);
+  }
+
+  const inputSerialText = document.getElementById("serial-input-text");
+  if (inputSerialText) {
+    inputSerialText.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        sendSerialCommand();
+      }
+    });
+  }
+}
+
+
+// =============================================================================
+// Live Command Execution API & Subprocess Controller
+// =============================================================================
+
+let isRunnerOnline = false;
+let currentExecController = null;
+
+// Check Server Runner API Status (GET /api/status)
+async function checkServerRunnerStatus() {
+  const pill = document.getElementById("runner-status-pill");
+  const text = document.getElementById("runner-status-text");
+
+  try {
+    const res = await fetch("/api/status", { cache: "no-cache" });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.status === "ok" && data.exec_supported) {
+        isRunnerOnline = true;
+        if (pill) pill.className = "runner-status-pill pill-online";
+        const distroLabel = data.distro_name || data.distro_id || data.os;
+        if (text) text.innerText = `Robot SBC: Online [${data.node || "host"}] (${data.machine || ""})`;
+
+        syncRobotHostInfo(data);
+        if (data.host_ip) applyHostIpDefaults(data.host_ip);
+        return;
+      }
+    }
+  } catch (e) {
+    // Runner offline
+  }
+
+  isRunnerOnline = false;
+  if (pill) pill.className = "runner-status-pill pill-offline";
+  if (text) text.innerText = "Robot SBC: Disconnected / Copy Mode";
+}
+
+// Seed the network-target IP fields with this host's LAN address (until the
+// user overrides them). Agent / Syslog / LiDAR all point back at the machine
+// running the Web UI by default.
+function applyHostIpDefaults(hostIp) {
+  ["cfg-agent-ip", "cfg-syslog-ip", "cfg-lidar-ip"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (!el || el.dataset.autoManaged === "false") return;
+    if (!el.value || el.value === "192.168.1.100") { el.value = hostIp; el.dataset.autoManaged = "true"; }
+  });
+}
+
+// Bring the live terminal on-screen: activate the Automation tab (the console
+// lives there) and scroll the console card into view. Used by the ROS 2 topic
+// stream / Hz buttons, which sit further up the same tab, so their output
+// otherwise lands out of sight.
+function jumpToTerminal() {
+  const autoTab = document.querySelector('[data-tab="tab-automation"]');
+  if (autoTab && !autoTab.classList.contains("active")) autoTab.click();
+  const card = document.querySelector(".web-serial-console-card");
+  if (card) card.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+// Execute Command with Live Streaming Output in Terminal Console
+async function executeCommandInTerminal(command, title = "Executing Command") {
+  const terminalScreen = document.getElementById("serial-terminal-screen");
+  const btnCancel = document.getElementById("btn-cancel-exec");
+  // Only an adc_calibrate run streams the 4096-entry LUT; for every other
+  // command the per-line accumulate + substring scan below is dead weight that
+  // grows O(n) in memory and O(n^2) in CPU over a long build log.
+  const _isAdcCal = /\badc_calibrate\b/.test(command);
+  // Declared here (function scope), not inside the try{} below, because it's
+  // set from the SSE "done" handler (inside try) and read in finally{} —
+  // try/catch/finally each introduce their own block scope for let/const, so
+  // a let declared inside try is a ReferenceError from finally.
+  let _adcLutCommitPending = false;
+
+  // Surface the live terminal: the console lives on the Automation tab, so a
+  // command fired from any other tab (I2C auto-detect, ADC calibrate, branch
+  // switch, …) would otherwise stream out of sight. Activate that tab, then
+  // scroll its console into view. No-op when already there. Remember where the
+  // user was so we can hop back when the command finishes (see finally block).
+  const _origTabBtn = document.querySelector(".nav-tab.active");
+  const _origScrollY = window.scrollY;
+  const _autoTabBtn = document.querySelector('[data-tab="tab-automation"]');
+  let _switchedTab = false;
+  if (_autoTabBtn && !_autoTabBtn.classList.contains("active")) {
+    _autoTabBtn.click();
+    _switchedTab = true;
+  }
+  const _restoreOrigTab = () => {
+    // only if we moved them AND they're still sitting on Automation (didn't
+    // navigate away themselves mid-run)
+    if (_switchedTab && _origTabBtn && _autoTabBtn && _autoTabBtn.classList.contains("active")) {
+      _origTabBtn.click();
+      // ...and back to the scroll position they launched from (the trigger
+      // button is often at the top of its tab; scrollIntoView had jumped us
+      // down to the console).
+      window.scrollTo({ top: _origScrollY, behavior: "auto" });
+    }
+  };
+  const terminalEl = document.querySelector(".web-serial-console-card");
+  if (terminalEl) {
+    // block:"start" (not "nearest") — the console sits well below the flash /
+    // build buttons on the Automation tab, so "nearest" left it at the very
+    // bottom edge, mostly clipped.
+    terminalEl.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  if (!isRunnerOnline) {
+    await checkServerRunnerStatus();
+  }
+
+  if (!isRunnerOnline) {
+    appendTerminalLine(`\n=========================================================`, "dim");
+    appendTerminalLine(`🚀 ${title}`, "in");
+    appendTerminalLine(`=========================================================`, "dim");
+    appendTerminalLine(`$ ${command}`, "out");
+    appendTerminalLine(`ℹ️  Local Execution Runner is not active on this host/port.`, "dim");
+    appendTerminalLine(`👉 Run 'python3 server.py' in tools/robot_config_engine/web to enable 1-click execution!`, "in");
+    appendTerminalLine(`📋 Command copied to clipboard for manual terminal execution.`, "dim");
+
+    navigator.clipboard.writeText(command).then(() => {
+      showToast("📋 Command copied! (Start 'python3 server.py' for 1-click execution)");
+    });
+    _restoreOrigTab();
+    return;
+  }
+
+  appendTerminalLine(`\n=========================================================`, "dim");
+  appendTerminalLine(`🚀 ${title}`, "in");
+  appendTerminalLine(`$ ${command}`, "dim");
+  appendTerminalLine(`=========================================================`, "dim");
+
+  if (btnCancel) btnCancel.style.display = "inline-flex";
+
+  // Update Hero Deploy Badge with Live Phase & Timer
+  const heroBadge = document.getElementById("hero-deploy-badge");
+  const heroStatusText = document.getElementById("hero-deploy-status-text");
+  const heroTimer = document.getElementById("hero-deploy-timer");
+  let deployStartTime = Date.now();
+  let deployTimerInterval = null;
+
+  // Generic "task running" indicator for every executeCommandInTerminal call
+  const execPill = document.getElementById("exec-progress-pill");
+  const execText = document.getElementById("exec-progress-text");
+  const execTimer = document.getElementById("exec-progress-timer");
+  const execTitle = title.replace(/^[^\w]+\s*/, "");
+  let execTimerInterval = null;
+  const setExecPhase = (p) => { if (execText) execText.textContent = p ? `${execTitle} · ${p}` : execTitle; };
+  if (execPill) {
+    execPill.style.display = "inline-flex";
+    execPill.className = "runner-status-pill pill-checking";
+    setExecPhase("");
+    if (execTimer) {
+      execTimer.textContent = "(0s)";
+      execTimerInterval = setInterval(() => {
+        const s = Math.floor((Date.now() - deployStartTime) / 1000);
+        execTimer.textContent = s < 60 ? `(${s}s)` : `(${Math.floor(s/60)}:${String(s%60).padStart(2,"0")})`;
+      }, 1000);
+    }
+  }
+
+  if (heroBadge && title.includes("Full Deploy")) {
+    heroBadge.className = "deploy-hero-badge deploying";
+    if (heroStatusText) heroStatusText.innerText = "Deploying...";
+    if (heroTimer) {
+      heroTimer.style.display = "inline";
+      heroTimer.innerText = "(0s)";
+      deployTimerInterval = setInterval(() => {
+        const sec = Math.floor((Date.now() - deployStartTime) / 1000);
+        heroTimer.innerText = `(${sec}s)`;
+      }, 1000);
+    }
+  }
+
+
+  try {
+    currentExecController = new AbortController();
+    const response = await fetch("/api/exec", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ command: command }),
+      signal: currentExecController.signal
+    });
+
+    if (!response.ok) {
+      let detail = "";
+      try { detail = (await response.json())?.error || ""; } catch (_) {}
+      appendTerminalLine(`❌ ${detail || `Server error: HTTP ${response.status}`}`, "err");
+      if (detail) showToast(`⚠️ ${detail}`);
+      if (btnCancel) btnCancel.style.display = "none";
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder("utf-8");
+
+    let buffer = "";
+    let adcStreamBuffer = "";
+    let _adcLutFreshlyCaptured = false;   // set once THIS run's sweep lands a LUT
+    // _adcLutCommitPending is declared at function scope above (see comment there).
+    let _sseDone = false;   // set on the `event: done` line — the socket may be
+                            // kept alive, so we can't rely on the stream closing
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (value) {
+        buffer += decoder.decode(value, { stream: true });
+        const events = buffer.split("\n\n");
+        buffer = events.pop(); // Keep incomplete event
+
+        for (const evt of events) {
+          if (!evt.trim()) continue;
+          const lines = evt.split("\n");
+          let eventType = "output";
+          let dataStr = "";
+
+          for (const line of lines) {
+            if (line.startsWith("event: ")) eventType = line.substring(7).trim();
+            if (line.startsWith("data: ")) dataStr = line.substring(6).trim();
+          }
+
+          if (dataStr) {
+            try {
+              const payload = JSON.parse(dataStr);
+              if ((eventType === "output" || eventType === "log" || eventType === "message") && (payload.line !== undefined || payload.text !== undefined || payload.data !== undefined)) {
+                const textLine = payload.line !== undefined ? payload.line : (payload.text !== undefined ? payload.text : payload.data);
+                appendTerminalLine(textLine, "out");
+
+                if (execPill) {
+                  const L = String(textLine);
+                  const step = L.match(/Step (\d)\/9/);
+                  const phaseBanner = L.match(/^=== \[\d\/\d\]\s+(.+?)\s+=+\s*$/);
+                  if (step) setExecPhase(`step ${step[1]}/9`);
+                  else if (phaseBanner) setExecPhase(phaseBanner[1].replace(/\s*\(.*$/, "").toLowerCase());
+                  else if (/PlatformIO not found|installing build toolchain|get-platformio|Installing PlatformIO Core/.test(L)) setExecPhase("installing build tools");
+                  else if (/apt-get|Installing |Reading package lists|Unpacking |Setting up /.test(L)) setExecPhase("installing packages");
+                  else if (/Cloning into|Receiving objects|Resolving deltas/.test(L)) setExecPhase("cloning sources");
+                  else if (/colcon build|Starting >>>|Finished <<</.test(L)) setExecPhase("building agent workspace");
+                  else if (/Compiling |Archiving |Indexing |Building \.pio/.test(L)) setExecPhase("compiling firmware");
+                  else if (/Linking \.pio|Retrieving maximum program size|Checking size/.test(L)) setExecPhase("linking");
+                  else if (/esptool|Writing at |Wrote \d+ bytes|Hash of data verified|Uploading \.pio|Hard resetting|picotool/.test(L)) setExecPhase("flashing MCU");
+                  else if (/Scanning I2C bus|Identified Hardware Matrix|Device ACK received/.test(L)) setExecPhase("scanning I2C bus");
+                  else if (/\[I2C_JSON\]/.test(L)) setExecPhase("sensors detected");
+                  else if (/micro_ros_agent|session established|Waiting for session handshake/.test(L)) setExecPhase("starting micro-ROS agent");
+                  else if (/Active ROS 2 Topics|ros2 topic list/.test(L)) setExecPhase("discovering ROS 2 topics");
+                  else if (/Test Linearity|Generating LUT|ADC_LUT/.test(L)) setExecPhase("calibrating ADC");
+                }
+
+                // Parse deployment phase for Hero Badge
+                if (heroStatusText && title.includes("Full Deploy")) {
+                  if (textLine.includes("Step 1")) heroStatusText.innerText = "1/9: Checking Tools";
+                  else if (textLine.includes("Step 2")) heroStatusText.innerText = "2/9: Verifying ROS 2";
+                  else if (textLine.includes("Step 4")) heroStatusText.innerText = "4/9: Ingesting C++ Header";
+                  else if (textLine.includes("Step 6")) heroStatusText.innerText = "6/9: Ingesting URDF";
+                  else if (textLine.includes("Step 8") || textLine.includes("Compiling")) heroStatusText.innerText = "8/9: Compiling Firmware (Please Wait...)";
+                  else if (textLine.includes("Uploading firmware") || textLine.includes("Writing at")) heroStatusText.innerText = "8/9: Flashing Microcontroller...";
+                  else if (textLine.includes("Step 9") || textLine.includes("Starting micro-ROS agent")) heroStatusText.innerText = "9/9: Launching Agent & Topics...";
+                  else if (textLine.includes("Deployment SUCCEEDED") || textLine.includes("ACTIVE TOPICS")) {
+                    heroBadge.className = "deploy-hero-badge succeeded";
+                    heroStatusText.innerText = "✅ Deployed (@ 50Hz)";
+                    if (deployTimerInterval) clearInterval(deployTimerInterval);
+                  }
+                }
+
+
+                // Live ADC Calibration Stream Parser
+                if (_isAdcCal && (textLine.includes("Test Linearity") || textLine.includes("Generating LUT") || textLine.includes("ADC_LUT"))) {
+                  const statusText = document.getElementById("adc-status-text");
+                  if (statusText) {
+                    statusText.innerText = String(textLine).trim();
+                    statusText.style.color = "#38bdf8";
+                  }
+                }
+
+                
+                // Live I2C Sensor Detection JSON Parser
+                if (textLine.includes("[I2C_JSON]")) {
+                  try {
+                    const jsonStr = textLine.substring(textLine.indexOf("[I2C_JSON]") + 10).trim();
+                    const i2cData = JSON.parse(jsonStr);
+                    if (i2cData.status === "ok") {
+                      handleI2cAutoDetectedSensors(i2cData);
+                    }
+                  } catch (err) {
+                    console.error("Failed to parse I2C_JSON:", err);
+                  }
+                }
+
+                if (_isAdcCal) adcStreamBuffer += textLine + "\n";
+                if (_isAdcCal && adcStreamBuffer.includes("ADC_LUT[4096]") && adcStreamBuffer.split("ADC_LUT[4096]").pop().includes("};")) {
+                  try {
+                    // Anchor on the LUT declaration so earlier build-log braces /
+                    // numbers can't leak into the parsed array.
+                    const tail = adcStreamBuffer.substring(adcStreamBuffer.indexOf("ADC_LUT[4096]"));
+                    const startIdx = tail.indexOf("{");
+                    const endIdx = tail.indexOf("};");
+                    if (startIdx !== -1 && endIdx > startIdx) {
+                      const inner = tail.substring(startIdx + 1, endIdx);
+                      const parsedPoints = inner.split(/[\s,]+/).map(s => parseInt(s.trim(), 10)).filter(n => !isNaN(n));
+                      if (parsedPoints.length >= 4000) {
+                        currentAdcLut = parsedPoints.slice(0, 4096);
+                        while (currentAdcLut.length < 4096) currentAdcLut.push(4095);
+                        renderAdcChart(currentRawAdcCurve || currentAdcLut, currentAdcLut, null);
+                        const codeDisplay = document.getElementById("adc-lut-code-display");
+                        if (codeDisplay) codeDisplay.innerText = formatAdcLutArray(currentAdcLut);
+                        // "Run Hardware Calibration" is the whole pipeline now:
+                        // sweep -> capture -> chart -> merge into the live spec.
+                        // No separate "Merge LUT Table" click needed.
+                        mergeAdcLutIntoConfig();
+                        _adcLutFreshlyCaptured = true;
+                        const statusText = document.getElementById("adc-status-text");
+                        if (statusText) {
+                          statusText.innerText = "🎉 Hardware ADC Calibration Complete! 4096 points captured & merged.";
+                          statusText.style.color = "var(--success)";
+                        }
+                        showToast("🎉 Hardware ADC Calibration Complete! LUT captured & merged.");
+                      }
+                    }
+                  } catch (e) {
+                    console.error("ADC parse error:", e);
+                  }
+                }
+              } else if (eventType === "done") {
+                const exitCode = payload.code !== undefined ? payload.code : (payload.exit_code !== undefined ? payload.exit_code : 0);
+                if (execPill) {
+                  if (execTimerInterval) { clearInterval(execTimerInterval); execTimerInterval = null; }
+                  if (execText) execText.textContent = exitCode === 0 ? `${execTitle} · done ✓` : `${execTitle} · exit ${exitCode} ✗`;
+                  execPill.className = exitCode === 0 ? "runner-status-pill pill-online" : "runner-status-pill pill-offline";
+                  setTimeout(() => { execPill.style.display = "none"; execPill.className = "runner-status-pill pill-checking"; }, 2500);
+                }
+                if (exitCode === 0) {
+                  appendTerminalLine(`\n✅ [SUCCESS] Command finished with exit code 0!`, "out");
+                  showToast("✅ Command executed successfully!");
+                  // The header written at the START of this run predates the
+                  // LUT (the sweep hadn't run yet), so it's still on disk
+                  // without it. Now that the port is free again, write it for
+                  // real — search-and-merge like every other config write —
+                  // and commit it, so the calibration is durably saved without
+                  // a second manual click.
+                  if (_isAdcCal && _adcLutFreshlyCaptured) _adcLutCommitPending = true;
+                } else {
+                  appendTerminalLine(`\n❌ [FAILED] Command exited with code ${exitCode}`, "err");
+                  showToast(`⚠️ Command exited with code ${exitCode}`);
+                }
+                _sseDone = true;   // stop reading; hop back to the launching tab now
+                _restoreOrigTab();
+              } else if (eventType === "error") {
+                appendTerminalLine(`❌ [ERROR] ${payload.error}`, "err");
+              }
+            } catch (e) {
+              appendTerminalLine(dataStr, "out");
+            }
+          }
+        }
+      }
+      if (_sseDone) { try { await reader.cancel(); } catch (_) {} break; }
+    }
+  } catch (err) {
+    if (err.name === "AbortError") {
+      appendTerminalLine(`\n⏹️ Process aborted by user.`, "dim");
+      showToast("⏹️ Process stopped.");
+    } else {
+      appendTerminalLine(`\n❌ Execution failed: ${err.message}`, "err");
+    }
+  } finally {
+    if (btnCancel) btnCancel.style.display = "none";
+    if (typeof execTimerInterval !== "undefined" && execTimerInterval) clearInterval(execTimerInterval);
+    // The hero-badge timer is otherwise only stopped on the "Deployment
+    // SUCCEEDED" line, so a failed / aborted / disconnected deploy leaks a
+    // 1 Hz setInterval (and stacks one more on every retry).
+    if (typeof deployTimerInterval !== "undefined" && deployTimerInterval) {
+      clearInterval(deployTimerInterval);
+      deployTimerInterval = null;
+      const _hb = document.getElementById("hero-deploy-badge");
+      if (_hb && _hb.className.indexOf("succeeded") === -1) {
+        _hb.className = "deploy-hero-badge";
+        const _ht = document.getElementById("hero-deploy-status-text");
+        if (_ht) _ht.innerText = "Idle";
+        const _htm = document.getElementById("hero-deploy-timer");
+        if (_htm) _htm.style.display = "none";
+      }
+    }
+    const _ep = document.getElementById("exec-progress-pill");
+    if (_ep && _ep.className.indexOf("pill-online") === -1 && _ep.className.indexOf("pill-offline") === -1) {
+      _ep.style.display = "none";
+    }
+    currentExecController = null;
+    // Action done — return the user to the tab they launched it from.
+    _restoreOrigTab();
+    // Fire the deferred LUT sync+commit now that the port/exec slot is free
+    // (never from inside the SSE handling above — that would race the
+    // server's single-flight /api/exec against this very command).
+    if (_adcLutCommitPending) {
+      const _name = currentSpec.robot_name || "robot";
+      executeCommandInTerminal(
+        getMergeAndCommitCmd(currentSpec, readAutomationOptions()),
+        `🔀 Auto-merging & committing calibrated ADC_LUT for '${_name}'`
+      );
+    }
+  }
+}
+
+// Abort running process via POST /api/kill
+async function cancelRunningExecution() {
+  if (currentExecController) {
+    currentExecController.abort();
+  }
+  try {
+    await fetch("/api/kill", { method: "POST" });
+  } catch (e) {}
+}
+
+// Formats 4096-entry ADC LUT into clean C++ header syntax (16 items per row)
+function formatAdcLutArray(lutData) {
+  if (typeof lutData === "string") return lutData;
+  if (!Array.isArray(lutData) || lutData.length === 0) {
+    return `const int16_t ADC_LUT[4096] = { /* insert adc_calibrate data here */ };`;
+  }
+  const rows = [];
+  for (let i = 0; i < lutData.length; i += 16) {
+    const slice = lutData.slice(i, i + 16);
+    rows.push("    " + slice.map(n => Math.round(n)).join(", ") + (i + 16 < lutData.length ? "," : ""));
+  }
+  return `const int16_t ADC_LUT[4096] = {\n${rows.join("\n")}\n};`;
+}
+
+// ==============================================================================
+// 🔋 ESP32 ADC Calibration Studio & LUT Linearizer
+// ==============================================================================
+let currentAdcLut = null;
+let currentRawAdcCurve = null;
+
+function initAdcCalibrationStudio() {
+  const canvas = document.getElementById("adc-chart-canvas");
+  const tooltip = document.getElementById("adc-chart-tooltip");
+  const btnRun = document.getElementById("btn-adc-run-cal");
+  const btnCopy = document.getElementById("btn-copy-lut-code");
+
+  if (!canvas) return;
+
+  // Theoretical/empirical placeholder curve so the chart isn't blank before
+  // the first hardware run. "Run Hardware Calibration" is now the only
+  // action in the studio — it sweeps, captures, charts, merges into the
+  // live spec, and syncs + commits the result to disk in one click; there
+  // used to be separate "Generate Model LUT" and "Merge LUT Table" buttons
+  // for those steps.
+  generateAdcModelLut(false);
+
+  if (btnRun) {
+    btnRun.addEventListener("click", () => {
+      runHardwareAdcCalibration();
+    });
+  }
+
+  if (btnCopy) {
+    btnCopy.addEventListener("click", () => {
+      if (currentAdcLut) {
+        const code = formatAdcLutArray(currentAdcLut);
+        navigator.clipboard.writeText(code).then(() => {
+          showToast("📋 ADC_LUT[4096] array copied to clipboard!");
+        });
+      } else {
+        showToast("⚠️ No LUT table generated yet.");
+      }
+    });
+  }
+
+  // Interactive Hover / Tooltip on Canvas
+  canvas.addEventListener("mousemove", (e) => {
+    if (!currentRawAdcCurve || !currentAdcLut) return;
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const paddingLeft = 45;
+    const paddingRight = 15;
+    const chartWidth = rect.width - paddingLeft - paddingRight;
+
+    if (x >= paddingLeft && x <= paddingLeft + chartWidth) {
+      const ratio = (x - paddingLeft) / chartWidth;
+      const index = Math.min(4095, Math.max(0, Math.round(ratio * 4095)));
+      renderAdcChart(currentRawAdcCurve, currentAdcLut, index);
+
+      if (tooltip) {
+        const rawVal = currentRawAdcCurve[index];
+        const lutVal = currentAdcLut[index];
+        const vInput = (index * 3.3 / 4095).toFixed(3);
+        const vRaw = (rawVal * 3.3 / 4095).toFixed(3);
+        const vCal = (lutVal * 3.3 / 4095).toFixed(3);
+        const delta = lutVal - rawVal;
+
+        tooltip.style.display = "block";
+        tooltip.style.left = `${Math.min(rect.width - 180, Math.max(10, x - 70))}px`;
+        tooltip.style.top = `15px`;
+        tooltip.innerHTML = `
+          <div><strong>Input: ${index}</strong> (${vInput}V)</div>
+          <div style="color:#f43f5e;">Raw ADC: ${Math.round(rawVal)} (${vRaw}V)</div>
+          <div style="color:#10b981;">Linearized: ${Math.round(lutVal)} (${vCal}V)</div>
+          <div style="color:#a5b4fc;">Offset Δ: ${delta >= 0 ? "+" : ""}${Math.round(delta)} counts</div>
+        `;
+      }
+    } else {
+      if (tooltip) tooltip.style.display = "none";
+      renderAdcChart(currentRawAdcCurve, currentAdcLut, null);
+    }
+  });
+
+  canvas.addEventListener("mouseleave", () => {
+    if (tooltip) tooltip.style.display = "none";
+    if (currentRawAdcCurve && currentAdcLut) {
+      renderAdcChart(currentRawAdcCurve, currentAdcLut, null);
+    }
+  });
+
+  // Handle responsive window resize for canvas
+  window.addEventListener("resize", () => {
+    if (currentRawAdcCurve && currentAdcLut) {
+      renderAdcChart(currentRawAdcCurve, currentAdcLut, null);
+    }
+  });
+}
+
+// Generate Mathematical / Empirical ESP32 ADC Transfer Function & Inverted LUT
+function generateAdcModelLut(showToastMsg = true) {
+  const rawCurve = new Float32Array(4096);
+  const lut = new Int16Array(4096);
+
+  // ESP32 Non-linear ADC Simulation:
+  // 1. Deadband near 0V: 0 to ~140mV outputs 0
+  // 2. Non-linear knee at low voltage (140mV - 500mV)
+  // 3. Linear response from 500mV to ~2900mV
+  // 4. Saturation compression from 2900mV to 3300mV (maxes out around 3.15V)
+  for (let i = 0; i < 4096; i++) {
+    const v = i * (3.3 / 4095.0); // True Input Voltage (0 to 3.3V)
+    let rawAdc = 0;
+
+    if (v < 0.14) {
+      rawAdc = 0;
+    } else if (v < 0.50) {
+      const t = (v - 0.14) / (0.50 - 0.14);
+      rawAdc = 620 * (t * t * 0.7 + t * 0.3);
+    } else if (v <= 2.90) {
+      const t = (v - 0.50) / (2.90 - 0.50);
+      rawAdc = 620 + t * (3780 - 620);
+    } else {
+      const t = Math.min(1.0, (v - 2.90) / (3.15 - 2.90));
+      rawAdc = 3780 + Math.sin(t * Math.PI / 2) * (4095 - 3780);
+    }
+    rawCurve[i] = Math.min(4095, Math.max(0, rawAdc));
+  }
+
+  // Generate Inverted Lookup Table (LUT) to Linearize ADC readings:
+  // For each ADC reading y (0..4095), find input x such that rawCurve[x] == y
+  for (let adc = 0; adc < 4096; adc++) {
+    if (adc <= 0) {
+      lut[0] = 0;
+      continue;
+    }
+    if (adc >= 4095) {
+      lut[4095] = 4095;
+      continue;
+    }
+    let low = 0;
+    let high = 4095;
+    while (low < high) {
+      const mid = (low + high) >> 1;
+      if (rawCurve[mid] < adc) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    let corrected = low;
+    if (low > 0 && low < 4095) {
+      const y0 = rawCurve[low - 1];
+      const y1 = rawCurve[low];
+      if (y1 > y0) {
+        corrected = (low - 1) + (adc - y0) / (y1 - y0);
+      }
+    }
+    lut[adc] = Math.min(4095, Math.max(0, Math.round(corrected)));
+  }
+
+  currentRawAdcCurve = Array.from(rawCurve);
+  currentAdcLut = Array.from(lut);
+
+  // Update UI Elements
+  renderAdcChart(currentRawAdcCurve, currentAdcLut, null);
+
+  const codeDisplay = document.getElementById("adc-lut-code-display");
+  if (codeDisplay) {
+    codeDisplay.innerText = formatAdcLutArray(currentAdcLut);
+  }
+
+  const statusText = document.getElementById("adc-status-text");
+  if (statusText) {
+    statusText.innerText = "Placeholder model curve — click Run Hardware Calibration for a real, merged LUT.";
+    statusText.style.color = "var(--text-muted)";
+  }
+
+  if (showToastMsg) {
+    showToast("🧪 Model ADC LUT generated! Graph and 4096-point table ready.");
+  }
+}
+
+// Interactive High-Performance Canvas Renderer
+function renderAdcChart(rawData, lutData, hoveredIndex = null) {
+  const canvas = document.getElementById("adc-chart-canvas");
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  const dpr = window.devicePixelRatio || 1;
+  const rect = canvas.getBoundingClientRect();
+
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  ctx.scale(dpr, dpr);
+
+  const w = rect.width;
+  const h = rect.height;
+  const padLeft = 45;
+  const padBottom = 30;
+  const padTop = 15;
+  const padRight = 15;
+  const plotW = w - padLeft - padRight;
+  const plotH = h - padTop - padBottom;
+
+  // Clear background
+  ctx.fillStyle = "#090d16";
+  ctx.fillRect(0, 0, w, h);
+
+  // Draw Grid Lines & Axis Labels
+  ctx.lineWidth = 1;
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.07)";
+  ctx.fillStyle = "#64748b";
+  ctx.font = "10px Inter, -apple-system, sans-serif";
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+
+  const numGrid = 4;
+  for (let i = 0; i <= numGrid; i++) {
+    const yVal = (4095 / numGrid) * i;
+    const yPos = padTop + plotH - (i / numGrid) * plotH;
+    const volts = (yVal * 3.3 / 4095).toFixed(1);
+
+    ctx.beginPath();
+    ctx.moveTo(padLeft, yPos);
+    ctx.lineTo(padLeft + plotW, yPos);
+    ctx.stroke();
+
+    ctx.fillText(`${volts}V`, padLeft - 6, yPos);
+  }
+
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  for (let i = 0; i <= numGrid; i++) {
+    const xVal = (4095 / numGrid) * i;
+    const xPos = padLeft + (i / numGrid) * plotW;
+    const volts = (xVal * 3.3 / 4095).toFixed(1);
+
+    ctx.beginPath();
+    ctx.moveTo(xPos, padTop);
+    ctx.lineTo(xPos, padTop + plotH);
+    ctx.stroke();
+
+    ctx.fillText(`${volts}V`, xPos, padTop + plotH + 6);
+  }
+
+  // 1. Plot Ideal Reference Line (Cyan Dashed)
+  ctx.save();
+  ctx.strokeStyle = "rgba(56, 189, 248, 0.4)";
+  ctx.lineWidth = 1.5;
+  ctx.setLineDash([4, 4]);
+  ctx.beginPath();
+  ctx.moveTo(padLeft, padTop + plotH);
+  ctx.lineTo(padLeft + plotW, padTop);
+  ctx.stroke();
+  ctx.restore();
+
+  // 2. Plot Raw Non-Linear Curve (Rose/Coral)
+  if (rawData && rawData.length > 0) {
+    ctx.save();
+    ctx.strokeStyle = "#f43f5e";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    const step = Math.max(1, Math.floor(rawData.length / plotW));
+    for (let i = 0; i < rawData.length; i += step) {
+      const xPos = padLeft + (i / 4095) * plotW;
+      const yPos = padTop + plotH - (rawData[i] / 4095) * plotH;
+      if (i === 0) ctx.moveTo(xPos, yPos);
+      else ctx.lineTo(xPos, yPos);
+    }
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // 3. Plot Calibrated Output Curve (Neon Emerald Green)
+  if (lutData && rawData && lutData.length > 0) {
+    ctx.save();
+    ctx.strokeStyle = "#10b981";
+    ctx.lineWidth = 2.5;
+    ctx.beginPath();
+    const step = Math.max(1, Math.floor(lutData.length / plotW));
+    for (let i = 0; i < lutData.length; i += step) {
+      const rawVal = Math.round(rawData[i]);
+      const calVal = (rawVal >= 0 && rawVal < lutData.length) ? lutData[rawVal] : rawVal;
+      const xPos = padLeft + (i / 4095) * plotW;
+      const yPos = padTop + plotH - (calVal / 4095) * plotH;
+      if (i === 0) ctx.moveTo(xPos, yPos);
+      else ctx.lineTo(xPos, yPos);
+    }
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // 4. Draw Crosshair & Indicators on Hover
+  if (hoveredIndex !== null && hoveredIndex >= 0 && hoveredIndex < 4096) {
+    const xPos = padLeft + (hoveredIndex / 4095) * plotW;
+    const rawVal = rawData ? rawData[hoveredIndex] : hoveredIndex;
+    const rawYPos = padTop + plotH - (rawVal / 4095) * plotH;
+    const calVal = (lutData && Math.round(rawVal) < lutData.length) ? lutData[Math.round(rawVal)] : hoveredIndex;
+    const calYPos = padTop + plotH - (calVal / 4095) * plotH;
+
+    // Vertical Crosshair
+    ctx.strokeStyle = "rgba(165, 180, 252, 0.5)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(xPos, padTop);
+    ctx.lineTo(xPos, padTop + plotH);
+    ctx.stroke();
+
+    // Raw Point Dot
+    ctx.fillStyle = "#f43f5e";
+    ctx.beginPath();
+    ctx.arc(xPos, rawYPos, 4.5, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Calibrated Point Dot
+    ctx.fillStyle = "#10b981";
+    ctx.beginPath();
+    ctx.arc(xPos, calYPos, 5, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = "#ffffff";
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+  }
+}
+
+// Live Hardware ADC Calibration Runner
+function runHardwareAdcCalibration() {
+  const spec = currentSpec;
+  if (!mcuHasDac((spec.mcu || "").toUpperCase())) {
+    showToast("⚠️ ADC calibration needs a hardware DAC — only ESP32 / ESP32-S2.");
+    return;
+  }
+  const port = document.getElementById("auto-flash-port")?.value.trim() || (isESP32(spec.mcu) ? "/dev/ttyUSB0" : "/dev/ttyACM0");
+  const baud = spec.baudrate || spec.telemetry?.baudrate || ((spec.mcu || "").toUpperCase() === "GENDRV" ? 1500000 : 921600);
+  const uploadCmd = getDirectUploadOrBuildCmd("adc_calibrate", true);
+
+  // adc_calibrate sweeps the DAC, prints `const int16_t ADC_LUT[4096] = {...};`
+  // once (~1-3 min after reset), then idles. The upload command alone never
+  // reads the port back, so append a short serial reader — the parser in
+  // executeCommandInTerminal() picks the LUT block out of the stream. Staged to
+  // a file (quoted heredoc) to sidestep python -c newline/quote escaping.
+  const monScript = [
+    `cat > /tmp/lr_adc_monitor.py << 'EOF_ADC_MON'`,
+    `import serial, sys, time`,
+    `s = serial.Serial('${port}', ${baud}, timeout=2)`,
+    `time.sleep(0.5); t = time.time(); seen = False`,
+    `while time.time() - t < 360:`,
+    `    l = s.readline().decode('utf-8', errors='ignore').rstrip()`,
+    `    if not l: continue`,
+    `    print(l); sys.stdout.flush()`,
+    `    if 'ADC_LUT[4096]' in l: seen = True`,
+    `    if seen and l.strip().endswith('};'): break`,
+    `s.close()`,
+    `EOF_ADC_MON`,
+    `~/.platformio/penv/bin/python -c 'import serial' 2>/dev/null || ~/.platformio/penv/bin/python -m pip install -q pyserial 2>/dev/null || true`,
+    `~/.platformio/penv/bin/python /tmp/lr_adc_monitor.py`
+  ].join("\n");
+  const cmd = `${uploadCmd}\necho "--- adc_calibrate flashed; capturing LUT over serial (${port} @ ${baud} baud, up to 6 min) ---"\n${monScript}`;
+
+  const statusText = document.getElementById("adc-status-text");
+  if (statusText) {
+    statusText.innerText = `Compiling & Uploading adc_calibrate to ${port}...`;
+    statusText.style.color = "#38bdf8";
+  }
+
+  executeCommandInTerminal(cmd, `⚡ Uploading & Running ADC Calibration (${port})`);
+}
+
+// Merge Generated ADC LUT Table into Robot Configuration
+function mergeAdcLutIntoConfig() {
+  if (!currentAdcLut || currentAdcLut.length === 0) {
+    showToast("⚠️ No LUT table generated to merge.");
+    return;
+  }
+
+  currentSpec.adc_lut = Array.from(currentAdcLut);
+  if (!currentSpec.sensors) currentSpec.sensors = {};
+  currentSpec.sensors.battery_monitor = "ADC_DIVIDER";
+  currentSpec.sensors.adc_lut = Array.from(currentAdcLut);
+
+  // Re-generate C++ Headers and update previews
+  updateAutomationPreviews();
+  renderActiveCode();
+
+  const name = currentSpec.robot_name || "robot";
+  showToast(`✅ ADC LUT merged into the '${name}' configuration — writing it to config/custom/${name}_config.h next.`);
+
+  const statusText = document.getElementById("adc-status-text");
+  if (statusText) {
+    statusText.innerText = `✅ ADC_LUT merged into the live spec — syncing to config/custom/${name}_config.h...`;
+    statusText.style.color = "var(--success)";
+  }
+}
+
+
+
+// Global Existing Config Base State
+let baseConfigSpec = null;
+let existingConfigsList = [];
+
+// Fetch available existing configs from server
+async function loadExistingConfigsList() {
+  const sel = document.getElementById('existing-config-select');
+  if (!sel) return;
+  try {
+    const res = await fetch('/api/configs');
+    if (!res.ok) return;
+    const data = await res.json();
+    existingConfigsList = data.configs || [];
+    sel.innerHTML = '<option value="">Select Existing Config...</option>';
+    existingConfigsList.forEach(c => {
+      const opt = document.createElement('option');
+      opt.value = c.filename;
+      opt.innerText = `${c.filename} (${c.mcu} | ${c.kinematics})`;
+      sel.appendChild(opt);
+    });
+  } catch (e) {
+    console.log('Configs API not available:', e);
+  }
+}
+
+// Load selected existing configuration into form for modification
+async function loadExistingConfig(filename) {
+  if (!filename) return;
+  const cfg = existingConfigsList.find(c => c.filename === filename);
+  if (!cfg) return;
+  try {
+    const res = await fetch('/api/parse', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: cfg.content, is_json: false })
+    });
+    const data = await res.json();
+    if (data.status === 'ok' && data.spec) {
+      baseConfigSpec = JSON.parse(JSON.stringify(data.spec));
+      currentSpec = data.spec;
+      populateFormFromSpec(currentSpec);
+      recomputeAll();
+      showToast(`📂 Loaded '${filename}'! You can now modify and merge settings.`);
+    }
+  } catch (e) {
+    showToast(`⚠️ Failed to parse ${filename}: ` + e.message);
+  }
+}
+
+// Merge modified UI form settings into base configuration
+// Sync to Config — one click, one result. Used to be two separate
+// steps ("Merge & Diff" previewed an in-memory merge; "Save to Firmware" then
+// wrote whatever currentSpec happened to be, which silently skipped the
+// merge if you saved without merging first). Now it always searches for an
+// existing config/custom/<robot>_config.h and merges into it — your changes
+// here win, anything else already in that file is kept — then writes the
+// result in the same click. A brand-new robot name just gets a fresh file.
+async function mergeAndSaveConfig() {
+  currentSpec = readSpecFromForm();
+  const name = currentSpec.robot_name || 'robot';
+  const filename = `${name}_config.h`;
+
+  // Prefer a base the user explicitly loaded this session (Load Existing
+  // Config); otherwise look up whatever's on disk for this robot name right
+  // now — a fresh /api/configs call, not the possibly-stale cached list, so
+  // a file created by another action (e.g. a Full Deploy) this session is
+  // still found.
+  let baseContent = null;
+  if (!baseConfigSpec) {
+    try {
+      const listRes = await fetch('/api/configs');
+      if (listRes.ok) {
+        const listData = await listRes.json();
+        existingConfigsList = listData.configs || [];
+        const hit = existingConfigsList.find(c => c.filename === filename);
+        if (hit) baseContent = hit.content;
+      }
+    } catch (e) { /* offline — fall through to a fresh save */ }
+  }
+
+  let headerCode, changeCount = null;
+  if (baseConfigSpec || baseContent) {
+    try {
+      const mergeBody = baseConfigSpec
+        ? { base_spec: baseConfigSpec, override_spec: currentSpec }
+        : { base_content: baseContent, override_spec: currentSpec };
+      const res = await fetch('/api/merge', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(mergeBody)
+      });
+      const data = await res.json();
+      if (data.status === 'ok') {
+        currentSpec = data.merged_spec;
+        changeCount = data.changes ? data.changes.length : 0;
+        headerCode = data.header;
+      } else {
+        headerCode = generateCppHeader(currentSpec);
+      }
+    } catch (e) {
+      showToast('⚠️ Merge error (saving unmerged): ' + e.message);
+      headerCode = generateCppHeader(currentSpec);
+    }
+  } else {
+    headerCode = generateCppHeader(currentSpec);
+  }
+
+  try {
+    const res = await fetch('/api/save', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        filename: filename,
+        header: headerCode,
+        wifi_config: generateWifiConfig(currentSpec),
+        spec: currentSpec
+      })
+    });
+    const data = await res.json();
+    if (data.status === 'saved') {
+      updateAutomationPreviews();
+      renderActiveCode();
+      const mergeNote = changeCount === null ? "new file" : `merged ${changeCount} field(s)`;
+      showToast(`💾 Saved config/custom/${filename} (${mergeNote}).` +
+        (data.wifi_config_written ? ` WiFi keys → git-ignored wifi_config.h.` : ``));
+    } else {
+      showToast('⚠️ Save error: ' + (data.error || 'unknown'));
+    }
+  } catch (e) {
+    showToast('⚠️ Save error: ' + e.message);
+  }
+}
+
+  // Existing Config & Merge Handlers
+  loadExistingConfigsList();
+  initSyslogControls();
+  const btnLoadCfg = document.getElementById("btn-load-config");
+  if (btnLoadCfg) {
+    btnLoadCfg.addEventListener("click", () => {
+      const sel = document.getElementById("existing-config-select");
+      if (sel && sel.value) loadExistingConfig(sel.value);
+      else showToast("Select an existing config first");
+    });
+  }
+  const btnMergeSaveCfg = document.getElementById("btn-merge-save-config");
+  if (btnMergeSaveCfg) btnMergeSaveCfg.addEventListener("click", mergeAndSaveConfig);
+
+
+// =============================================================================
+// Live ROS 2 Topic Streamer, Hz Table & Inspector
+// =============================================================================
+let activeRos2EventSource = null;
+let activeRos2StreamMode = null; // 'echo' or 'hz'
+let selectedRos2Topic = "/odom/unfiltered";
+
+async function fetchRos2Topics() {
+  try {
+    const res = await fetch("/api/ros2/topics");
+    if (!res.ok) return;
+    const data = await res.json();
+    if (data.status === "ok" && Array.isArray(data.topics) && data.topics.length > 0) {
+      renderRos2TopicTable(data.topics);
+      updateRos2Dropdown(data.topics);
+      const graphStatus = document.getElementById("ros2-graph-status");
+      if (graphStatus) {
+        graphStatus.textContent = `● ${data.topics.length} Topics Active`;
+        graphStatus.className = "badge-pill badge-ok";
+      }
+    }
+  } catch (err) {
+    console.warn("fetchRos2Topics error:", err);
+  }
+}
+
+function updateRos2Dropdown(topics) {
+  const select = document.getElementById("ros2-topic-select");
+  if (!select) return;
+  const cur = select.value;
+  select.innerHTML = "";
+  topics.forEach(t => {
+    const opt = document.createElement("option");
+    opt.value = t.topic;
+    opt.textContent = `${t.topic} (${t.type.split("/").pop()})`;
+    select.appendChild(opt);
+  });
+  if (topics.some(t => t.topic === selectedRos2Topic)) {
+    select.value = selectedRos2Topic;
+  } else if (topics.some(t => t.topic === cur)) {
+    select.value = cur;
+  }
+}
+
+function renderRos2TopicTable(topics) {
+  const tbody = document.getElementById("ros2-topic-table-body");
+  if (!tbody) return;
+  tbody.innerHTML = "";
+
+  topics.forEach(t => {
+    const isSelected = (t.topic === selectedRos2Topic);
+    const tr = document.createElement("tr");
+    tr.className = "topic-row" + (isSelected ? " active" : "");
+    tr.setAttribute("data-topic", t.topic);
+
+    let icon = "📡";
+    if (t.topic.includes("odom")) icon = "🏎️";
+    else if (t.topic.includes("imu")) icon = "🧭";
+    else if (t.topic.includes("bat")) icon = "🔋";
+    else if (t.topic.includes("cmd")) icon = "🎮";
+
+    let hzClass = "topic-hz-badge";
+    if (t.hz.includes("1.0") || t.hz.includes("Event")) hzClass += " hz-low";
+    if (t.hz.includes("Sub")) hzClass += " hz-sub";
+
+    tr.innerHTML = `
+      <td style="text-align: center;"><input type="radio" name="topic-select-radio" value="${t.topic}" ${isSelected ? "checked" : ""}></td>
+      <td><span class="topic-table-name font-mono">${icon} ${t.topic}</span></td>
+      <td><span class="topic-table-type font-mono text-muted">${t.type}</span></td>
+      <td style="text-align: center;"><span class="${hzClass}" id="hz-cell-${t.topic.replace(/[^a-zA-Z0-9]/g, '_')}">${t.hz}</span></td>
+      <td style="text-align: center;"><span class="badge-pill ${t.status === 'active' ? 'badge-ok' : 'badge-info'}">${t.status === 'active' ? 'Active' : 'Sub'}</span></td>
+      <td style="text-align: right;">
+        <button type="button" class="btn btn-xs btn-accent btn-table-stream" data-topic="${t.topic}">▶️ Stream</button>
+        ${t.status === 'active' ? `<button type="button" class="btn btn-xs btn-ghost btn-table-hz" data-topic="${t.topic}">⚡ Hz</button>` : ''}
+      </td>
+    `;
+
+    // Row Click selects topic & starts live display
+    tr.addEventListener("click", (e) => {
+      if (e.target.tagName === "BUTTON") return;
+      selectTopicAndDisplay(t.topic);
+    });
+
+    const btnStream = tr.querySelector(".btn-table-stream");
+    if (btnStream) {
+      btnStream.addEventListener("click", (e) => {
+        e.stopPropagation();
+        selectTopicAndDisplay(t.topic, "echo");
+      });
+    }
+
+    const btnHz = tr.querySelector(".btn-table-hz");
+    if (btnHz) {
+      btnHz.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        selectTopicAndDisplay(t.topic, "hz");
+      });
+    }
+
+    tbody.appendChild(tr);
+  });
+}
+
+function selectTopicAndDisplay(topic, mode = "echo") {
+  selectedRos2Topic = topic;
+
+  // Update table selection state
+  document.querySelectorAll("#ros2-topic-table tbody tr").forEach(r => {
+    if (r.getAttribute("data-topic") === topic) {
+      r.classList.add("active");
+      const rad = r.querySelector("input[type='radio']");
+      if (rad) rad.checked = true;
+    } else {
+      r.classList.remove("active");
+    }
+  });
+
+  // Update dropdown
+  const select = document.getElementById("ros2-topic-select");
+  if (select && select.value !== topic) {
+    select.value = topic;
+  }
+
+  // Update HUD
+  const hudTopic = document.getElementById("hud-topic-name");
+  if (hudTopic) hudTopic.textContent = topic;
+
+  startRos2Stream(topic, mode);
+}
+
+async function measureAllTopicHz() {
+  const tbody = document.getElementById("ros2-topic-table-body");
+  if (!tbody) return;
+  const rows = [...tbody.querySelectorAll("tr.topic-row")];
+  // 7 s window so a 1 Hz topic (/battery, /pressure, /temperature, …) is
+  // averaged over ~7 samples instead of 2. Run every row in parallel so the
+  // total wait is ~7 s regardless of how many topics there are.
+  await Promise.all(rows.map(async (row) => {
+    const topic = row.getAttribute("data-topic");
+    if (!topic || topic.includes("cmd_vel")) return;
+    const badge = row.querySelector(".topic-hz-badge");
+    if (badge) { badge.textContent = "Measuring…"; badge.style.opacity = "0.6"; }
+    try {
+      const res = await fetch(`/api/ros2/hz_single?topic=${encodeURIComponent(topic)}&secs=7`);
+      const data = await res.json();
+      if (data.status === "ok" && data.hz && badge) {
+        badge.textContent = data.hz;
+        badge.style.opacity = "1.0";
+      } else if (badge) {
+        badge.style.opacity = "1.0";
+      }
+    } catch (e) {
+      if (badge) badge.style.opacity = "1.0";
+    }
+  }));
+}
+
+function stopRos2Stream() {
+  if (activeRos2EventSource) {
+    activeRos2EventSource.close();
+    activeRos2EventSource = null;
+  }
+  activeRos2StreamMode = null;
+  const echoBtn = document.getElementById("btn-ros2-echo");
+  if (echoBtn) {
+    const icon = document.getElementById("ros2-echo-icon");
+    const text = document.getElementById("ros2-echo-text");
+    if (icon) icon.textContent = "📡";
+    if (text) text.textContent = "Stream Topic";
+    echoBtn.className = "btn btn-sm btn-accent";
+  }
+  const cancelBtn = document.getElementById("btn-cancel-exec");
+  if (cancelBtn) cancelBtn.style.display = "none";
+}
+
+function startRos2Stream(topic, mode = "echo") {
+  stopRos2Stream();
+
+  // Surface the console so the streamed messages are actually visible (the
+  // topic table / Hz buttons are higher up the same tab).
+  jumpToTerminal();
+
+  const screen = document.getElementById("serial-terminal-screen");
+  if (screen) {
+    screen.innerHTML = `<div class="terminal-line terminal-info">📡 Connecting to live ROS 2 topic stream: <strong>${topic}</strong> (mode: ${mode})...</div>`;
+  }
+
+  const hudTopic = document.getElementById("hud-topic-name");
+  if (hudTopic) hudTopic.textContent = topic;
+
+  const echoBtn = document.getElementById("btn-ros2-echo");
+  if (echoBtn) {
+    const icon = document.getElementById("ros2-echo-icon");
+    const text = document.getElementById("ros2-echo-text");
+    if (icon) icon.textContent = "⏹️";
+    if (text) text.textContent = "Stop Stream";
+    echoBtn.className = "btn btn-sm btn-danger";
+  }
+  const cancelBtn = document.getElementById("btn-cancel-exec");
+  if (cancelBtn) {
+    cancelBtn.style.display = "inline-flex";
+    cancelBtn.onclick = stopRos2Stream;
+  }
+
+  activeRos2StreamMode = mode;
+  const url = `/api/ros2/stream?topic=${encodeURIComponent(topic)}&mode=${encodeURIComponent(mode)}`;
+  activeRos2EventSource = new EventSource(url);
+
+  activeRos2EventSource.onmessage = function(e) {
+    try {
+      const data = JSON.parse(e.data);
+      if (data.type === "line" || data.type === "start") {
+        const text = data.text;
+        appendTerminalLine(text);
+
+        // Parse metrics for Live HUD
+        if (text.includes("average rate:")) {
+          const m = text.match(/average rate:\s*([0-9.]+)/);
+          if (m) {
+            const hzVal = document.getElementById("hud-topic-hz");
+            if (hzVal) hzVal.textContent = `${parseFloat(m[1]).toFixed(1)} Hz`;
+            const cellBadge = document.getElementById(`hz-cell-${topic.replace(/[^a-zA-Z0-9]/g, '_')}`);
+            if (cellBadge) cellBadge.textContent = `${parseFloat(m[1]).toFixed(1)} Hz`;
+          }
+        }
+        if (text.includes("linear:") || text.includes("x:")) {
+          const m = text.match(/x:\s*([0-9.-]+)/);
+          if (m && Math.abs(parseFloat(m[1])) > 0.0001) {
+            const v1 = document.getElementById("hud-topic-val1");
+            if (v1) v1.textContent = `${parseFloat(m[1]).toFixed(3)} m/s`;
+          }
+        }
+        if (text.includes("angular:") || text.includes("z:")) {
+          const m = text.match(/z:\s*([0-9.-]+)/);
+          if (m && Math.abs(parseFloat(m[1])) > 0.0001) {
+            const v2 = document.getElementById("hud-topic-val2");
+            if (v2) v2.textContent = `${parseFloat(m[1]).toFixed(3)} rad/s`;
+          }
+        }
+        if (text.includes("voltage:")) {
+          const m = text.match(/voltage:\s*([0-9.]+)/);
+          if (m) {
+            const v1 = document.getElementById("hud-topic-val1");
+            if (v1) v1.textContent = `${parseFloat(m[1]).toFixed(2)} V`;
+          }
+        }
+      } else if (data.type === "error") {
+        appendTerminalLine(`[ERROR] ${data.text}`, "err");
+      }
+    } catch (err) {
+      appendTerminalLine(e.data, "dim");
+    }
+  };
+
+  activeRos2EventSource.onerror = function() {
+    appendTerminalLine("[INFO] ROS 2 topic stream ended.", "info");
+    stopRos2Stream();
+  };
+}
+
+function initRos2TopicInspector() {
+  const echoBtn = document.getElementById("btn-ros2-echo");
+  const hzBtn = document.getElementById("btn-ros2-hz");
+  const refreshBtn = document.getElementById("btn-ros2-refresh");
+  const inspRefreshBtn = document.getElementById("btn-ros2-inspector-refresh");
+  const measureAllBtn = document.getElementById("btn-measure-all-hz");
+  const topicSelect = document.getElementById("ros2-topic-select");
+
+  if (echoBtn) {
+    echoBtn.addEventListener("click", () => {
+      if (activeRos2EventSource) {
+        stopRos2Stream();
+      } else {
+        const t = topicSelect ? topicSelect.value : selectedRos2Topic;
+        selectTopicAndDisplay(t, "echo");
+      }
+    });
+  }
+  if (hzBtn) {
+    hzBtn.addEventListener("click", () => {
+      const t = topicSelect ? topicSelect.value : selectedRos2Topic;
+      selectTopicAndDisplay(t, "hz");
+    });
+  }
+  if (refreshBtn) refreshBtn.addEventListener("click", fetchRos2Topics);
+  if (inspRefreshBtn) inspRefreshBtn.addEventListener("click", fetchRos2Topics);
+  if (measureAllBtn) measureAllBtn.addEventListener("click", measureAllTopicHz);
+
+  if (topicSelect) {
+    topicSelect.addEventListener("change", () => {
+      selectTopicAndDisplay(topicSelect.value, activeRos2StreamMode || "echo");
+    });
+  }
+
+  fetchRos2Topics();
+  setInterval(fetchRos2Topics, 10000);
+}
+
+// -----------------------------------------------------------------------------
+// AI I2C Sensor Auto-Detection & Auto-Configuration Handler
+// -----------------------------------------------------------------------------
+function handleI2cAutoDetectedSensors(data) {
+  console.log("Auto-detected I2C Hardware:", data);
+  const _b = document.getElementById("btn-auto-detect-i2c");
+  if (_b) { _b.disabled = false; if (_b.dataset._t) _b.textContent = _b.dataset._t; }
+  const resultsDiv = document.getElementById("i2c-detect-results");
+  let summaryParts = [];
+
+  // 1. Auto-select IMU driver
+  const imuSelect = document.getElementById("cfg-imu");
+  if (imuSelect) {
+    if (data.imu && data.imu !== "NONE") {
+      for (let opt of imuSelect.options) {
+        if (opt.value.toUpperCase().includes(data.imu.toUpperCase())) {
+          imuSelect.value = opt.value;
+          summaryParts.push(`IMU: <strong>${data.imu}</strong>`);
+          break;
+        }
+      }
+    } else {
+      imuSelect.value = "FAKE";
+    }
+    imuSelect.dispatchEvent(new Event("change"));
+  }
+
+  // 2. Auto-select Magnetometer driver
+  const magSelect = document.getElementById("cfg-mag");
+  if (magSelect) {
+    if (data.mag && data.mag !== "NONE") {
+      for (let opt of magSelect.options) {
+        if (opt.value.toUpperCase().includes(data.mag.toUpperCase())) {
+          magSelect.value = opt.value;
+          summaryParts.push(`MAG: <strong>${data.mag}</strong>`);
+          break;
+        }
+      }
+    } else {
+      magSelect.value = "NONE";
+    }
+    magSelect.dispatchEvent(new Event("change"));
+  }
+
+  // 3. Auto-configure Current / Power Monitor
+  const batSelect = document.getElementById("cfg-battery");
+  if (batSelect) {
+    if (data.current && data.current.includes("INA219")) {
+      batSelect.value = "INA219";
+      summaryParts.push(`Power: <strong>INA219</strong>`);
+    }
+    batSelect.dispatchEvent(new Event("change"));
+  }
+
+  // 4. Auto-configure Environmental barometer (env category — BMP280 / BME280)
+  const envSelect = document.getElementById("cfg-env");
+  if (envSelect) {
+    const envDev = (data.devices || []).find((d) => d.category === "env");
+    if (envDev) {
+      const model = String(envDev.model || "BMP280").toUpperCase();
+      for (let opt of envSelect.options) {
+        if (opt.value.toUpperCase() === model) { envSelect.value = opt.value; break; }
+      }
+      if (envSelect.value === "NONE") envSelect.value = "BMP280";
+      summaryParts.push(`Env: <strong>${envSelect.value}</strong>`);
+      envSelect.dispatchEvent(new Event("change"));
+    }
+  }
+
+  // Update UI results box
+  if (resultsDiv) {
+    resultsDiv.style.display = "block";
+    if (summaryParts.length > 0) {
+      resultsDiv.innerHTML = `✅ <span style="color:#34d399;">Auto-Configured Drivers:</span> ${summaryParts.join(" | ")} <span class="badge-pill badge-ok ml-2">Drivers Applied</span>`;
+    } else {
+      resultsDiv.innerHTML = `ℹ️ <span style="color:#94a3b8;">No physical I2C chips detected. Configured to Bare Module mode (Fake IMU/MAG).</span>`;
+    }
+  }
+
+  // Regenerate configuration headers & code
+  if (typeof updateGeneratedCode === "function") {
+    updateGeneratedCode();
+  }
+
+  const toastMsg = summaryParts.length > 0
+    ? `🎉 Auto-Detected: ${summaryParts.join(", ")}! Drivers configured.`
+    : `ℹ️ Bus scanned: No I2C chips detected (Bare Module Mode preserved).`;
+  showToast(toastMsg);
+}
+
+function runI2cSensorAutoDetect() {
+  const mcu = (document.getElementById("cfg-mcu")?.value || "GENDRV").toUpperCase();
+  // tools/i2c_detect/platformio.ini envs: gendrv, esp32, esp32s3, pico, pico2
+  // tools/i2c_detect always runs at 921600 (its own BAUDRATE default / [env]
+  // monitor_speed) — NOT the 1.5 Mbaud the GenDrv micro-ROS firmware uses.
+  let envName = "esp32", baud = 921600;
+  if (mcu.includes("GENDRV")) { envName = "gendrv"; }
+  else if (mcu.includes("PICO2")) envName = "pico2";
+  else if (mcu.includes("PICO"))  envName = "pico";
+  else if (mcu.includes("S3"))    envName = "esp32s3";
+  else if (mcu.includes("S2"))    envName = "esp32";   // no s2 env; override pins carry it
+  const distro = mcu.includes("GENDRV") ? "gendrv" : envName;
+
+  const portSelect = document.getElementById("auto-flash-port");
+  const port = (portSelect && portSelect.value) ? portSelect.value.trim()
+             : (envName === "gendrv" || envName === "esp32" || envName === "esp32s3" ? "/dev/ttyUSB0" : "/dev/ttyACM0");
+  const uploadFlag = (port && !port.includes("BOOTSEL")) ? ` --upload-port ${port}` : "";
+
+  // Scan the pins currently set in the Pinout matrix (not whatever the tracked
+  // board header happens to define). Passed as build flags the tools/i2c_detect
+  // firmware honours ahead of BOARD_INIT.
+  const sda = parseInt(document.getElementById("pin-i2c-sda")?.value, 10);
+  const scl = parseInt(document.getElementById("pin-i2c-scl")?.value, 10);
+  const havePins = Number.isInteger(sda) && Number.isInteger(scl) && sda >= 0 && scl >= 0;
+  const pfx = havePins ? `PLATFORMIO_BUILD_FLAGS="-D I2C_SDA_OVERRIDE=${sda} -D I2C_SCL_OVERRIDE=${scl}" ` : "";
+  const pinNote = havePins ? ` on SDA ${sda} / SCL ${scl}` : "";
+
+  // i2c_detect resets on port open, then boots (~1.5 s) and prints the scan +
+  // the [I2C_JSON] line, repeating every 5 s. Read up to 20 s, stop at the
+  // first JSON (or the "no devices" line).
+  const monitorPy = "import serial, sys, time; s = serial.Serial('" + port + "', " + baud + ", timeout=2); t = time.time();\nwhile time.time() - t < 20:\n  l = s.readline().decode('utf-8', errors='ignore').strip()\n  if not l: continue\n  print(l); sys.stdout.flush()\n  if '[I2C_JSON]' in l or 'No I2C devices detected' in l: break\ns.close()";
+  const rd = document.getElementById("i2c-detect-results");
+  if (rd) {
+    rd.style.display = "block";
+    rd.innerHTML = `<span style="color:#38bdf8;">⏳ Watch the <strong>Automation &amp; Flash</strong> tab terminal — installs tools (first run only) → builds &amp; flashes <code>tools/i2c_detect</code>${pinNote} → scans the bus. Returns here when done.</span>`;
+  }
+  const btn = document.getElementById("btn-auto-detect-i2c");
+  let _btnRestore = null;
+  if (btn) {
+    btn.disabled = true; btn.dataset._t = btn.textContent; btn.textContent = "⏳ Scanning…";
+    _btnRestore = () => { btn.disabled = false; if (btn.dataset._t) btn.textContent = btn.dataset._t; };
+    setTimeout(() => { if (btn.disabled) _btnRestore(); }, 360000);
+  }
+  // (executeCommandInTerminal activates the Automation tab so this streams on-screen.)
+  const rwFix = `for _d in /dev/ttyUSB* /dev/ttyACM*; do [ -e "$_d" ] && [ ! -w "$_d" ] && sudo chmod a+rw "$_d" 2>/dev/null || true; done`;
+  // Guarantee the pyserial the mini-monitor below imports (penv python has pip).
+  const ensurePyserial = `~/.platformio/penv/bin/python -c 'import serial' 2>/dev/null || ~/.platformio/penv/bin/python -m pip install -q pyserial 2>/dev/null || python3 -m pip install -q --user pyserial 2>/dev/null || true`;
+  // Explicit phase banners so the streamed terminal output reads as
+  // installing tools -> building/flashing -> scanning.
+  let cmd;
+  if (remoteConfig.targetMode === "remote") {
+    const host = remoteConfig.remoteHost;
+    const user = remoteConfig.remoteUser;
+    const sshPort = remoteConfig.remotePort || 22;
+    const sshKey = remoteConfig.remoteKey;
+    const sshOpts = `-o StrictHostKeyChecking=no -p ${sshPort}` + (sshKey ? ` -i ${sshKey}` : "");
+    const isPico = envName.includes("pico");
+    const binExt = isPico ? "uf2" : "bin";
+    const binFile = `tools/i2c_detect/.pio/build/${envName}/firmware.${binExt}`;
+    const remoteDest = `/tmp/i2c_detect.${binExt}`;
+
+    cmd = [
+      `set -e`,
+      `echo; echo "=== [1/4] Build tools (Laptop PlatformIO) ========================"`,
+      ensurePioToolchainSnippet(),
+      `echo; echo "=== [2/4] Building i2c_detect firmware locally (${envName}) ===="`,
+      `cd tools/i2c_detect && ${pfx}pio run -e ${envName}`,
+      `cd ../..`,
+      `echo; echo "=== [3/4] Transferring & Flashing on remote robot (${user}@${host}) ===="`,
+      `scp ${sshOpts} ${binFile} ${user}@${host}:${remoteDest}`,
+      isPico 
+        ? `ssh ${sshOpts} ${user}@${host} "picotool load -f ${remoteDest} -x || sudo cp ${remoteDest} /media/*/RPI-RP2/ 2>/dev/null"`
+        : `ssh ${sshOpts} ${user}@${host} "which esptool.py >/dev/null 2>&1 || python3 -m esptool version >/dev/null 2>&1 || python3 -m pip install -q --user esptool 2>/dev/null || true; python3 -m esptool --port ${port} --baud 460800 --before default_reset --after hard_reset write_flash 0x10000 ${remoteDest} || esptool.py --port ${port} --baud 460800 write_flash 0x10000 ${remoteDest}"`,
+      `echo; echo "=== [4/4] Scanning I2C bus over remote serial (${port} @ ${baud}) ===="`,
+      `ssh ${sshOpts} ${user}@${host} "python3 -c \"${monitorPy}\" || (stty -F '${port}' ${baud} raw -echo 2>/dev/null && timeout 15 cat '${port}')"`,
+    ].join("\n");
+  } else {
+    cmd = [
+      `set -e`,
+      rwFix,
+      `echo; echo "=== [1/3] Build tools (PlatformIO) ================================"`,
+      ensurePioToolchainSnippet(),
+      ensurePyserial,
+      `echo; echo "=== [2/3] Building & flashing i2c_detect firmware (${envName}) ===="`,
+      `cd tools/i2c_detect`,
+      `${pfx}pio run -e ${envName} -t upload${uploadFlag}`,
+      `echo; echo "=== [3/3] Scanning the I2C bus${pinNote} ========================="`,
+      `~/.platformio/penv/bin/python -c "${monitorPy}"`,
+    ].join("\n");
+  }
+  const p = executeCommandInTerminal(cmd, `🔍 AI Auto-Detecting I2C Sensors (${envName}${pinNote} -> ${port})`);
+  if (p && typeof p.finally === "function" && _btnRestore) p.finally(_btnRestore);
+}
+
+
+// =============================================================================
+// 📡 Live UDP Syslog Server & Streamer Management
+// =============================================================================
+let activeSyslogEventSource = null;
+let isSyslogRunning = false;
+
+async function checkSyslogStatus() {
+  try {
+    const res = await fetch('/api/syslog/status');
+    if (!res.ok) return;
+    const data = await res.json();
+    updateSyslogUIState(data);
+    if (data.running && !activeSyslogEventSource) {
+      connectSyslogStream();
+    }
+  } catch (e) {
+    // server might be offline or reloading
+  }
+}
+
+function updateSyslogUIState(data) {
+  // /api/syslog/status reports data.running; the start/stop responses report
+  // data.status ("running"/"already_running"/"stopped"). Accept either.
+  const running = (typeof data.running === "boolean")
+    ? data.running
+    : (data.status === "running" || data.status === "already_running");
+  data = { ...data, running };
+  isSyslogRunning = running;
+  const badge = document.getElementById('syslog-status-badge');
+  const badgeText = document.getElementById('syslog-status-text');
+  const btnStart = document.getElementById('btn-syslog-start');
+  const btnStop = document.getElementById('btn-syslog-stop');
+  const tab5Text = document.getElementById('tab5-syslog-text');
+  const tab5Btn = document.getElementById('btn-tab5-launch-syslog');
+  const statFile = document.getElementById('syslog-stat-file');
+  const statPackets = document.getElementById('syslog-stat-packets');
+  const statClient = document.getElementById('syslog-stat-client');
+  const portInput = document.getElementById('cfg-syslog-port');
+
+  if (portInput && data.port) {
+    portInput.value = data.port;
+  }
+
+  if (badge && badgeText) {
+    if (data.running) {
+      badge.className = 'syslog-status-badge running';
+      badgeText.textContent = `Syslog: UDP :${data.port}`;
+    } else {
+      badge.className = 'syslog-status-badge stopped';
+      badgeText.textContent = 'Syslog: Offline';
+    }
+  }
+
+  if (btnStart && btnStop) {
+    if (data.running) {
+      btnStart.style.display = 'none';
+      btnStop.style.display = 'inline-flex';
+    } else {
+      btnStart.style.display = 'inline-flex';
+      btnStop.style.display = 'none';
+    }
+  }
+
+  if (tab5Text) {
+    tab5Text.textContent = data.running ? `Syslog: :${data.port}` : 'Syslog Server';
+  }
+  if (tab5Btn) {
+    if (data.running) {
+      tab5Btn.classList.add('btn-accent');
+      tab5Btn.classList.remove('btn-ghost');
+    } else {
+      tab5Btn.classList.remove('btn-accent');
+      tab5Btn.classList.add('btn-ghost');
+    }
+  }
+
+  if (statFile && data.logfile) statFile.textContent = data.logfile;
+  if (statPackets && typeof data.packets === 'number') statPackets.textContent = data.packets;
+  if (statClient && data.last_sender) statClient.textContent = data.last_sender;
+  const otaIp = document.getElementById('cfg-ota-ip');
+  if (otaIp && !otaIp.value && data.last_sender) otaIp.value = data.last_sender;
+}
+
+async function startSyslogServer(requestedPort) {
+  const portInput = document.getElementById('cfg-syslog-port');
+  const port = requestedPort || (portInput ? parseInt(portInput.value) || 514 : 514);
+  try {
+    const res = await fetch('/api/syslog/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ port: port })
+    });
+    const data = await res.json();
+    if (data.status === 'running' || data.status === 'already_running') {
+      updateSyslogUIState(data);
+      const ipEl = document.getElementById('cfg-syslog-ip');
+      if (ipEl && data.host_ip) ipEl.value = data.host_ip;
+      const portEl = document.getElementById('cfg-syslog-port');
+      if (portEl && data.port) portEl.value = data.port;   // reflect the bound port in the config
+      if (data.host_ip) showToast(`📡 Syslog target set to ${data.host_ip}:${data.port}`);
+      recomputeAll();
+      connectSyslogStream();
+      const fallbackNote = data.fallback ? ` (fell back to :${data.port})` : '';
+      showToast(`🟢 Syslog Server listening on UDP port ${data.port}${fallbackNote}!`);
+      
+      appendTerminalLine(`[SYSLOG SERVER] Listening on UDP 0.0.0.0:${data.port} | Saving to ${data.logfile}`, "in");
+    } else {
+      showToast(`⚠️ Failed to start syslog: ${data.error || 'Unknown error'}`);
+    }
+  } catch (e) {
+    showToast(`⚠️ Syslog start error: ${e.message}`);
+  }
+}
+
+async function stopSyslogServer() {
+  try {
+    const res = await fetch('/api/syslog/stop', { method: 'POST' });
+    const data = await res.json();
+    updateSyslogUIState(data);
+    if (activeSyslogEventSource) {
+      activeSyslogEventSource.close();
+      activeSyslogEventSource = null;
+    }
+    showToast(`⏹️ Syslog Server stopped. Total packets: ${data.packets || 0}`);
+    appendTerminalLine(`[SYSLOG SERVER] Stopped (Captured ${data.packets || 0} packets).`, "dim");
+  } catch (e) {
+    showToast(`⚠️ Syslog stop error: ${e.message}`);
+  }
+}
+
+function connectSyslogStream() {
+  if (activeSyslogEventSource) {
+    activeSyslogEventSource.close();
+  }
+  activeSyslogEventSource = new EventSource('/api/syslog/stream');
+  
+  activeSyslogEventSource.addEventListener('status', (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      updateSyslogUIState(data);
+    } catch (_) {}
+  });
+
+  activeSyslogEventSource.addEventListener('syslog', (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      const statPackets = document.getElementById('syslog-stat-packets');
+      const statClient = document.getElementById('syslog-stat-client');
+      if (statPackets) {
+        const cur = parseInt(statPackets.textContent) || 0;
+        statPackets.textContent = cur + 1;
+      }
+      if (statClient) statClient.textContent = data.sender;
+
+      const chkStream = document.getElementById('chk-stream-syslog-terminal');
+      if (!chkStream || chkStream.checked) {
+        const esc = (s) => String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        const timePart = data.time ? data.time.split(' ')[1] || data.time : '';
+        appendTerminalHtml(
+          `<span class="badge-syslog">SYSLOG</span> <span class="syslog-time">${esc(timePart)}</span> <span class="syslog-sender">[${esc(data.sender)}]</span> <span class="syslog-msg">${esc(data.message)}</span>`,
+          'syslog'
+        );
+      }
+    } catch (_) {}
+  });
+
+  activeSyslogEventSource.onerror = () => {
+    // will auto-reconnect
+  };
+}
+
+async function viewSyslogFiles() {
+  try {
+    const res = await fetch('/api/syslog/logs?tail=30');
+    if (!res.ok) return;
+    const data = await res.json();
+    const terminalScreen = document.getElementById('serial-terminal-screen');
+    if (terminalScreen) {
+      const lineEl = document.createElement('div');
+      lineEl.className = 'terminal-line terminal-in';
+      lineEl.textContent = `=== 📂 Syslog Files in logs/ (${data.files.length} files) ===`;
+      terminalScreen.appendChild(lineEl);
+      for (const f of data.files) {
+        const fEl = document.createElement('div');
+        fEl.className = 'terminal-line terminal-out';
+        fEl.textContent = `  - ${f.name} (${f.size} bytes)`;
+        terminalScreen.appendChild(fEl);
+      }
+      if (data.lines && data.lines.length > 0) {
+        const hEl = document.createElement('div');
+        hEl.className = 'terminal-line terminal-in';
+        hEl.textContent = `--- Tail of ${data.current_file} ---`;
+        terminalScreen.appendChild(hEl);
+        for (const l of data.lines) {
+          const lEl = document.createElement('div');
+          lEl.className = 'terminal-line terminal-syslog';
+          lEl.textContent = `  ${l}`;
+          terminalScreen.appendChild(lEl);
+        }
+      }
+      terminalScreen.scrollTop = terminalScreen.scrollHeight;
+    }
+    showToast(`📂 Found ${data.files.length} log files in logs/`);
+  } catch (e) {
+    showToast(`⚠️ Could not list logs: ${e.message}`);
+  }
+}
+
+function initSyslogControls() {
+  const btnStart = document.getElementById('btn-syslog-start');
+  if (btnStart) btnStart.addEventListener('click', () => startSyslogServer());
+
+  const btnStop = document.getElementById('btn-syslog-stop');
+  if (btnStop) btnStop.addEventListener('click', () => stopSyslogServer());
+
+  const btnTab5 = document.getElementById('btn-tab5-launch-syslog');
+  if (btnTab5) {
+    btnTab5.addEventListener('click', () => {
+      if (isSyslogRunning) stopSyslogServer();
+      else startSyslogServer();
+    });
+  }
+
+  const btnViewLogs = document.getElementById('btn-syslog-view-logs');
+  if (btnViewLogs) btnViewLogs.addEventListener('click', () => viewSyslogFiles());
+
+  checkSyslogStatus();
+}
+
+
+async function checkAndDisplayAgentPortStatus() {
+  const iconElem = document.getElementById("agent-port-indicator-icon");
+  const textElem = document.getElementById("agent-port-indicator-text");
+  const btnRelease = document.getElementById("btn-release-agent-port");
+  if (!iconElem || !textElem) return;
+
+  const port = document.getElementById("auto-flash-port")?.value.trim() || "/dev/ttyUSB0";
+  const remoteHost = (document.getElementById("hdr-remote-flash")?.value || "").trim();
+  let user = "ubuntu";
+  let host = "";
+  if (remoteHost) {
+    if (remoteHost.includes("@")) {
+      [user, host] = remoteHost.split("@");
+    } else {
+      host = remoteHost;
+    }
+  }
+
+  iconElem.textContent = "⏳";
+  textElem.textContent = `Checking ${port}...`;
+
+  try {
+    const url = `/api/agent/port_check?port=${encodeURIComponent(port)}&mode=serial&host=${encodeURIComponent(host)}&user=${encodeURIComponent(user)}`;
+    const res = await fetch(url).then(r => r.json());
+    if (res.status === "ok") {
+      if (res.in_use) {
+        iconElem.textContent = "⚠️";
+        textElem.innerHTML = `<strong>Conflict:</strong> ${res.summary || "Port is occupied"} <span class="text-secondary" style="font-size:0.75rem;">(${res.details || ""})</span>`;
+        if (btnRelease) btnRelease.style.display = "inline-block";
+      } else {
+        iconElem.textContent = "🟢";
+        textElem.innerHTML = `Port <code>${res.target}</code> is free and ready`;
+        if (btnRelease) btnRelease.style.display = "none";
+      }
+    } else {
+      iconElem.textContent = "ℹ️";
+      textElem.textContent = res.details || "Port check unavailable";
+      if (btnRelease) btnRelease.style.display = "none";
+    }
+  } catch (err) {
+    iconElem.textContent = "ℹ️";
+    textElem.textContent = "Port check skipped (offline)";
+    if (btnRelease) btnRelease.style.display = "none";
+  }
+}
+
+async function releaseAgentPortFromUI() {
+  const iconElem = document.getElementById("agent-port-indicator-icon");
+  const textElem = document.getElementById("agent-port-indicator-text");
+  const btnRelease = document.getElementById("btn-release-agent-port");
+  const port = document.getElementById("auto-flash-port")?.value.trim() || "/dev/ttyUSB0";
+  const remoteHost = (document.getElementById("hdr-remote-flash")?.value || "").trim();
+  let user = "ubuntu";
+  let host = "";
+  if (remoteHost) {
+    if (remoteHost.includes("@")) {
+      [user, host] = remoteHost.split("@");
+    } else {
+      host = remoteHost;
+    }
+  }
+
+  if (iconElem) iconElem.textContent = "⏳";
+  if (textElem) textElem.textContent = `Releasing ${port}...`;
+
+  try {
+    const res = await fetch("/api/agent/port_release", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ port, mode: "serial", host, user })
+    }).then(r => r.json());
+
+    if (res.status === "ok") {
+      await checkAndDisplayAgentPortStatus();
+    } else {
+      if (textElem) textElem.textContent = `Release error: ${res.error || "failed"}`;
+    }
+  } catch (err) {
+    if (textElem) textElem.textContent = `Release failed: ${err.message}`;
+  }
+}

--- a/tools/robot_config_engine/web/index.html
+++ b/tools/robot_config_engine/web/index.html
@@ -54,7 +54,7 @@
             <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2">
               <circle cx="12" cy="12" r="3"/><line x1="3" y1="12" x2="9" y2="12"/><line x1="15" y1="12" x2="21" y2="12"/>
             </svg>
-            <span id="git-version-text">········</span>
+            <span id="git-version-text">·······</span>
           </button>
           <div id="git-version-popover" class="git-version-popover" hidden></div>
         </div>
@@ -72,6 +72,11 @@
             <option value="waveshare_gendrv">Waveshare General Driver (ESP32 + BTS7960)</option>
           </select>
         </div>
+        <button type="button" id="btn-header-deploy" class="btn btn-accent hdr-deploy-btn"
+                title="Set Robot Name, press = name, then Run Full Deploy — build, flash & bring up live ROS 2 topics">
+          <span class="btn-icon">🚀</span>
+          <span><strong>Run Full Deploy</strong></span>
+        </button>
       </div>
 
       <!-- OS Quick Indicator -->
@@ -79,11 +84,6 @@
         <span class="os-badge-icon" id="header-os-icon">🐧</span>
         <span class="os-badge-text" id="header-os-text">Detecting OS...</span>
       </div>
-
-      <button id="btn-quick-deploy" class="btn btn-accent" title="Jump to Automation Hub">
-        <span class="tab-icon">🚀</span>
-        <span>Deploy & Flash</span>
-      </button>
 
       <!-- Action Buttons -->
       <button id="btn-load-board" class="btn btn-secondary" title="Load board configuration from firmware/platformio.ini">

--- a/tools/robot_config_engine/web/index.html
+++ b/tools/robot_config_engine/web/index.html
@@ -501,11 +501,17 @@
                 <label for="cfg-imu" class="form-label">Inertial Measurement Unit (IMU)</label>
                 <select id="cfg-imu" class="form-select">
                   <option value="FAKE" selected>Fake IMU (Bare Module Default — Zero Drift / Zero Hang)</option>
-                  <option value="BNO085">BNO085 / BNO080 (State-machine recovery & onboard fusion)</option>
-                  <option value="MPU6050">MPU6050 (6-DOF Accelerometer & Gyroscope)</option>
-                  <option value="QMI8658">QMI8658 (Waveshare on-board IMU)</option>
-                  <option value="MPU9250">MPU9250 (9-DOF IMU + Compass)</option>
-                  <option value="GY85">GY-85 (ADXL345 + ITG3200 + HMC5883L, 9-DOF)</option>
+                  <optgroup label="Recommended — low drift / low noise">
+                    <option value="BNO085">BNO085 / BNO080 (best — onboard sensor fusion, state-machine recovery)</option>
+                    <option value="LSM6DSOX">LSM6DSOX (ST 6-DOF, low noise)</option>
+                    <option value="ICM20948">ICM-20948 (TDK 9-DOF, low noise; onboard AK09916 mag)</option>
+                    <option value="QMI8658">QMI8658 (6-DOF, Waveshare on-board IMU)</option>
+                  </optgroup>
+                  <optgroup label="Legacy — higher drift / noise (may cause SLAM drift)">
+                    <option value="MPU9250">MPU9250 (9-DOF IMU + Compass)</option>
+                    <option value="MPU6050">MPU6050 (6-DOF)</option>
+                    <option value="GY85">GY-85 (ADXL345 + ITG3200 + HMC5883L, 9-DOF)</option>
+                  </optgroup>
                   <option value="NONE">None (Disabled)</option>
                 </select>
               </div>
@@ -514,8 +520,9 @@
                 <label for="cfg-mag" class="form-label">Magnetometer (Digital Compass)</label>
                 <select id="cfg-mag" class="form-select">
                   <option value="NONE" selected>Fake Magnetometer (Default / Estimated)</option>
-                  <option value="QMC5883L">QMC5883L (I2C Digital Compass)</option>
+                  <option value="ICM20948">ICM-20948 onboard AK09916 (needs ICM-20948 IMU)</option>
                   <option value="AK09918">AK09918 (I2C Digital Compass)</option>
+                  <option value="QMC5883L">QMC5883L (I2C Digital Compass)</option>
                   <option value="HMC5883L">HMC5883L (Legacy Compass)</option>
                 </select>
               </div>
@@ -539,9 +546,9 @@
                 <span class="input-hint">Subtracted from each raw reading (<code>#define MAG_BIAS</code>). Leave all blank to skip.</span>
               </div>
 
-              <div class="form-group">
+              <div class="form-group" style="grid-column:1 / -1;">
                 <label class="form-label">Covariance Overrides <span class="badge-optional">Optional</span></label>
-                <div class="form-grid" style="grid-template-columns:repeat(4,1fr);gap:8px;">
+                <div class="form-grid" style="grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px 16px;">
                   <div>
                     <label for="cfg-cov-accel" class="input-hint" style="display:block;">ACCEL_COV</label>
                     <input type="number" id="cfg-cov-accel" class="form-input font-mono" value="" step="0.0001" placeholder="1e-5">
@@ -558,18 +565,20 @@
                     <label for="cfg-cov-mag" class="input-hint" style="display:block;">MAG_COV</label>
                     <input type="number" id="cfg-cov-mag" class="form-input font-mono" value="" step="0.0001" placeholder="1e-5">
                   </div>
-                </div>
-                <div class="form-grid" style="grid-template-columns:repeat(2,1fr);gap:8px;margin-top:8px;">
-                  <div>
+                  <div style="grid-column:1 / -1;">
                     <label for="cfg-cov-pose" class="input-hint" style="display:block;">POSE_COV</label>
-                    <input type="text" id="cfg-cov-pose" class="form-input font-mono" value="" placeholder="scalar, or x,y,z,r,p,yaw">
+                    <input type="text" id="cfg-cov-pose" class="form-input font-mono" value="" placeholder="scalar, or x,y,z,roll,pitch,yaw">
                   </div>
-                  <div>
+                  <div style="grid-column:1 / -1;">
                     <label for="cfg-cov-twist" class="input-hint" style="display:block;">TWIST_COV</label>
-                    <input type="text" id="cfg-cov-twist" class="form-input font-mono" value="" placeholder="scalar, or x,y,z,r,p,yaw">
+                    <input type="text" id="cfg-cov-twist" class="form-input font-mono" value="" placeholder="scalar, or x,y,z,roll,pitch,yaw">
+                  </div>
+                  <div style="grid-column:1 / -1;">
+                    <label for="cfg-cov-env" class="input-hint" style="display:block;">ENV_COV</label>
+                    <input type="text" id="cfg-cov-env" class="form-input font-mono" value="" placeholder="scalar, or pressure, temperature, humidity">
                   </div>
                 </div>
-                <span class="input-hint">Diagonal covariance overrides. ACCEL / GYRO / ORI / MAG → <code>/imu/data*</code> (3 values); POSE / TWIST → <code>/odom/unfiltered</code> (6 values — a scalar expands, or list all 6). Blank = firmware default.</span>
+                <span class="input-hint">Diagonal covariance overrides. ACCEL / GYRO / ORI / MAG → <code>/imu/data*</code> (3 values); POSE / TWIST → <code>/odom/unfiltered</code> (6 values — a scalar expands, or list all 6); ENV → <code>/pressure /temperature /humidity</code> <code>.variance</code> (3 values). ACCEL / GYRO / MAG / ENV auto-fill from the selected sensor's datasheet — type to override, clear to fall back to the firmware default.</span>
               </div>
 
               <div class="form-group">
@@ -579,6 +588,16 @@
                   <option value="ADC_DIVIDER">ADC Resistor Voltage Divider (R1: 30kΩ, R2: 7.5kΩ)</option>
                   <option value="INA219">INA219 (I2C Current & Voltage Sensor)</option>
                 </select>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-env" class="form-label">Environmental Sensor (Barometer)</label>
+                <select id="cfg-env" class="form-select">
+                  <option value="NONE" selected>None</option>
+                  <option value="BMP280">BMP280 (I2C pressure + temperature)</option>
+                  <option value="BME280">BME280 (I2C pressure + temperature + humidity)</option>
+                </select>
+                <span class="input-hint">Publishes <code>/pressure</code> + <code>/temperature</code> (and <code>/humidity</code> for a BME280) at 1 Hz. The driver auto-detects the chip at I2C <code>0x77</code>/<code>0x76</code> — BMP280 vs BME280 here just sets your expectation.</span>
               </div>
 
               <!-- Battery Parameters Sub-Panel -->
@@ -607,8 +626,8 @@
                   </div>
                   <div class="form-group">
                     <label for="cfg-bat-dip" class="form-label">Voltage Drop Alert (DIP Ratio)</label>
-                    <input type="number" id="cfg-bat-dip" class="form-input" value="0.98" step="0.01" min="0.5" max="1.0">
-                    <span class="input-hint">Alert threshold for transient sag</span>
+                    <input type="number" id="cfg-bat-dip" class="form-input" value="" step="0.01" min="0.5" max="1.0" placeholder="blank = off · e.g. 0.98">
+                    <span class="input-hint">Off by default (it adds an out-of-band <code>/battery</code> burst on sag, costing I2C/serial bandwidth). Set e.g. <code>0.98</code> to enable.</span>
                   </div>
                 </div>
 

--- a/tools/robot_config_engine/web/index.html
+++ b/tools/robot_config_engine/web/index.html
@@ -283,6 +283,11 @@
                     <label for="cfg-syslog-port" class="form-label">Syslog UDP Port</label>
                     <input type="number" id="cfg-syslog-port" class="form-input font-mono" value="514" placeholder="514 or 5140">
                   </div>
+                  <div class="form-group" style="margin-bottom:0;">
+                    <label for="cfg-wifi-monitor" class="form-label">Wi-Fi RSSI → syslog (min)</label>
+                    <input type="number" id="cfg-wifi-monitor" class="form-input font-mono" value="0" min="0" max="60" placeholder="0 = off">
+                    <span class="input-hint">Periodic <code>WIFI_MONITOR</code> RSSI report; 0 disables</span>
+                  </div>
                   <div class="btn-group-row" style="margin-top:0;">
                     <button type="button" id="btn-syslog-start" class="btn btn-sm btn-primary flex-1" title="Launch background UDP Syslog receiver">
                       <span>▶️ Launch Syslog Server</span>
@@ -331,7 +336,17 @@
                   <div class="form-group">
                     <label for="cfg-lidar-uart" class="form-label">LiDAR UART Number</label>
                     <input type="number" id="cfg-lidar-uart" class="form-input" value="1" min="0" max="3">
-                    <span class="input-hint">Fixed 230400 baud (hardware)</span>
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-lidar-baud" class="form-label">LiDAR Baud Rate</label>
+                    <select id="cfg-lidar-baud" class="form-select font-mono">
+                      <option value="115200">115200 — LD14</option>
+                      <option value="230400" selected>230400 — LD06 / LD19 / LD14P / STL-06N / D300 / D500</option>
+                      <option value="460800">460800</option>
+                      <option value="921600">921600 — LD19 Plus / STL-27L</option>
+                      <option value="1000000">1000000</option>
+                    </select>
+                    <span class="input-hint">LDROBOT/LDLIDAR default rates (8N1). Match your model.</span>
                   </div>
                 </div>
               </div>
@@ -490,6 +505,7 @@
                   <option value="MPU6050">MPU6050 (6-DOF Accelerometer & Gyroscope)</option>
                   <option value="QMI8658">QMI8658 (Waveshare on-board IMU)</option>
                   <option value="MPU9250">MPU9250 (9-DOF IMU + Compass)</option>
+                  <option value="GY85">GY-85 (ADXL345 + ITG3200 + HMC5883L, 9-DOF)</option>
                   <option value="NONE">None (Disabled)</option>
                 </select>
               </div>
@@ -524,22 +540,36 @@
               </div>
 
               <div class="form-group">
-                <label class="form-label">IMU Covariance Overrides <span class="badge-optional">Optional</span></label>
-                <div class="form-grid" style="grid-template-columns:repeat(3,1fr);gap:8px;">
+                <label class="form-label">Covariance Overrides <span class="badge-optional">Optional</span></label>
+                <div class="form-grid" style="grid-template-columns:repeat(4,1fr);gap:8px;">
                   <div>
                     <label for="cfg-cov-accel" class="input-hint" style="display:block;">ACCEL_COV</label>
-                    <input type="number" id="cfg-cov-accel" class="form-input font-mono" value="" step="0.0001" placeholder="0.00001">
+                    <input type="number" id="cfg-cov-accel" class="form-input font-mono" value="" step="0.0001" placeholder="1e-5">
                   </div>
                   <div>
                     <label for="cfg-cov-gyro" class="input-hint" style="display:block;">GYRO_COV</label>
-                    <input type="number" id="cfg-cov-gyro" class="form-input font-mono" value="" step="0.0001" placeholder="0.00001">
+                    <input type="number" id="cfg-cov-gyro" class="form-input font-mono" value="" step="0.0001" placeholder="1e-5">
                   </div>
                   <div>
                     <label for="cfg-cov-ori" class="input-hint" style="display:block;">ORI_COV</label>
-                    <input type="number" id="cfg-cov-ori" class="form-input font-mono" value="" step="0.0001" placeholder="0.00001">
+                    <input type="number" id="cfg-cov-ori" class="form-input font-mono" value="" step="0.0001" placeholder="1e-5">
+                  </div>
+                  <div>
+                    <label for="cfg-cov-mag" class="input-hint" style="display:block;">MAG_COV</label>
+                    <input type="number" id="cfg-cov-mag" class="form-input font-mono" value="" step="0.0001" placeholder="1e-5">
                   </div>
                 </div>
-                <span class="input-hint">Diagonal covariance for the <code>/imu/data*</code> message. Blank = firmware default (0.00001).</span>
+                <div class="form-grid" style="grid-template-columns:repeat(2,1fr);gap:8px;margin-top:8px;">
+                  <div>
+                    <label for="cfg-cov-pose" class="input-hint" style="display:block;">POSE_COV</label>
+                    <input type="text" id="cfg-cov-pose" class="form-input font-mono" value="" placeholder="scalar, or x,y,z,r,p,yaw">
+                  </div>
+                  <div>
+                    <label for="cfg-cov-twist" class="input-hint" style="display:block;">TWIST_COV</label>
+                    <input type="text" id="cfg-cov-twist" class="form-input font-mono" value="" placeholder="scalar, or x,y,z,r,p,yaw">
+                  </div>
+                </div>
+                <span class="input-hint">Diagonal covariance overrides. ACCEL / GYRO / ORI / MAG → <code>/imu/data*</code> (3 values); POSE / TWIST → <code>/odom/unfiltered</code> (6 values — a scalar expands, or list all 6). Blank = firmware default.</span>
               </div>
 
               <div class="form-group">
@@ -1268,17 +1298,8 @@ const int16_t ADC_LUT[4096] = { /* insert adc_calibrate data here */ };</code></
                   <label for="auto-agent-multiserial-ports" class="form-label-xs">Multi-Serial Devices (space-separated for multi-MCU robots)</label>
                   <input type="text" id="auto-agent-multiserial-ports" class="form-input form-input-sm font-mono" value="/dev/ttyACM0 /dev/ttyUSB0" placeholder="/dev/ttyACM0 /dev/ttyUSB0">
                 </div>
-                <div class="form-group" style="width: 140px;">
-                  <label for="auto-agent-baud" class="form-label-xs">Agent Baud Rate</label>
-                  <select id="auto-agent-baud" class="form-select form-select-sm font-mono">
-                    <option value="1500000">1500000 (1.5M)</option>
-                    <option value="921600" selected>921600</option>
-                    <option value="460800">460800</option>
-                    <option value="115200">115200</option>
-                    <option value="57600">57600</option>
-                  </select>
-                </div>
               </div>
+              <p class="input-hint mt-1">Agent baud follows <strong>Serial Communication Baud Rate</strong> on Tab 1 (the firmware <code>BAUDRATE</code>).</p>
               <pre class="quick-cmd-code"><code id="preview-agent-cmd">ros2 run micro_ros_agent micro_ros_agent serial --dev /dev/ttyUSB0 -b 921600</code></pre>
             </div>
 
@@ -1427,10 +1448,11 @@ const int16_t ADC_LUT[4096] = { /* insert adc_calibrate data here */ };</code></
                     <span id="serial-btn-icon">🔌</span>
                     <span id="serial-btn-text">Browser USB</span>
                   </button>
-                  <select id="serial-baud-select" class="form-select form-select-sm" title="Serial Baud Rate">
+                  <select id="serial-baud-select" class="form-select form-select-sm" data-auto-managed="true" title="Serial baud rate — follows Tab 1 BAUDRATE until you pick one here (override for bootloader / MicroPython / non-linorobot boards)">
                     <option value="1500000">1500000 Baud (1.5M High Speed)</option>
                     <option value="921600" selected>921600 Baud (micro-ROS / Diagnostics)</option>
                     <option value="460800">460800 Baud</option>
+                    <option value="230400">230400 Baud</option>
                     <option value="115200">115200 Baud</option>
                     <option value="57600">57600 Baud</option>
                     <option value="9600">9600 Baud</option>

--- a/tools/robot_config_engine/web/index.html
+++ b/tools/robot_config_engine/web/index.html
@@ -37,20 +37,41 @@
     </div>
 
     <div class="header-actions">
-      <!-- Preset Quick Loader -->
-      <div class="preset-selector-group">
-        <label for="preset-select" class="preset-label">⚡ Reference Build:</label>
-        <select id="preset-select" class="preset-select">
-          <option value="bare" selected>🧩 Bare Module — all pins N/C (safe default)</option>
-          <option value="pico2_diff">⚡ Pico 2 · 2WD Differential · BTS7960 (Fake IMU)</option>
-          <option value="pico2_mecanum">⚡ Pico 2 · 4WD Mecanum · BTS7960 (Fake IMU)</option>
-          <option value="pico2_skid">⚡ Pico 2 · 4WD Skid Steer · BTS7960 (Fake IMU)</option>
-          <option value="scout_pico2">Raspberry Pi Pico 2 (2WD Diff + TB6612 / L298N)</option>
-          <option value="mech_pico2">Raspberry Pi Pico 2 (4WD Mecanum + TB6612)</option>
-          <option value="mech_esp32">ESP32 (4WD Mecanum + WiFi UDP + BNO085)</option>
-          <option value="crawler_esp32s3">ESP32-S3 (4WD Skid + Sonar + ADC)</option>
-          <option value="waveshare_gendrv">Waveshare General Driver (ESP32 + BTS7960)</option>
-        </select>
+      <!-- Robot name, branch, git version & reference build -->
+      <div class="reference-build-stack">
+        <div class="hdr-field">
+          <label for="cfg-robot-name">🤖 Robot Name:</label>
+          <input type="text" id="cfg-robot-name" class="form-input hdr-input" value="scout_pico2" placeholder="e.g. scout_pico2" pattern="^[a-z0-9_]+$" title="Lowercase alphanumeric &amp; underscores only">
+        </div>
+        <div class="hdr-field">
+          <label for="auto-git-branch">⎇ Branch:</label>
+          <input type="text" id="auto-git-branch" class="form-input hdr-input" data-auto-managed="true" value="scout_pico2" placeholder="current branch" title="Robot SBC git branch. Run Merge &amp; Commit checks it out (creating it if new).">
+          <button type="button" id="btn-branch-to-name" class="hdr-btn" title="Set the branch to the robot name and switch to it">= name</button>
+        </div>
+        <div class="git-version-row">
+          <button id="git-version-badge" class="git-version-badge" type="button" aria-expanded="false"
+                  title="Repo version the web server started on — click for branch, remotes &amp; recent commits">
+            <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="3"/><line x1="3" y1="12" x2="9" y2="12"/><line x1="15" y1="12" x2="21" y2="12"/>
+            </svg>
+            <span id="git-version-text">········</span>
+          </button>
+          <div id="git-version-popover" class="git-version-popover" hidden></div>
+        </div>
+        <div class="preset-selector-group">
+          <label for="preset-select" class="preset-label">⚡ Reference Build:</label>
+          <select id="preset-select" class="preset-select">
+            <option value="bare" selected>🧩 Bare Module — all pins N/C (safe default)</option>
+            <option value="pico2_diff">⚡ Pico 2 · 2WD Differential · BTS7960 (Fake IMU)</option>
+            <option value="pico2_mecanum">⚡ Pico 2 · 4WD Mecanum · BTS7960 (Fake IMU)</option>
+            <option value="pico2_skid">⚡ Pico 2 · 4WD Skid Steer · BTS7960 (Fake IMU)</option>
+            <option value="scout_pico2">Raspberry Pi Pico 2 (2WD Diff + TB6612 / L298N)</option>
+            <option value="mech_pico2">Raspberry Pi Pico 2 (4WD Mecanum + TB6612)</option>
+            <option value="mech_esp32">ESP32 (4WD Mecanum + WiFi UDP + BNO085)</option>
+            <option value="crawler_esp32s3">ESP32-S3 (4WD Skid + Sonar + ADC)</option>
+            <option value="waveshare_gendrv">Waveshare General Driver (ESP32 + BTS7960)</option>
+          </select>
+        </div>
       </div>
 
       <!-- OS Quick Indicator -->
@@ -133,24 +154,9 @@
 
             <div class="form-grid">
               <div class="form-group">
-                <label for="cfg-robot-name" class="form-label">Robot Name (Identifier)</label>
-                <input type="text" id="cfg-robot-name" class="form-input" value="scout_pico2" placeholder="e.g. scout_pico2" pattern="^[a-z0-9_]+$">
-                <span class="input-hint">Lowercase alphanumeric & underscores only</span>
-              </div>
-
-              <div class="form-group">
                 <label for="cfg-topic-prefix" class="form-label">ROS 2 Topic Prefix <span class="badge-optional">Optional</span></label>
                 <input type="text" id="cfg-topic-prefix" class="form-input font-mono" value="" placeholder="e.g. robot1  ->  /robot1/odom/unfiltered">
                 <span class="input-hint">Prepended to every published/subscribed topic (<code>#define TOPIC_PREFIX</code>). Leave blank for bare <code>/cmd_vel</code>, <code>/odom/unfiltered</code>, …</span>
-              </div>
-
-              <div class="form-group">
-                <label for="cfg-kinematics" class="form-label">Kinematics Base Type</label>
-                <select id="cfg-kinematics" class="form-select">
-                  <option value="DIFFERENTIAL_DRIVE" selected>2WD Differential Drive (2 Motors)</option>
-                  <option value="SKID_STEER">4WD Skid Steer (4 Motors)</option>
-                  <option value="MECANUM">4WD Mecanum Drive (4 Motors)</option>
-                </select>
               </div>
 
               <div class="form-group">
@@ -362,27 +368,15 @@
         <!-- Tab 2: Drive & Motors -->
         <div class="tab-pane" id="tab-drive">
           <div class="form-section">
-            <h2 class="section-title">Chassis Geometry & Physics</h2>
+            <h2 class="section-title">Kinematics Base</h2>
             <div class="form-grid">
               <div class="form-group">
-                <label for="cfg-wheel-dia" class="form-label">Wheel Diameter (m)</label>
-                <input type="number" id="cfg-wheel-dia" class="form-input" value="0.08" step="0.005" min="0.01" max="1.0">
-                <span class="input-hint">e.g. 0.08m = 80mm</span>
-              </div>
-              <div class="form-group">
-                <label for="cfg-track-width" class="form-label">Track Width (LR Wheels Distance) (m)</label>
-                <input type="number" id="cfg-track-width" class="form-input" value="0.22" step="0.005" min="0.05" max="2.0">
-                <span class="input-hint">Center-to-center distance between Left and Right wheels</span>
-              </div>
-              <div class="form-group" id="group-wheelbase" style="display: none;">
-                <label for="cfg-wheelbase" class="form-label">Wheelbase (FR Wheels Distance) (m)</label>
-                <input type="number" id="cfg-wheelbase" class="form-input" value="0.20" step="0.005" min="0.05" max="2.0">
-                <span class="input-hint">Front-to-rear axle distance (for 4WD/Mecanum)</span>
-              </div>
-              <div class="form-group">
-                <label for="cfg-weight" class="form-label">Robot Total Weight (kg) <span class="badge-optional">Optional</span></label>
-                <input type="number" id="cfg-weight" class="form-input" value="3.5" step="0.1" min="0.1" max="200.0">
-                <span class="input-hint">Used to calculate max linear acceleration & inertia</span>
+                <label for="cfg-kinematics" class="form-label">Kinematics Base Type</label>
+                <select id="cfg-kinematics" class="form-select">
+                  <option value="DIFFERENTIAL_DRIVE" selected>2WD Differential Drive (2 Motors)</option>
+                  <option value="SKID_STEER">4WD Skid Steer (4 Motors)</option>
+                  <option value="MECANUM">4WD Mecanum Drive (4 Motors)</option>
+                </select>
               </div>
             </div>
           </div>
@@ -439,6 +433,32 @@
               </div>
             </div>
 
+          </div>
+
+          <div class="form-section">
+            <h2 class="section-title">Chassis Geometry &amp; Physics</h2>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="cfg-wheel-dia" class="form-label">Wheel Diameter (m)</label>
+                <input type="number" id="cfg-wheel-dia" class="form-input" value="0.08" step="0.005" min="0.01" max="1.0">
+                <span class="input-hint">e.g. 0.08m = 80mm</span>
+              </div>
+              <div class="form-group">
+                <label for="cfg-track-width" class="form-label">Track Width (LR Wheels Distance) (m)</label>
+                <input type="number" id="cfg-track-width" class="form-input" value="0.22" step="0.005" min="0.05" max="2.0">
+                <span class="input-hint">Center-to-center distance between Left and Right wheels</span>
+              </div>
+              <div class="form-group" id="group-wheelbase" style="display: none;">
+                <label for="cfg-wheelbase" class="form-label">Wheelbase (FR Wheels Distance) (m)</label>
+                <input type="number" id="cfg-wheelbase" class="form-input" value="0.20" step="0.005" min="0.05" max="2.0">
+                <span class="input-hint">Front-to-rear axle distance (for 4WD/Mecanum)</span>
+              </div>
+              <div class="form-group">
+                <label for="cfg-weight" class="form-label">Robot Total Weight (kg) <span class="badge-optional">Optional</span></label>
+                <input type="number" id="cfg-weight" class="form-input" value="3.5" step="0.1" min="0.1" max="200.0">
+                <span class="input-hint">Used to calculate max linear acceleration &amp; inertia</span>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -936,13 +956,8 @@
 
             <!-- 4. Merge Generated Headers & Git Commit -->
             <h3 class="sub-title mt-4">🔀 4. Merge Generated Headers & Git Commit Automation</h3>
+            <p class="input-hint" style="margin-bottom:0.5rem;">Runs on the <strong>Branch</strong> set in the header (top-right) — <strong>Run Merge &amp; Commit</strong> checks that branch out first, creating it if it doesn't exist.</p>
             <div class="form-grid">
-              <div class="form-group">
-                <label for="auto-git-branch" class="form-label">Git Branch Name</label>
-                <input type="text" id="auto-git-branch" class="form-input" data-auto-managed="true" value="config/scout_pico2" placeholder="e.g. config/scout_pico2">
-                <span class="input-hint">Auto-created branch for isolated testing</span>
-              </div>
-
               <div class="form-group">
                 <label for="auto-git-commit-msg" class="form-label">Git Commit Message</label>
                 <input type="text" id="auto-git-commit-msg" class="form-input" data-auto-managed="true" value="feat(config): add configuration for scout_pico2" placeholder="Commit message">

--- a/tools/robot_config_engine/web/index.html
+++ b/tools/robot_config_engine/web/index.html
@@ -1,0 +1,1604 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Linorobot2 | Robot Configuration Engine</title>
+  <meta name="description" content="Automated Hardware Rule Validator, Kinematics Physics Calculator, and Firmware / ROS 2 Code Generator for Linorobot2.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <!-- Background Glow Accents -->
+  <div class="bg-glow glow-1"></div>
+  <div class="bg-glow glow-2"></div>
+  <div class="bg-glow glow-3"></div>
+
+  <!-- Top Navigation Header -->
+  <header class="app-header">
+    <div class="header-brand">
+      <div class="brand-logo">
+        <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="12" cy="12" r="9" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="9" cy="10" r="1.5" fill="currentColor"/>
+          <circle cx="15" cy="10" r="1.5" fill="currentColor"/>
+          <path d="M8 15h8" stroke-linecap="round"/>
+          <path d="M12 3v-2" stroke-linecap="round"/>
+          <circle cx="12" cy="1" r="1" fill="currentColor"/>
+          <path d="M3 12H1M23 12h-2" stroke-linecap="round"/>
+        </svg>
+      </div>
+      <div>
+        <h1 class="brand-title">Linorobot2 <span class="badge-accent">Config Engine</span></h1>
+        <p class="brand-subtitle">AI Hardware Rule Validator & Code Generator</p>
+      </div>
+    </div>
+
+    <div class="header-actions">
+      <!-- Preset Quick Loader -->
+      <div class="preset-selector-group">
+        <label for="preset-select" class="preset-label">⚡ Reference Build:</label>
+        <select id="preset-select" class="preset-select">
+          <option value="bare" selected>🧩 Bare Module — all pins N/C (safe default)</option>
+          <option value="pico2_diff">⚡ Pico 2 · 2WD Differential · BTS7960 (Fake IMU)</option>
+          <option value="pico2_mecanum">⚡ Pico 2 · 4WD Mecanum · BTS7960 (Fake IMU)</option>
+          <option value="pico2_skid">⚡ Pico 2 · 4WD Skid Steer · BTS7960 (Fake IMU)</option>
+          <option value="scout_pico2">Raspberry Pi Pico 2 (2WD Diff + TB6612 / L298N)</option>
+          <option value="mech_pico2">Raspberry Pi Pico 2 (4WD Mecanum + TB6612)</option>
+          <option value="mech_esp32">ESP32 (4WD Mecanum + WiFi UDP + BNO085)</option>
+          <option value="crawler_esp32s3">ESP32-S3 (4WD Skid + Sonar + ADC)</option>
+          <option value="waveshare_gendrv">Waveshare General Driver (ESP32 + BTS7960)</option>
+        </select>
+      </div>
+
+      <!-- OS Quick Indicator -->
+      <div class="os-quick-badge" id="header-os-badge" title="Auto-Detected Client Environment">
+        <span class="os-badge-icon" id="header-os-icon">🐧</span>
+        <span class="os-badge-text" id="header-os-text">Detecting OS...</span>
+      </div>
+
+      <button id="btn-quick-deploy" class="btn btn-accent" title="Jump to Automation Hub">
+        <span class="tab-icon">🚀</span>
+        <span>Deploy & Flash</span>
+      </button>
+
+      <!-- Action Buttons -->
+      <button id="btn-load-board" class="btn btn-secondary" title="Load board configuration from firmware/platformio.ini">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
+        </svg>
+        <span>Load Board Config</span>
+      </button>
+      <label class="btn btn-ghost btn-sm" for="import-json-file" title="Import saved JSON specification" style="font-size:0.78rem;padding:4px 10px;">
+        <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/>
+        </svg>
+        <span>Import JSON</span>
+        <input type="file" id="import-json-file" accept=".json" style="display: none;">
+      </label>
+
+      <button id="btn-export-json" class="btn btn-primary" title="Export complete JSON specification">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/>
+        </svg>
+        <span>Export Spec</span>
+      </button>
+
+      <a href="https://github.com/linorobot/linorobot2_hardware" target="_blank" rel="noopener noreferrer" class="github-link" title="Linorobot2 Hardware on GitHub">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
+        </svg>
+      </a>
+    </div>
+  </header>
+
+  <!-- Main Grid App Container -->
+  <main class="app-container">
+
+    <!-- Left Column: Configurator Panels -->
+    <section class="config-panel">
+      <!-- Nav Tabs -->
+      <nav class="nav-tabs" role="tablist">
+        <button class="nav-tab active" data-tab="tab-base" id="btn-tab-base">
+          <span class="tab-icon">🤖</span>
+          <span>1. Base & MCU</span>
+        </button>
+        <button class="nav-tab" data-tab="tab-drive" id="btn-tab-drive">
+          <span class="tab-icon">⚙️</span>
+          <span>2. Drive & Motors</span>
+        </button>
+        <button class="nav-tab" data-tab="tab-sensors" id="btn-tab-sensors">
+          <span class="tab-icon">🧭</span>
+          <span>3. Sensors</span>
+        </button>
+        <button class="nav-tab" data-tab="tab-pins" id="btn-tab-pins">
+          <span class="tab-icon">🔌</span>
+          <span>4. Pinout Matrix</span>
+        </button>
+        <button class="nav-tab" data-tab="tab-automation" id="btn-tab-automation">
+          <span class="tab-icon">🚀</span>
+          <span>5. Automation & Flash</span>
+        </button>
+      </nav>
+
+      <!-- Form Content Area -->
+      <div class="tab-content-wrapper">
+
+        <!-- Tab 1: Base & MCU -->
+        <div class="tab-pane active" id="tab-base">
+          <div class="form-section">
+            <h2 class="section-title">Robot Identity & Microcontroller</h2>
+
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="cfg-robot-name" class="form-label">Robot Name (Identifier)</label>
+                <input type="text" id="cfg-robot-name" class="form-input" value="scout_pico2" placeholder="e.g. scout_pico2" pattern="^[a-z0-9_]+$">
+                <span class="input-hint">Lowercase alphanumeric & underscores only</span>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-topic-prefix" class="form-label">ROS 2 Topic Prefix <span class="badge-optional">Optional</span></label>
+                <input type="text" id="cfg-topic-prefix" class="form-input font-mono" value="" placeholder="e.g. robot1  ->  /robot1/odom/unfiltered">
+                <span class="input-hint">Prepended to every published/subscribed topic (<code>#define TOPIC_PREFIX</code>). Leave blank for bare <code>/cmd_vel</code>, <code>/odom/unfiltered</code>, …</span>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-kinematics" class="form-label">Kinematics Base Type</label>
+                <select id="cfg-kinematics" class="form-select">
+                  <option value="DIFFERENTIAL_DRIVE" selected>2WD Differential Drive (2 Motors)</option>
+                  <option value="SKID_STEER">4WD Skid Steer (4 Motors)</option>
+                  <option value="MECANUM">4WD Mecanum Drive (4 Motors)</option>
+                </select>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-mcu" class="form-label">Microcontroller Unit (MCU)</label>
+                <select id="cfg-mcu" class="form-select">
+                  <option value="PICO2W" selected>Raspberry Pi Pico 2 W (RP2350 + WiFi for OTA/Syslog)</option>
+                  <option value="PICO2">Raspberry Pi Pico 2 (RP2350 - Native USB CDC)</option>
+                  <option value="PICOW">Raspberry Pi Pico W (RP2040 + WiFi for OTA/Syslog)</option>
+                  <option value="PICO">Raspberry Pi Pico (RP2040 - Native USB CDC)</option>
+                  <option value="ESP32">Espressif ESP32 (Dual Core / WiFi & Bluetooth)</option>
+                  <option value="ESP32S3">Espressif ESP32-S3 (SuperMini / Native USB CDC)</option>
+                  <option value="ESP32S2">Espressif ESP32-S2 (Single Core)</option>
+                  <option value="GENDRV">Waveshare ESP32 General Driver Board</option>
+                </select>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-transport" class="form-label">micro-ROS Transport</label>
+                <select id="cfg-transport" class="form-select">
+                  <option value="SERIAL" selected>USB Serial Transport (/dev/ttyACM0 or /dev/ttyUSB0)</option>
+                  <option value="WIFI_UDP">WiFi UDP (Micro-ROS Agent on Host)</option>
+                </select>
+              </div>
+
+              <div class="form-group" id="group-serial-baudrate">
+                <label for="cfg-baudrate" class="form-label">Serial Communication Baud Rate</label>
+                <select id="cfg-baudrate" class="form-select font-mono">
+                  <option value="1500000">1500000 (1.5M Baud — High-Throughput ESP32 / GenDrv CP2102N)</option>
+                  <option value="921600" selected>921600 (micro-ROS & Diagnostics Baseline)</option>
+                  <option value="460800">460800</option>
+                  <option value="230400">230400</option>
+                  <option value="115200">115200 (Legacy / Low Speed)</option>
+                </select>
+                <span class="input-hint">High-speed 1.5M / 921.6k baud ensures multi-topic 50.0 Hz telemetry throughput.</span>
+              </div>
+
+              <div class="form-group" id="group-serial-interface">
+                <label for="cfg-serial-interface" class="form-label">Serial Interface (ESP32-S2 / ESP32-S3)</label>
+                <select id="cfg-serial-interface" class="form-select">
+                  <option value="CDC" selected>Native USB CDC (/dev/ttyACM0) — Direct On-Chip USB</option>
+                  <option value="BRIDGE">USB-to-UART Bridge (/dev/ttyUSB0) — CP2102/CH340/FTDI</option>
+                </select>
+                <span class="input-hint">Select whether your S2/S3 board uses native USB CDC or an onboard USB-UART bridge.</span>
+              </div>
+
+              <div class="form-group" id="group-wifi-telemetry">
+                <label class="checkbox-label" style="margin-top: 10px;">
+                  <input type="checkbox" id="cfg-wifi-telemetry" checked>
+                  <span><strong>Enable Background WiFi for OTA & Syslog</strong> (Pico W / Pico 2 W / ESP32)</span>
+                </label>
+                <span class="input-hint">Keeps micro-ROS on USB Serial while enabling wireless OTA flashing & Syslog</span>
+              </div>
+
+              <div class="form-group" id="group-dual-core">
+                <label class="checkbox-label" style="margin-top: 10px;">
+                  <input type="checkbox" id="cfg-dual-core" checked>
+                  <span><strong>Enable Dual-Core Task Allocation (Strict 50Hz Real-Time PID on Core 1)</strong> (ESP32)</span>
+                </label>
+                <span class="input-hint">Pins high-priority motor PID and encoder loop to Core 1 via FreeRTOS vTaskDelayUntil (20ms), isolating motor control from I2C bus and communication latency</span>
+              </div>
+
+              <div class="form-group" id="group-wdt">
+                <label class="checkbox-label" style="margin-top: 10px;">
+                  <input type="checkbox" id="cfg-wdt-enable">
+                  <span><strong>Enable Hardware Task Watchdog (WDT)</strong> (ESP32 / Pico)</span>
+                </label>
+                <span class="input-hint">Automatically resets MCU if main control loop hangs or micro-ROS locks up</span>
+              </div>
+
+              <div class="form-group" id="group-wdt-timeout" style="display: none;">
+                <label for="cfg-wdt-timeout" class="form-label">Watchdog Timeout (Seconds)</label>
+                <input type="number" id="cfg-wdt-timeout" class="form-input" value="60" min="1" max="300" step="1">
+                <span class="input-hint">Timeout period (default: 60s, recommended: 30–60s)</span>
+              </div>
+            </div>
+
+            <!-- WiFi Details (Conditional) -->
+            <div id="wifi-config-box" class="sub-panel" style="display: none;">
+              <h3 class="sub-title">📶 WiFi & micro-ROS Agent Settings</h3>
+              <div class="form-grid">
+                <div class="form-group">
+                  <label for="cfg-wifi-ssid" class="form-label">WiFi SSID</label>
+                  <input type="text" id="cfg-wifi-ssid" class="form-input" value="YOUR_WIFI_SSID">
+                </div>
+                <div class="form-group">
+                  <label for="cfg-wifi-pass" class="form-label">WiFi Password</label>
+                  <input type="password" id="cfg-wifi-pass" class="form-input" value="YOUR_WIFI_PASSWORD">
+                  <label class="checkbox-label" style="margin-top:4px;font-size:0.78rem;">
+                    <input type="checkbox" id="cfg-wifi-pass-show"> <span>Show password</span>
+                  </label>
+                </div>
+                <div class="form-group">
+                  <label for="cfg-agent-ip" class="form-label">Agent Host IP Address</label>
+                  <input type="text" id="cfg-agent-ip" class="form-input" value="192.168.1.100" data-auto-managed="true">
+                </div>
+                <div class="form-group">
+                  <label for="cfg-agent-port" class="form-label">Agent UDP Port</label>
+                  <input type="number" id="cfg-agent-port" class="form-input" value="8888">
+                </div>
+              </div>
+              <!-- UDP Syslog Server & Streamer Card -->
+              <div class="syslog-card" id="syslog-config-card">
+                <div class="syslog-header">
+                  <div class="syslog-title-wrap">
+                    <span class="syslog-icon">📡</span>
+                    <div>
+                      <h4 class="syslog-title">UDP Syslog Server & Telemetry Logger</h4>
+                      <span class="input-hint" style="margin:0;">Receives real-time wireless debug telemetry from robot MCU and saves to <code>logs/</code></span>
+                    </div>
+                  </div>
+                  <div class="syslog-status-badge stopped" id="syslog-status-badge">
+                    <span class="pulse-dot" id="syslog-status-dot"></span>
+                    <span id="syslog-status-text">Syslog: Offline</span>
+                  </div>
+                </div>
+
+                <div class="syslog-controls-grid">
+                  <div class="form-group" style="margin-bottom:0;">
+                    <label for="cfg-syslog-ip" class="form-label">Syslog Server IP</label>
+                    <input type="text" id="cfg-syslog-ip" class="form-input font-mono" value="192.168.1.100" data-auto-managed="true" placeholder="host running the UI">
+                    <span class="input-hint">Auto-set to this host when you launch the server below</span>
+                  </div>
+                  <div class="form-group" style="margin-bottom:0;">
+                    <label for="cfg-syslog-port" class="form-label">Syslog UDP Port</label>
+                    <input type="number" id="cfg-syslog-port" class="form-input font-mono" value="514" placeholder="514 or 5140">
+                  </div>
+                  <div class="btn-group-row" style="margin-top:0;">
+                    <button type="button" id="btn-syslog-start" class="btn btn-sm btn-primary flex-1" title="Launch background UDP Syslog receiver">
+                      <span>▶️ Launch Syslog Server</span>
+                    </button>
+                    <button type="button" id="btn-syslog-stop" class="btn btn-sm btn-danger flex-1" style="display:none;" title="Stop UDP Syslog receiver">
+                      <span>⏹️ Stop Server</span>
+                    </button>
+                    <button type="button" id="btn-syslog-view-logs" class="btn btn-sm btn-ghost" title="Inspect recent syslog files in logs/">
+                      <span>📂 Logs</span>
+                    </button>
+                  </div>
+                </div>
+
+                <div class="syslog-stats-bar" id="syslog-stats-bar">
+                  <div class="syslog-stat-item">
+                    <span class="syslog-stat-label">Active Log:</span>
+                    <span class="syslog-stat-val" id="syslog-stat-file">logs/syslog_YYYYMMDD.log</span>
+                  </div>
+                  <div class="syslog-stat-item">
+                    <span class="syslog-stat-label">Packets:</span>
+                    <span class="syslog-stat-val" id="syslog-stat-packets">0</span>
+                  </div>
+                  <div class="syslog-stat-item">
+                    <span class="syslog-stat-label">Last Client:</span>
+                    <span class="syslog-stat-val" id="syslog-stat-client">--</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- LiDAR over WiFi UDP -->
+              <div class="sub-panel">
+                <h3 class="sub-title">🛰️ LiDAR over WiFi UDP</h3>
+                <label class="checkbox-label">
+                  <input type="checkbox" id="cfg-lidar-udp">
+                  <span>Forward raw LiDAR serial frames to a host over UDP</span>
+                </label>
+                <div class="form-grid mt-2">
+                  <div class="form-group">
+                    <label for="cfg-lidar-ip" class="form-label">LiDAR UDP Server IP</label>
+                    <input type="text" id="cfg-lidar-ip" class="form-input font-mono" value="192.168.1.100" data-auto-managed="true">
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-lidar-port" class="form-label">LiDAR UDP Port</label>
+                    <input type="number" id="cfg-lidar-port" class="form-input font-mono" value="8889">
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-lidar-uart" class="form-label">LiDAR UART Number</label>
+                    <input type="number" id="cfg-lidar-uart" class="form-input" value="1" min="0" max="3">
+                    <span class="input-hint">Fixed 230400 baud (hardware)</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Arduino OTA (settings — the "flash over OTA" action toggle is on Tab 5 §5) -->
+              <div class="sub-panel">
+                <h3 class="sub-title">📶 Arduino OTA (wireless flashing)</h3>
+                <span class="input-hint">Turn OTA flashing on/off next to the upload buttons on Tab 5 → “5. Standalone …”.</span>
+                <div class="form-grid mt-2">
+                  <div class="form-group">
+                    <label for="cfg-ota-ip" class="form-label">Device IP (OTA target)</label>
+                    <input type="text" id="cfg-ota-ip" class="form-input font-mono" value="" data-auto-managed="true" placeholder="auto from syslog / mDNS">
+                    <span class="input-hint">Filled from the last syslog client when available</span>
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-ota-hostname" class="form-label">mDNS Hostname</label>
+                    <input type="text" id="cfg-ota-hostname" class="form-input font-mono" value="" data-auto-managed="true" placeholder="robot name">
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-ota-password" class="form-label">OTA Password <span class="badge-optional">Optional</span></label>
+                    <input type="password" id="cfg-ota-password" class="form-input" value="">
+                    <label class="checkbox-label" style="margin-top:4px;font-size:0.78rem;">
+                      <input type="checkbox" id="cfg-ota-password-show"> <span>Show password</span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+
+
+            </div>
+          </div>
+        </div>
+
+        <!-- Tab 2: Drive & Motors -->
+        <div class="tab-pane" id="tab-drive">
+          <div class="form-section">
+            <h2 class="section-title">Chassis Geometry & Physics</h2>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="cfg-wheel-dia" class="form-label">Wheel Diameter (m)</label>
+                <input type="number" id="cfg-wheel-dia" class="form-input" value="0.08" step="0.005" min="0.01" max="1.0">
+                <span class="input-hint">e.g. 0.08m = 80mm</span>
+              </div>
+              <div class="form-group">
+                <label for="cfg-track-width" class="form-label">Track Width (LR Wheels Distance) (m)</label>
+                <input type="number" id="cfg-track-width" class="form-input" value="0.22" step="0.005" min="0.05" max="2.0">
+                <span class="input-hint">Center-to-center distance between Left and Right wheels</span>
+              </div>
+              <div class="form-group" id="group-wheelbase" style="display: none;">
+                <label for="cfg-wheelbase" class="form-label">Wheelbase (FR Wheels Distance) (m)</label>
+                <input type="number" id="cfg-wheelbase" class="form-input" value="0.20" step="0.005" min="0.05" max="2.0">
+                <span class="input-hint">Front-to-rear axle distance (for 4WD/Mecanum)</span>
+              </div>
+              <div class="form-group">
+                <label for="cfg-weight" class="form-label">Robot Total Weight (kg) <span class="badge-optional">Optional</span></label>
+                <input type="number" id="cfg-weight" class="form-input" value="3.5" step="0.1" min="0.1" max="200.0">
+                <span class="input-hint">Used to calculate max linear acceleration & inertia</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <h2 class="section-title">Motor Driver & Encoder Specifications</h2>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="cfg-driver-type" class="form-label">Motor Driver Type</label>
+                <select id="cfg-driver-type" class="form-select">
+                  <option value="BTS7960" selected>2 output pins — dual PWM, no enable (BTS7960 / DRV8833 / TB6612 / L298N driven PWM-only) — Recommended, saves I/O</option>
+                  <option value="GENERIC_2_IN">3 output pins — 2 direction + 1 enable/PWM (L298N or TB6612 with STBY, VNH5019)</option>
+                  <option value="GENERIC_1_IN">2 output pins — PWM + single direction (Cytron MD10C)</option>
+                  <option value="ESC">1 output pin — RC / ESC servo PWM</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label for="cfg-max-rpm" class="form-label">Rated Motor Max RPM</label>
+                <input type="number" id="cfg-max-rpm" class="form-input" value="400" min="10" max="5000">
+                <span class="input-hint">Max unloaded or rated RPM under operating voltage</span>
+              </div>
+              <div class="form-group">
+                <label for="cfg-cpr" class="form-label">Encoder Counts Per Revolution (CPR)</label>
+                <input type="number" id="cfg-cpr" class="form-input" value="1440" min="10" max="100000">
+                <span class="input-hint">Total quadrature ticks per full wheel turn</span>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Velocity PID Constants <span class="badge-optional">per-wheel closed loop</span></label>
+                <div class="form-grid" style="grid-template-columns:repeat(3,1fr);gap:8px;">
+                  <div>
+                    <label for="cfg-pid-kp" class="input-hint" style="display:block;">K_P</label>
+                    <input type="number" id="cfg-pid-kp" class="form-input font-mono" value="0.6" step="0.05" min="0">
+                  </div>
+                  <div>
+                    <label for="cfg-pid-ki" class="input-hint" style="display:block;">K_I</label>
+                    <input type="number" id="cfg-pid-ki" class="form-input font-mono" value="0.8" step="0.05" min="0">
+                  </div>
+                  <div>
+                    <label for="cfg-pid-kd" class="input-hint" style="display:block;">K_D</label>
+                    <input type="number" id="cfg-pid-kd" class="form-input font-mono" value="0.5" step="0.05" min="0">
+                  </div>
+                </div>
+                <span class="input-hint">Motor RPM PID gains (<code>K_P</code> / <code>K_I</code> / <code>K_D</code>). Defaults 0.6 / 0.8 / 0.5.</span>
+              </div>
+              <div class="form-group">
+                <label for="cfg-motor-voltage" class="form-label">Motor Operating Voltage (V)</label>
+                <input type="number" id="cfg-motor-voltage" class="form-input" value="12.0" step="0.5">
+              </div>
+              <div class="form-group">
+                <label for="cfg-motor-torque" class="form-label">Motor Rated Torque (kg·cm) <span class="badge-optional">Optional</span></label>
+                <input type="number" id="cfg-motor-torque" class="form-input" value="1.5" step="0.1" min="0.1" max="100.0">
+                <span class="input-hint">Rated / Stall torque per motor (1.5 kg·cm = 0.15 N·m)</span>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+        <!-- Tab 3: Sensors -->
+        <div class="tab-pane" id="tab-sensors">
+          <!-- AI I2C Sensor Auto-Detection Card -->
+          <div class="card p-3 mb-3 border-accent-glow" style="background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.7)); border: 1px solid rgba(56, 189, 248, 0.3); border-radius: 8px; margin-bottom: 1.25rem;">
+            <div class="flex-between" style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+              <div>
+                <h4 style="color:#38bdf8; font-size:1.05rem; margin-bottom:0.25rem; font-weight: 600;">🤖 AI I2C Sensor Auto-Detection</h4>
+                <p class="text-muted" style="font-size:0.85rem; margin:0;">Probe active I2C bus, identify IMU / Mag / Current sensor chips via WHO_AM_I registers, and auto-select matching drivers.</p>
+              </div>
+              <button type="button" id="btn-auto-detect-i2c" class="btn btn-accent" style="white-space:nowrap; padding:0.6rem 1.2rem; cursor: pointer;">
+                <span class="btn-icon">⚡</span>
+                <span><strong>Auto-Detect Sensors</strong></span>
+              </button>
+            </div>
+            <div id="i2c-detect-results" class="mt-2" style="display:none; padding:0.6rem; background:rgba(0,0,0,0.3); border-radius:6px; font-size:0.85rem; margin-top: 0.75rem;"></div>
+          </div>
+
+          <div class="form-section">
+            <h2 class="section-title">IMU, Magnetometer & Battery Peripherals</h2>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="cfg-imu" class="form-label">Inertial Measurement Unit (IMU)</label>
+                <select id="cfg-imu" class="form-select">
+                  <option value="FAKE" selected>Fake IMU (Bare Module Default — Zero Drift / Zero Hang)</option>
+                  <option value="BNO085">BNO085 / BNO080 (State-machine recovery & onboard fusion)</option>
+                  <option value="MPU6050">MPU6050 (6-DOF Accelerometer & Gyroscope)</option>
+                  <option value="QMI8658">QMI8658 (Waveshare on-board IMU)</option>
+                  <option value="MPU9250">MPU9250 (9-DOF IMU + Compass)</option>
+                  <option value="NONE">None (Disabled)</option>
+                </select>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-mag" class="form-label">Magnetometer (Digital Compass)</label>
+                <select id="cfg-mag" class="form-select">
+                  <option value="NONE" selected>Fake Magnetometer (Default / Estimated)</option>
+                  <option value="QMC5883L">QMC5883L (I2C Digital Compass)</option>
+                  <option value="AK09918">AK09918 (I2C Digital Compass)</option>
+                  <option value="HMC5883L">HMC5883L (Legacy Compass)</option>
+                </select>
+              </div>
+
+              <div class="form-group" id="group-imu-tuning">
+                <label class="form-label">Magnetometer Hard-Iron Bias <span class="badge-optional">Optional</span></label>
+                <div class="form-grid" style="grid-template-columns:repeat(3,1fr);gap:8px;">
+                  <div>
+                    <label for="cfg-mag-bias-x" class="input-hint" style="display:block;">X (µT)</label>
+                    <input type="number" id="cfg-mag-bias-x" class="form-input font-mono" value="" step="0.1" placeholder="0">
+                  </div>
+                  <div>
+                    <label for="cfg-mag-bias-y" class="input-hint" style="display:block;">Y (µT)</label>
+                    <input type="number" id="cfg-mag-bias-y" class="form-input font-mono" value="" step="0.1" placeholder="0">
+                  </div>
+                  <div>
+                    <label for="cfg-mag-bias-z" class="input-hint" style="display:block;">Z (µT)</label>
+                    <input type="number" id="cfg-mag-bias-z" class="form-input font-mono" value="" step="0.1" placeholder="0">
+                  </div>
+                </div>
+                <span class="input-hint">Subtracted from each raw reading (<code>#define MAG_BIAS</code>). Leave all blank to skip.</span>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">IMU Covariance Overrides <span class="badge-optional">Optional</span></label>
+                <div class="form-grid" style="grid-template-columns:repeat(3,1fr);gap:8px;">
+                  <div>
+                    <label for="cfg-cov-accel" class="input-hint" style="display:block;">ACCEL_COV</label>
+                    <input type="number" id="cfg-cov-accel" class="form-input font-mono" value="" step="0.0001" placeholder="0.00001">
+                  </div>
+                  <div>
+                    <label for="cfg-cov-gyro" class="input-hint" style="display:block;">GYRO_COV</label>
+                    <input type="number" id="cfg-cov-gyro" class="form-input font-mono" value="" step="0.0001" placeholder="0.00001">
+                  </div>
+                  <div>
+                    <label for="cfg-cov-ori" class="input-hint" style="display:block;">ORI_COV</label>
+                    <input type="number" id="cfg-cov-ori" class="form-input font-mono" value="" step="0.0001" placeholder="0.00001">
+                  </div>
+                </div>
+                <span class="input-hint">Diagonal covariance for the <code>/imu/data*</code> message. Blank = firmware default (0.00001).</span>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-battery" class="form-label">Battery Voltage Monitoring</label>
+                <select id="cfg-battery" class="form-select">
+                  <option value="NONE" selected>None (Bare Module Default)</option>
+                  <option value="ADC_DIVIDER">ADC Resistor Voltage Divider (R1: 30kΩ, R2: 7.5kΩ)</option>
+                  <option value="INA219">INA219 (I2C Current & Voltage Sensor)</option>
+                </select>
+              </div>
+
+              <!-- Battery Parameters Sub-Panel -->
+              <div id="battery-params-box" class="sub-panel">
+                <h3 class="sub-title">🔋 Battery Capacity & Voltage Specs</h3>
+                <div class="form-grid">
+                  <div class="form-group">
+                    <label for="cfg-bat-cap" class="form-label">Battery Capacity (Ah)</label>
+                    <input type="number" id="cfg-bat-cap" class="form-input" value="2.2" step="0.1" min="0.1" max="100.0">
+                    <span class="input-hint">Rated capacity (enables /battery remaining capacity)</span>
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-bat-nom" class="form-label">Nominal Voltage (V)</label>
+                    <input type="number" id="cfg-bat-nom" class="form-input" value="11.1" step="0.1" min="1.0" max="60.0">
+                    <span class="input-hint">e.g. 11.1V (3S LiPo), 12.0V, 24.0V</span>
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-bat-min" class="form-label">Min Cutoff Voltage (0% V)</label>
+                    <input type="number" id="cfg-bat-min" class="form-input" value="9.0" step="0.1" min="1.0" max="50.0">
+                    <span class="input-hint">Low-voltage cutoff threshold</span>
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-bat-max" class="form-label">Max Full Voltage (100% V)</label>
+                    <input type="number" id="cfg-bat-max" class="form-input" value="12.6" step="0.1" min="1.0" max="65.0">
+                    <span class="input-hint">Full charge voltage threshold</span>
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-bat-dip" class="form-label">Voltage Drop Alert (DIP Ratio)</label>
+                    <input type="number" id="cfg-bat-dip" class="form-input" value="0.98" step="0.01" min="0.5" max="1.0">
+                    <span class="input-hint">Alert threshold for transient sag</span>
+                  </div>
+                </div>
+
+                <!-- Voltage Divider Resistors & Filter Capacitor Config -->
+                <div id="adc-divider-config-box" class="mt-3">
+                  <h4 class="sub-title-sm">⚡ ADC Voltage Divider Resistors & Noise Filter</h4>
+                  <div class="form-grid">
+                    <div class="form-group">
+                      <label for="cfg-bat-r1" class="form-label">Upper Resistor R1 (Ω)</label>
+                      <input type="number" id="cfg-bat-r1" class="form-input" value="30000" step="100" min="100" max="1000000">
+                      <span class="input-hint">High-side resistor to +VBAT (e.g. 30kΩ, 33kΩ, 10kΩ)</span>
+                    </div>
+                    <div class="form-group">
+                      <label for="cfg-bat-r2" class="form-label">Lower Resistor R2 (Ω)</label>
+                      <input type="number" id="cfg-bat-r2" class="form-input" value="7500" step="100" min="100" max="1000000">
+                      <span class="input-hint">Low-side resistor to GND (e.g. 7.5kΩ, 10kΩ, 1kΩ)</span>
+                    </div>
+                    <div class="form-group">
+                      <label for="cfg-bat-cap" class="form-label">ADC Filter Capacitor C (pF)</label>
+                      <input type="number" id="cfg-bat-cap-val" class="form-input" value="1000" step="100" min="0" max="100000">
+                      <span class="input-hint">Parallel capacitor to GND (1000pF / 1nF recommended)</span>
+                    </div>
+                  </div>
+
+                  <!-- Real-time ADC Voltage & 3.0V Safety Warning Banner -->
+                  <div id="bat-adc-safety-banner" class="adc-safety-banner safe">
+                    <div class="safety-banner-icon" id="safety-banner-icon">🛡️</div>
+                    <div class="safety-banner-content">
+                      <div class="safety-banner-title" id="safety-banner-title">ADC Input Voltage: Safe (&le; 3.0V)</div>
+                      <div class="safety-banner-desc" id="safety-banner-desc">
+                        Divider Ratio: <code id="lbl-divider-ratio">0.2000 (1:5)</code> | Max ADC Pin Voltage: <code id="lbl-adc-max-v">2.52 V</code> at full charge (12.6V).
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-sonar" class="form-label">Ultrasonic Sonar Range Sensor</label>
+                <select id="cfg-sonar" class="form-select">
+                  <option value="false" selected>Disabled (Bare Module Default)</option>
+                  <option value="true">Enabled (HC-SR04 on /sonar)</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Tab 4: Pinout Matrix -->
+        <div class="tab-pane" id="tab-pins">
+          <div class="form-section">
+            <div class="section-header-flex">
+              <h2 class="section-title">Microcontroller Pin Allocation</h2>
+              <button id="btn-smart-alloc" class="btn btn-sm btn-accent" title="Auto-assign verified conflict-free pins">
+                <span>⚡ Smart Auto-Assign</span>
+              </button>
+            </div>
+
+            <!-- LED Pin -->
+            <div class="form-grid mb-3">
+              <div class="form-group">
+                <label for="pin-led" class="form-label">Status LED Pin (GPIO)</label>
+                <input type="number" id="pin-led" class="form-input pin-input" value="25">
+              </div>
+            </div>
+
+            <!-- Motor Pins -->
+            <h3 class="sub-title">🏎️ Motor Driver Pins</h3>
+            <div class="pin-table-wrapper">
+              <table class="pin-table">
+                <thead>
+                  <tr id="motor-pin-headers">
+                    <th>Motor</th>
+                    <th>PWM / PWM_R</th>
+                    <th>IN_A / PWM_L</th>
+                    <th>IN_B / EN</th>
+                    <th title="Invert motor spin direction">Invert</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><strong>Motor 1 (Left)</strong></td>
+                    <td><input type="number" id="pin-m1-p1" class="form-input pin-input" value="14"></td>
+                    <td><input type="number" id="pin-m1-p2" class="form-input pin-input" value="15"></td>
+                    <td><input type="number" id="pin-m1-p3" class="form-input pin-input" value="13"></td>
+                  <td style="text-align:center;"><input type="checkbox" id="pin-m1-inv"></td>
+                  </tr>
+                  <tr>
+                    <td><strong>Motor 2 (Right)</strong></td>
+                    <td><input type="number" id="pin-m2-p1" class="form-input pin-input" value="16"></td>
+                    <td><input type="number" id="pin-m2-p2" class="form-input pin-input" value="17"></td>
+                    <td><input type="number" id="pin-m2-p3" class="form-input pin-input" value="12"></td>
+                  <td style="text-align:center;"><input type="checkbox" id="pin-m2-inv" checked></td>
+                  </tr>
+                  <tr id="row-motor-3" style="display: none;">
+                    <td><strong>Motor 3 (Rear L)</strong></td>
+                    <td><input type="number" id="pin-m3-p1" class="form-input pin-input" value="8"></td>
+                    <td><input type="number" id="pin-m3-p2" class="form-input pin-input" value="9"></td>
+                    <td><input type="number" id="pin-m3-p3" class="form-input pin-input" value="10"></td>
+                  <td style="text-align:center;"><input type="checkbox" id="pin-m3-inv"></td>
+                  </tr>
+                  <tr id="row-motor-4" style="display: none;">
+                    <td><strong>Motor 4 (Rear R)</strong></td>
+                    <td><input type="number" id="pin-m4-p1" class="form-input pin-input" value="11"></td>
+                    <td><input type="number" id="pin-m4-p2" class="form-input pin-input" value="18"></td>
+                    <td><input type="number" id="pin-m4-p3" class="form-input pin-input" value="19"></td>
+                  <td style="text-align:center;"><input type="checkbox" id="pin-m4-inv" checked></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <!-- Encoder Pins -->
+            <h3 class="sub-title mt-4">📟 Encoder Quadrature Pins</h3>
+            <div class="pin-table-wrapper">
+              <table class="pin-table">
+                <thead>
+                  <tr>
+                    <th>Channel</th>
+                    <th>Encoder Pin A (Interrupt)</th>
+                    <th>Encoder Pin B (Direction)</th>
+                    <th title="Invert encoder count direction">Invert</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><strong>Encoder 1 (Left)</strong></td>
+                    <td><input type="number" id="pin-enc-1a" class="form-input pin-input" value="2"></td>
+                    <td><input type="number" id="pin-enc-1b" class="form-input pin-input" value="3"></td>
+                    <td style="text-align:center;"><input type="checkbox" id="pin-enc-1-inv" title="Invert encoder 1 count"></td>
+                  </tr>
+                  <tr>
+                    <td><strong>Encoder 2 (Right)</strong></td>
+                    <td><input type="number" id="pin-enc-2a" class="form-input pin-input" value="4"></td>
+                    <td><input type="number" id="pin-enc-2b" class="form-input pin-input" value="5"></td>
+                    <td style="text-align:center;"><input type="checkbox" id="pin-enc-2-inv" title="Invert encoder 2 count"></td>
+                  </tr>
+                  <tr id="row-enc-3" style="display: none;">
+                    <td><strong>Encoder 3 (Rear L)</strong></td>
+                    <td><input type="number" id="pin-enc-3a" class="form-input pin-input" value="6"></td>
+                    <td><input type="number" id="pin-enc-3b" class="form-input pin-input" value="7"></td>
+                    <td style="text-align:center;"><input type="checkbox" id="pin-enc-3-inv" title="Invert encoder 3 count"></td>
+                  </tr>
+                  <tr id="row-enc-4" style="display: none;">
+                    <td><strong>Encoder 4 (Rear R)</strong></td>
+                    <td><input type="number" id="pin-enc-4a" class="form-input pin-input" value="20"></td>
+                    <td><input type="number" id="pin-enc-4b" class="form-input pin-input" value="21"></td>
+                    <td style="text-align:center;"><input type="checkbox" id="pin-enc-4-inv" title="Invert encoder 4 count"></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <!-- Auxiliary & Bus Pins -->
+            <h3 class="sub-title mt-4">🛰️ I2C Bus & Sensor Pins</h3>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="pin-i2c-sda" class="form-label">I2C SDA Pin</label>
+                <input type="number" id="pin-i2c-sda" class="form-input pin-input" value="8">
+              </div>
+              <div class="form-group">
+                <label for="pin-i2c-scl" class="form-label">I2C SCL Pin</label>
+                <input type="number" id="pin-i2c-scl" class="form-input pin-input" value="9">
+              </div>
+              <div class="form-group" id="box-battery-pin">
+                <label for="pin-battery" class="form-label">Battery ADC Pin</label>
+                <input type="number" id="pin-battery" class="form-input pin-input" value="26">
+                <span class="input-hint">Pico: GP26, GP27, GP28</span>
+              </div>
+              <div class="form-group" id="box-sonar-trig">
+                <label for="pin-sonar-trig" class="form-label">Sonar Trigger Pin</label>
+                <input type="number" id="pin-sonar-trig" class="form-input pin-input" value="18">
+              </div>
+              <div class="form-group" id="box-sonar-echo">
+                <label for="pin-sonar-echo" class="form-label">Sonar Echo Pin</label>
+                <input type="number" id="pin-sonar-echo" class="form-input pin-input" value="19">
+              </div>
+              <div class="form-group" id="box-lidar-rxd">
+                <label for="cfg-lidar-rxd" class="form-label">LiDAR Serial RX Pin</label>
+                <input type="number" id="cfg-lidar-rxd" class="form-input pin-input" value="-1">
+                <span class="input-hint">MCU GPIO wired to the LiDAR TX line (enable LiDAR-UDP on the Sensors tab)</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Tab 5: Automation & Deployment -->
+        <div class="tab-pane" id="tab-automation">
+          <div class="form-section">
+            <h2 class="section-title">🚀 Robot SBC Host Automation & Flashing Hub</h2>
+            <p class="section-desc">Automate your entire workflow directly on the headless Robot Host Computer (e.g. Raspberry Pi 4/5, Jetson Orin, or x86 Mini-PC): detect robot SBC environment, install toolchains, configure ROS 2, merge generated C++ headers, flash connected microcontrollers, and run the micro-ROS agent.</p>
+
+            <!-- Robot Host Detection Banner -->
+            <div class="os-detect-banner" id="os-detect-banner">
+              <div class="os-detect-info">
+                <span class="os-icon-large" id="os-banner-icon">🤖</span>
+                <div>
+                  <div class="os-banner-title">
+                    <span id="os-banner-detected-text">Target Robot SBC: Auto-Detecting...</span>
+                    <span class="badge-pill badge-ok" id="os-banner-status">Robot Host Online</span>
+                  </div>
+                  <p class="os-banner-sub" id="os-banner-sub">Architecture: <strong id="os-banner-arch">aarch64</strong> | Connected MCU Ports: <span id="os-banner-ports" style="color:var(--accent); font-weight:600;">/dev/ttyACM0</span></p>
+                </div>
+              </div>
+              <button type="button" id="btn-redetect-os" class="btn btn-sm btn-ghost" title="Re-scan robot computer hardware and serial ports">
+                <span>🔄 Scan Robot SBC</span>
+              </button>
+            </div>
+
+            <!-- HERO ACTION: 1-Click Full Deploy & Flash Control (Top of Tab 5) -->
+            <div class="deploy-hero-card mt-3">
+              <div class="deploy-hero-header">
+                <div>
+                  <h3 class="deploy-hero-title">🚀 1-Click Full Deploy & Live Telemetry</h3>
+                  <p class="deploy-hero-desc">Build firmware, release serial port, flash microcontroller (or BOOTSEL), establish micro-ROS agent handshake, and stream live ROS 2 topics.</p>
+                </div>
+                <div class="deploy-hero-badge" id="hero-deploy-badge">
+                  <span class="pulse-dot" id="hero-deploy-dot"></span> <span id="hero-deploy-status-text">Ready to Deploy</span> <span id="hero-deploy-timer" style="display:none;"></span>
+                </div>
+              </div>
+
+              <div class="form-grid mt-3">
+                <div class="form-group">
+                  <label for="auto-flash-target" class="form-label">🎯 Target Firmware Binary</label>
+                  <select id="auto-flash-target" class="form-select">
+                    <option value="firmware" selected>🏎️ Robot Firmware (Main micro-ROS Motor Controller)</option>
+                    <option value="test_sensors">🧭 Sensor Diagnostics Utility (test_sensors/)</option>
+                    <option value="test_motors">⚙️ Motor & Encoder Diagnostics (test_motors/)</option>
+                    <option value="test_acc">📈 Dynamic Acceleration Profiler (test_acc/)</option>
+                    <option value="i2c_detect">🔍 I2C Hardware Scanner & Auto-Identifier (tools/i2c_detect/)</option>
+                    <option value="adc_calibrate">🔋 ESP32 ADC Calibration & LUT Linearizer (adc_calibrate/)</option>
+                    <option value="bno085_cal">🧭 BNO085 IMU Calibration (bno085_cal/)</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label for="auto-flash-port" class="form-label">🔌 Upload Serial Port / BOOTSEL Protocol</label>
+                  <input type="text" id="auto-flash-port" class="form-input font-mono" data-auto-managed="true" value="/dev/ttyACM0" placeholder="/dev/ttyACM0, /dev/ttyUSB0, BOOTSEL, or AUTO">
+                  <div id="flash-port-chips" class="port-chips-wrap mt-1"></div>
+                </div>
+              </div>
+
+              <div class="btn-group-row mt-3">
+                <button type="button" id="btn-exec-deploy-script" class="btn btn-accent btn-hero-deploy flex-2" title="Execute complete 9-phase deployment lifecycle on Robot SBC">
+                  <span class="btn-icon">🚀</span>
+                  <span class="btn-text"><strong>Run Full Deploy</strong> (Build, Flash & Discover Topics)</span>
+                </button>
+                <button type="button" id="btn-exec-build-cmd" class="btn btn-secondary flex-1" title="Compile selected target firmware on Robot SBC">
+                  <span>🔨 Run Build</span>
+                </button>
+                <button type="button" id="btn-exec-upload-cmd" class="btn btn-primary flex-1" title="Compile and upload firmware on Robot SBC">
+                  <span>⚡ Flash MCU</span>
+                </button>
+                <button type="button" id="btn-download-deploy-script" class="btn btn-ghost" title="Download deploy_robot.sh script">
+                  <span>📥 Script</span>
+                </button>
+                <button type="button" id="btn-tab5-launch-syslog" class="btn btn-ghost" title="Launch or stop UDP Syslog Telemetry Server">
+                  <span id="tab5-syslog-icon">📡</span> <span id="tab5-syslog-text">Syslog Server</span>
+                </button>
+              </div>
+              <div class="deploy-time-hint mt-2">
+                <span class="hint-icon">⏱️</span>
+                <span><strong>Note for lower-spec PCs / SBCs:</strong> First-time build compiles micro-ROS IDLs & C++ libraries (may take 2–4 min on Raspberry Pi or older CPUs). Subsequent builds are cached and take &lt;10s.</span>
+              </div>
+            </div>
+
+            <!-- 1. OS & Workspace Environment -->
+            <h3 class="sub-title mt-4">🖥️ 1. Robot Host OS & Workspace Environment</h3>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="auto-os-select" class="form-label">Robot Host Operating System</label>
+                <select id="auto-os-select" class="form-select">
+                  <option value="ubuntu_2404">Ubuntu 24.04 LTS (Noble Numbat / Jazzy — RPi 5 / Jetson)</option>
+                  <option value="ubuntu_2604">Ubuntu 26.04 LTS (Resolute Raccoon / Lyrical)</option>
+                  <option value="ubuntu_2204">Ubuntu 22.04 LTS (Jammy Jellyfish / Humble — RPi 4 / Jetpack 5)</option>
+                  <option value="debian">Debian 12 / 13 (Bookworm / Raspberry Pi OS)</option>
+                  <option value="fedora">Fedora / Bluefin Linux</option>
+                  <option value="macos">macOS (Remote Workstation)</option>
+                  <option value="windows_wsl">Windows 10 / 11 (WSL2 Ubuntu)</option>
+                </select>
+                <span class="input-hint">Target environment where firmware builds and agent execute</span>
+              </div>
+
+              <div class="form-group">
+                <label for="auto-env-select" class="form-label">Runtime Environment Mode</label>
+                <select id="auto-env-select" class="form-select">
+                  <option value="native">Native Host System</option>
+                  <option value="distrobox">Distrobox Workspace Container (jazzy / resolute)</option>
+                  <option value="docker">Docker Container</option>
+                </select>
+                <span class="input-hint">Isolates build tools and compiler dependencies</span>
+              </div>
+
+              <div class="form-group">
+                <label for="auto-arch-select" class="form-label">Target CPU Architecture</label>
+                <select id="auto-arch-select" class="form-select">
+                  <option value="aarch64">aarch64 / arm64 (Raspberry Pi 4/5 / Jetson Orin / Apple Silicon)</option>
+                  <option value="x86_64">x86_64 (Intel NUC / AMD Mini-PC / PC)</option>
+                </select>
+              </div>
+            </div>
+
+            <!-- 2. Toolchain & Permissions Installer -->
+            <h3 class="sub-title mt-4">🛠️ 2. Toolchain & Hardware Permissions Installer</h3>
+            <div class="automation-options-grid">
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-install-pio" checked>
+                <span><strong>PlatformIO Core (<code>pio</code>)</strong> — Microcontroller compiler & flash engine</span>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-install-udev" checked>
+                <span><strong>Hardware udev Rules (<code>99-platformio-udev.rules</code>)</strong> — Grant non-root USB access</span>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-install-dialout" checked>
+                <span><strong>User Serial Groups</strong> — Add current user to <code>dialout</code> and <code>plugdev</code></span>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-install-buildtools" checked>
+                <span><strong>Build Essentials</strong> — <code>git</code>, <code>cmake</code>, <code>ninja-build</code>, <code>python3-pip</code></span>
+              </label>
+            </div>
+
+            <div class="quick-cmd-box">
+              <div class="quick-cmd-header">
+                <span class="quick-cmd-title">⚡ One-Click Toolchain Install Command</span>
+                <div class="quick-cmd-actions">
+                  <button type="button" id="btn-exec-tool-cmd" class="btn btn-xs btn-primary" title="Execute toolchain installer on Robot SBC">▶️ Run on Robot SBC</button>
+                  <button type="button" id="btn-copy-tool-cmd" class="btn btn-xs btn-ghost">📋 Copy</button>
+                </div>
+              </div>
+              <pre class="quick-cmd-code"><code id="preview-tool-cmd"># Updating...</code></pre>
+            </div>
+
+            <!-- 3. ROS 2 Distribution Selector & Setup -->
+            <h3 class="sub-title mt-4">🤖 3. ROS 2 Distribution Setup (Robot SBC)</h3>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="auto-ros-distro" class="form-label">ROS 2 Distribution</label>
+                <select id="auto-ros-distro" class="form-select">
+                  <option value="jazzy" selected>ROS 2 Jazzy Jalisco (Ubuntu 24.04 LTS — Recommended)</option>
+                  <option value="lyrical">ROS 2 Lyrical (Ubuntu 26.04 LTS)</option>
+                  <option value="rolling">ROS 2 Rolling Ridley (Continuous Release)</option>
+                  <option value="humble">ROS 2 Humble Hawksbill (Ubuntu 22.04 LTS)</option>
+                  <option value="none">None / Standalone Firmware Only (Skip ROS 2)</option>
+                </select>
+                <span class="input-hint">Select your host ROS 2 distribution or skip for standalone MCU</span>
+              </div>
+
+              <div class="form-group" id="group-ros-install-type">
+                <label for="auto-ros-type" class="form-label">ROS 2 Package Bundle</label>
+                <select id="auto-ros-type" class="form-select">
+                  <option value="base" selected>Base Bundle (ros-distro-ros-base + Micro-ROS — Recommended for SBC)</option>
+                  <option value="desktop">Desktop Bundle (ros-distro-desktop + GUI Tools)</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="automation-options-grid mt-2" id="group-microros-agent">
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-build-microros-agent" checked>
+                <span><strong>Build micro-ROS Agent Workspace</strong> — Clone and compile <code>micro_ros_agent</code> for DDS bridging</span>
+              </label>
+            </div>
+
+            <div class="quick-cmd-box" id="box-ros-cmd">
+              <div class="quick-cmd-header">
+                <span class="quick-cmd-title">⚡ One-Click ROS 2 Setup Command</span>
+                <div class="quick-cmd-actions">
+                  <button type="button" id="btn-exec-ros-cmd" class="btn btn-xs btn-primary" title="Execute ROS 2 setup on Robot SBC">▶️ Run on Robot SBC</button>
+                  <button type="button" id="btn-copy-ros-cmd" class="btn btn-xs btn-ghost">📋 Copy</button>
+                </div>
+              </div>
+              <pre class="quick-cmd-code"><code id="preview-ros-cmd"># Updating...</code></pre>
+            </div>
+
+            <!-- 4. Merge Generated Headers & Git Commit -->
+            <h3 class="sub-title mt-4">🔀 4. Merge Generated Headers & Git Commit Automation</h3>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="auto-git-branch" class="form-label">Git Branch Name</label>
+                <input type="text" id="auto-git-branch" class="form-input" data-auto-managed="true" value="config/scout_pico2" placeholder="e.g. config/scout_pico2">
+                <span class="input-hint">Auto-created branch for isolated testing</span>
+              </div>
+
+              <div class="form-group">
+                <label for="auto-git-commit-msg" class="form-label">Git Commit Message</label>
+                <input type="text" id="auto-git-commit-msg" class="form-input" data-auto-managed="true" value="feat(config): add configuration for scout_pico2" placeholder="Commit message">
+              </div>
+            </div>
+
+            <div class="automation-options-grid mt-2">
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-merge-header" checked>
+                <span>Write <code>config/custom/&lt;robot&gt;_config.h</code> and register in <code>config/config.h</code></span>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-merge-pio-firmware" checked>
+                <span>Append <code>[env:&lt;robot&gt;]</code> to <code>firmware/platformio.ini</code> (automatically inherited by <code>test_motors</code> & <code>test_sensors</code>)</span>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-merge-urdf" checked>
+                <span>Generate <code>urdf/&lt;robot&gt;_properties.urdf.xacro</code></span>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-auto-commit" checked>
+                <span>Stage changes and create Git commit automatically</span>
+              </label>
+            </div>
+
+            <div class="quick-cmd-box">
+              <div class="quick-cmd-header">
+                <span class="quick-cmd-title">⚡ One-Click Merge & Git Commit Command</span>
+                <div class="quick-cmd-actions">
+                  <button type="button" id="btn-exec-merge-cmd" class="btn btn-xs btn-primary" title="Execute header merge and Git commit on Robot SBC">▶️ Run Merge & Commit</button>
+                  <button type="button" id="btn-copy-merge-cmd" class="btn btn-xs btn-ghost">📋 Copy</button>
+                </div>
+              </div>
+              <pre class="quick-cmd-code"><code id="preview-merge-cmd"># Updating...</code></pre>
+            </div>
+
+            <!-- 5. Standalone Diagnostics & Utilities -->
+            <h3 class="sub-title mt-4">⚡ 5. Standalone Diagnostics & Direct Microcontroller Uploads</h3>
+
+            <!-- Direct 1-Click Upload Action Grid -->
+            <div class="direct-upload-section mt-3">
+              <label class="checkbox-label mb-2">
+                <input type="checkbox" id="cfg-ota-enable">
+                <span><strong>Flash over WiFi (OTA)</strong> — uses the device IP &amp; password from the Sensors tab instead of the USB port</span>
+              </label>
+              <label class="form-label mb-2">🚀 Direct 1-Click Microcontroller Uploads</label>
+              <div class="direct-upload-grid">
+                <button type="button" id="btn-upload-sensors" class="btn-direct-upload btn-upload-sensors" title="Compile & Upload Sensor Diagnostics on Robot SBC">
+                  <span class="direct-upload-icon">🧭</span>
+                  <div class="direct-upload-info">
+                    <span class="direct-upload-title">Upload <code>test_sensors</code></span>
+                    <span class="direct-upload-desc">I2C Scanner & Sensor Telemetry</span>
+                  </div>
+                  <span class="direct-upload-badge">⚡ Upload</span>
+                </button>
+
+                <button type="button" id="btn-upload-motors" class="btn-direct-upload btn-upload-motors" title="Compile & Upload Motor Diagnostics on Robot SBC">
+                  <span class="direct-upload-icon">⚙️</span>
+                  <div class="direct-upload-info">
+                    <span class="direct-upload-title">Upload <code>test_motors</code></span>
+                    <span class="direct-upload-desc">Sequential Motor & CPR Test</span>
+                  </div>
+                  <span class="direct-upload-badge">⚡ Upload</span>
+                </button>
+
+                <button type="button" id="btn-upload-acc" class="btn-direct-upload btn-upload-acc" title="Compile & Upload Acceleration Profiler on Robot SBC">
+                  <span class="direct-upload-icon">📈</span>
+                  <div class="direct-upload-info">
+                    <span class="direct-upload-title">Upload <code>test_acc</code></span>
+                    <span class="direct-upload-desc">Dynamic Acceleration Profiler</span>
+                  </div>
+                  <span class="direct-upload-badge">⚡ Upload</span>
+                </button>
+
+                <button type="button" id="btn-upload-adc" class="btn-direct-upload btn-upload-adc" title="Compile & Upload ESP32 ADC Calibration on Robot SBC">
+                  <span class="direct-upload-icon">🔋</span>
+                  <div class="direct-upload-info">
+                    <span class="direct-upload-title">Upload <code>adc_calibrate</code></span>
+                    <span class="direct-upload-desc">Hardware DAC ADC Linearization</span>
+                  </div>
+                  <span class="direct-upload-badge">⚡ Upload</span>
+                </button>
+
+                <button type="button" id="btn-upload-firmware" class="btn-direct-upload btn-upload-firmware" title="Compile & Upload Main Robot Controller on Robot SBC">
+                  <span class="direct-upload-icon">🏎️</span>
+                  <div class="direct-upload-info">
+                    <span class="direct-upload-title">Upload <code>firmware</code></span>
+                    <span class="direct-upload-desc">Main micro-ROS Robot Controller</span>
+                  </div>
+                  <span class="direct-upload-badge">⚡ Upload</span>
+                </button>
+              </div>
+            </div>
+
+
+
+
+            <!-- 6. ADC Calibration Studio & LUT Visualizer -->
+            <h3 class="sub-title mt-4">🔋 6. ESP32 ADC Calibration Studio & LUT Linearizer</h3>
+            <div class="adc-studio-card" id="adc-studio-card">
+              <div class="adc-studio-header">
+                <div class="adc-studio-title-wrap">
+                  <span class="adc-studio-icon">🔋</span>
+                  <div>
+                    <h4 class="adc-studio-title">Hardware DAC Sweep & 12-Bit Inverse Lookup Table (LUT)</h4>
+                    <p class="adc-studio-subtitle">Linearizes ESP32 ADC battery & sensor readings across the full 0–3.3V range</p>
+                  </div>
+                </div>
+                <div class="adc-studio-actions">
+                  <button type="button" id="btn-adc-run-cal" class="btn btn-sm btn-primary" title="Upload adc_calibrate & Run Live Sweep on Robot SBC">
+                    <span>⚡ Run Hardware Calibration</span>
+                  </button>
+                  <button type="button" id="btn-adc-sim-cal" class="btn btn-sm btn-secondary" title="Compute Theoretical/Empirical ESP32 ADC Linearization Model">
+                    <span>🧪 Generate Model LUT</span>
+                  </button>
+                  <button type="button" id="btn-adc-merge-lut" class="btn btn-sm btn-success" title="Merge generated ADC_LUT into custom robot configuration" disabled>
+                    <span>🔀 Merge LUT Table</span>
+                  </button>
+                </div>
+              </div>
+
+              <!-- Setup Instruction & CAD Schematic Banner -->
+              <div class="adc-setup-banner">
+                <span class="adc-setup-badge">🔌 Hardware Wiring</span>
+                <span class="adc-setup-text">Connect <strong>DAC Output GPIO 25 (DAC1)</strong> to your <strong>Battery ADC Input Pin</strong> (e.g. GPIO 33) for calibration. Use a <strong>1000pF filter capacitor</strong> to ground for noise suppression.</span>
+              </div>
+
+              <!-- CAD Circuit Schematic Viewer -->
+              <div class="adc-cad-schematic-card mt-3 mb-3">
+                <div class="schematic-header">
+                  <div class="schematic-title-wrap">
+                    <span class="schematic-icon">📐</span>
+                    <div>
+                      <h4 class="schematic-title">Interactive CAD Circuit Schematic (ADC Voltage Divider, 1000pF Filter & DAC Calibration)</h4>
+                      <p class="schematic-subtitle">Hardware topology for battery sensing with transient noise filter & hardware DAC sweep</p>
+                    </div>
+                  </div>
+                  <div class="schematic-badges">
+                    <span class="schematic-badge" id="cad-badge-ratio">Ratio: 0.2000 (1:5)</span>
+                    <span class="schematic-badge badge-safe" id="cad-badge-safety">🛡️ V_ADC: 2.52V &le; 3.0V</span>
+                  </div>
+                </div>
+
+                <div class="schematic-svg-container">
+                  <svg id="adc-circuit-svg" viewBox="0 0 760 220" class="schematic-svg" xmlns="http://www.w3.org/2000/svg">
+                    <defs>
+                      <linearGradient id="grad-wire" x1="0%" y1="0%" x2="100%" y2="0%">
+                        <stop offset="0%" stop-color="#38bdf8"/>
+                        <stop offset="100%" stop-color="#818cf8"/>
+                      </linearGradient>
+                      <linearGradient id="grad-dac" x1="0%" y1="0%" x2="100%" y2="0%">
+                        <stop offset="0%" stop-color="#f59e0b"/>
+                        <stop offset="100%" stop-color="#10b981"/>
+                      </linearGradient>
+                    </defs>
+
+                    <!-- Battery / Power In -->
+                    <g class="cad-component" id="cad-comp-battery">
+                      <rect x="20" y="35" width="85" height="42" rx="6" fill="#1e293b" stroke="#38bdf8" stroke-width="2"/>
+                      <text x="62" y="55" fill="#f8fafc" font-size="12" font-weight="bold" text-anchor="middle">+VBAT</text>
+                      <text x="62" y="69" fill="#94a3b8" font-size="10" text-anchor="middle" id="cad-svg-vbat">12.6 V (Full)</text>
+                      <!-- Lead line -->
+                      <line x1="105" y1="56" x2="150" y2="56" stroke="#38bdf8" stroke-width="2.5"/>
+                    </g>
+
+                    <!-- Resistor R1 (Upper Divider) -->
+                    <g class="cad-component" id="cad-comp-r1">
+                      <!-- Resistor Box -->
+                      <rect x="150" y="44" width="90" height="24" rx="4" fill="#0f172a" stroke="#38bdf8" stroke-width="2"/>
+                      <text x="195" y="60" fill="#38bdf8" font-size="11" font-family="monospace" font-weight="bold" text-anchor="middle" id="cad-svg-r1">R1: 30.0 kΩ</text>
+                      <text x="195" y="36" fill="#94a3b8" font-size="9" text-anchor="middle">Upper Resistor</text>
+                      <!-- Wire to central node -->
+                      <line x1="240" y1="56" x2="340" y2="56" stroke="#38bdf8" stroke-width="2.5"/>
+                    </g>
+
+                    <!-- Central ADC Node -->
+                    <circle cx="340" cy="56" r="5" fill="#818cf8"/>
+                    <text x="340" y="36" fill="#c084fc" font-size="10" font-weight="bold" text-anchor="middle">ADC NODE</text>
+
+                    <!-- Resistor R2 (Lower Divider to GND) -->
+                    <g class="cad-component" id="cad-comp-r2">
+                      <line x1="300" y1="56" x2="300" y2="90" stroke="#818cf8" stroke-width="2.5"/>
+                      <rect x="270" y="90" width="60" height="36" rx="4" fill="#0f172a" stroke="#818cf8" stroke-width="2"/>
+                      <text x="300" y="108" fill="#818cf8" font-size="10" font-family="monospace" font-weight="bold" text-anchor="middle" id="cad-svg-r2">R2</text>
+                      <text x="300" y="120" fill="#94a3b8" font-size="9" font-family="monospace" text-anchor="middle" id="cad-svg-r2-val">7.5 kΩ</text>
+                      <line x1="300" y1="126" x2="300" y2="160" stroke="#64748b" stroke-width="2.5"/>
+                      <!-- GND Symbol -->
+                      <line x1="288" y1="160" x2="312" y2="160" stroke="#94a3b8" stroke-width="2"/>
+                      <line x1="292" y1="165" x2="308" y2="165" stroke="#94a3b8" stroke-width="2"/>
+                      <line x1="296" y1="170" x2="304" y2="170" stroke="#94a3b8" stroke-width="2"/>
+                    </g>
+
+                    <!-- Filter Capacitor (1000pF across ADC to GND) -->
+                    <g class="cad-component" id="cad-comp-cap">
+                      <line x1="380" y1="56" x2="380" y2="95" stroke="#818cf8" stroke-width="2.5"/>
+                      <!-- Capacitor Plates -->
+                      <line x1="365" y1="95" x2="395" y2="95" stroke="#10b981" stroke-width="3"/>
+                      <line x1="365" y1="105" x2="395" y2="105" stroke="#10b981" stroke-width="3"/>
+                      <text x="435" y="104" fill="#10b981" font-size="10" font-family="monospace" font-weight="bold" text-anchor="start" id="cad-svg-cap">C: 1000 pF (1nF)</text>
+                      <text x="435" y="117" fill="#6ee7b7" font-size="8" text-anchor="start">Noise Reduction Filter</text>
+                      <line x1="380" y1="105" x2="380" y2="160" stroke="#64748b" stroke-width="2.5"/>
+                      <!-- GND Symbol -->
+                      <line x1="368" y1="160" x2="392" y2="160" stroke="#94a3b8" stroke-width="2"/>
+                      <line x1="372" y1="165" x2="388" y2="165" stroke="#94a3b8" stroke-width="2"/>
+                      <line x1="376" y1="170" x2="384" y2="170" stroke="#94a3b8" stroke-width="2"/>
+                    </g>
+
+                    <!-- Horizontal Bus Connection to ADC Pin -->
+                    <line x1="340" y1="56" x2="570" y2="56" stroke="url(#grad-wire)" stroke-width="2.5"/>
+
+                    <!-- MCU ADC Input Pin -->
+                    <g class="cad-component" id="cad-comp-mcu">
+                      <rect x="570" y="32" width="165" height="48" rx="6" fill="#1e1b4b" stroke="#a855f7" stroke-width="2"/>
+                      <text x="652" y="52" fill="#e9d5ff" font-size="11" font-weight="bold" text-anchor="middle" id="cad-svg-adc-pin">ESP32 ADC (GPIO 33)</text>
+                      <text x="652" y="68" fill="#c084fc" font-size="10" font-family="monospace" text-anchor="middle" id="cad-svg-vadc-read">V_ADC = 2.52 V (Max)</text>
+                    </g>
+
+                    <!-- Hardware DAC Sweep Line (Calibration Mode) -->
+                    <g class="cad-component" id="cad-comp-dac">
+                      <!-- DAC Box on bottom left -->
+                      <rect x="20" y="130" width="135" height="45" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+                      <text x="87" y="148" fill="#fcd34d" font-size="11" font-weight="bold" text-anchor="middle">ESP32 DAC (GPIO 25)</text>
+                      <text x="87" y="163" fill="#94a3b8" font-size="9" text-anchor="middle">Hardware Sweep 0–3.3V</text>
+                      <!-- Calibration Jumper Line to Node -->
+                      <path d="M 155 152 L 240 152 L 240 70 L 335 58" fill="none" stroke="url(#grad-dac)" stroke-width="2" stroke-dasharray="4,4"/>
+                      <circle cx="155" cy="152" r="3.5" fill="#f59e0b"/>
+                      <text x="200" y="145" fill="#f59e0b" font-size="8" font-family="monospace">CALIBRATION JUMPER</text>
+                    </g>
+
+                    <!-- 3.0V Safety Warning Box in SVG -->
+                    <g id="cad-svg-warning-box" style="display: none;">
+                      <rect x="490" y="130" width="245" height="45" rx="6" fill="#450a0a" stroke="#f43f5e" stroke-width="2"/>
+                      <text x="612" y="148" fill="#fca5a5" font-size="11" font-weight="bold" text-anchor="middle">⚠️ EXCEEDS 3.0V LIMIT!</text>
+                      <text x="612" y="163" fill="#fecdd3" font-size="9" text-anchor="middle" id="cad-svg-warning-text">V_ADC exceeds safe linear range</text>
+                    </g>
+                  </svg>
+                </div>
+              </div>
+
+              <!-- ADC Studio Content Grid -->
+              <div class="adc-studio-grid">
+                <!-- Left: Interactive Canvas Chart -->
+                <div class="adc-chart-pane">
+                  <div class="adc-chart-toolbar">
+                    <span class="adc-chart-title">📊 ADC Transfer Function & Linearization Plot</span>
+                    <div class="adc-chart-legend">
+                      <span class="legend-item legend-raw"><span class="legend-dot" style="background:#f43f5e;"></span> Raw Non-Linear</span>
+                      <span class="legend-item legend-ideal"><span class="legend-dot" style="background:#38bdf8;"></span> Ideal (0-4095)</span>
+                      <span class="legend-item legend-calibrated"><span class="legend-dot" style="background:#10b981;"></span> Calibrated Output</span>
+                    </div>
+                  </div>
+                  <div class="adc-canvas-container">
+                    <canvas id="adc-chart-canvas" width="600" height="320"></canvas>
+                    <div id="adc-chart-tooltip" class="adc-chart-tooltip" style="display: none;"></div>
+                  </div>
+                  <div class="adc-metrics-row">
+                    <div class="adc-metric-box">
+                      <span class="metric-label">Resolution</span>
+                      <span class="metric-val">12-Bit (4096 pts)</span>
+                    </div>
+                    <div class="adc-metric-box">
+                      <span class="metric-label">Low Knee Deadband</span>
+                      <span class="metric-val" id="metric-knee-low">~0.15 V (0-180 ADC)</span>
+                    </div>
+                    <div class="adc-metric-box">
+                      <span class="metric-label">High Knee Compression</span>
+                      <span class="metric-val" id="metric-knee-high">~3.15 V (3920-4095)</span>
+                    </div>
+                    <div class="adc-metric-box">
+                      <span class="metric-label">Max Correction Δ</span>
+                      <span class="metric-val text-accent" id="metric-max-delta">±142 ADC</span>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Right: LUT Code / Stream Inspector -->
+                <div class="adc-lut-pane">
+                  <div class="adc-lut-header">
+                    <span class="adc-lut-title">📋 Generated <code>ADC_LUT[4096]</code></span>
+                    <button type="button" id="btn-copy-lut-code" class="btn btn-xs btn-ghost">📋 Copy LUT</button>
+                  </div>
+                  <div class="adc-lut-code-wrap">
+                    <pre class="adc-lut-code" id="adc-lut-code-display"><code>// Click "Run Hardware Calibration" or "Generate Model LUT" to build LUT table...
+const int16_t ADC_LUT[4096] = { /* insert adc_calibrate data here */ };</code></pre>
+                  </div>
+                  <div class="adc-status-bar" id="adc-status-bar">
+                    <span class="pulse-dot"></span>
+                    <span id="adc-status-text">Ready for calibration. Pin 25 (DAC1) -> Pin 33/34 (Battery ADC).</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- 7. micro-ROS Agent Host Runner -->
+            <h3 class="sub-title mt-4">📡 7. micro-ROS Agent Host Bridge (Robot SBC)</h3>
+            <div class="quick-cmd-box" id="box-agent-cmd">
+              <div class="quick-cmd-header">
+                <span class="quick-cmd-title">⚡ Live micro-ROS Agent Runner</span>
+                <div class="quick-cmd-actions">
+                  <button type="button" id="btn-exec-agent-serial" class="btn btn-xs btn-success" title="Launch Serial micro-ROS Agent for single MCU">▶️ Single Serial</button>
+                  <button type="button" id="btn-exec-agent-multiserial" class="btn btn-xs btn-accent" title="Launch Multi-Serial micro-ROS Agent for multiple MCUs simultaneously">▶️ Multi-Serial</button>
+                  <button type="button" id="btn-exec-agent-udp" class="btn btn-xs btn-primary" title="Launch UDP WiFi micro-ROS Agent on Robot SBC">▶️ UDP WiFi</button>
+                  <button type="button" id="btn-copy-agent-cmd" class="btn btn-xs btn-ghost">📋 Copy</button>
+                </div>
+              </div>
+              <div class="agent-config-row mt-2 mb-2">
+                <div class="form-group flex-1">
+                  <label for="auto-agent-multiserial-ports" class="form-label-xs">Multi-Serial Devices (space-separated for multi-MCU robots)</label>
+                  <input type="text" id="auto-agent-multiserial-ports" class="form-input form-input-sm font-mono" value="/dev/ttyACM0 /dev/ttyUSB0" placeholder="/dev/ttyACM0 /dev/ttyUSB0">
+                </div>
+                <div class="form-group" style="width: 140px;">
+                  <label for="auto-agent-baud" class="form-label-xs">Agent Baud Rate</label>
+                  <select id="auto-agent-baud" class="form-select form-select-sm font-mono">
+                    <option value="1500000">1500000 (1.5M)</option>
+                    <option value="921600" selected>921600</option>
+                    <option value="460800">460800</option>
+                    <option value="115200">115200</option>
+                    <option value="57600">57600</option>
+                  </select>
+                </div>
+              </div>
+              <pre class="quick-cmd-code"><code id="preview-agent-cmd">ros2 run micro_ros_agent micro_ros_agent serial --dev /dev/ttyUSB0 -b 921600</code></pre>
+            </div>
+
+                                    <!-- 8. Live ROS 2 Topic Frequency (Hz) Monitor & Stream Inspector -->
+            <h3 class="sub-title mt-4">📡 8. Live ROS 2 Topic Monitor & Frequency (Hz) Table</h3>
+            <div class="ros2-inspector-card" id="ros2-inspector-card">
+              <div class="ros2-inspector-header">
+                <div class="ros2-inspector-title-wrap">
+                  <span class="ros2-inspector-icon">📡</span>
+                  <div>
+                    <h4 class="ros2-inspector-title">Active ROS 2 Graph & Real-Time Hz Table</h4>
+                    <p class="ros2-inspector-subtitle">Select any topic row in the table to stream live telemetry into the console and verify the 50.0 Hz control loop</p>
+                  </div>
+                </div>
+                <div class="ros2-inspector-actions">
+                  <span class="badge-pill badge-ok" id="ros2-graph-status">● micro-ROS Active</span>
+                  <button type="button" id="btn-measure-all-hz" class="btn btn-xs btn-success" title="Measure live Hz for all active topics">⚡ Measure All Hz</button>
+                  <button type="button" id="btn-ros2-inspector-refresh" class="btn btn-xs btn-ghost" title="Re-scan ROS 2 graph">🔄 Refresh Topics</button>
+                </div>
+              </div>
+
+              <!-- Interactive Topic Hz Table -->
+              <div class="ros2-table-wrapper mt-3">
+                <table class="ros2-topic-table" id="ros2-topic-table">
+                  <thead>
+                    <tr>
+                      <th style="width: 45px; text-align: center;">Sel</th>
+                      <th>Topic Name</th>
+                      <th>Message Type</th>
+                      <th style="width: 130px; text-align: center;">Frequency (Hz)</th>
+                      <th style="width: 100px; text-align: center;">Status</th>
+                      <th style="width: 140px; text-align: right;">Live Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody id="ros2-topic-table-body">
+                    <tr class="topic-row active" data-topic="/odom/unfiltered">
+                      <td style="text-align: center;"><input type="radio" name="topic-select-radio" value="/odom/unfiltered" checked></td>
+                      <td><span class="topic-table-name font-mono">🏎️ /odom/unfiltered</span></td>
+                      <td><span class="topic-table-type font-mono text-muted">nav_msgs/msg/Odometry</span></td>
+                      <td style="text-align: center;"><span class="topic-hz-badge" id="hz-badge-odom">50.0 Hz</span></td>
+                      <td style="text-align: center;"><span class="badge-pill badge-ok">Active</span></td>
+                      <td style="text-align: right;">
+                        <button type="button" class="btn btn-xs btn-accent btn-table-stream" data-topic="/odom/unfiltered">▶️ Stream</button>
+                        <button type="button" class="btn btn-xs btn-ghost btn-table-hz" data-topic="/odom/unfiltered">⚡ Hz</button>
+                      </td>
+                    </tr>
+                    <tr class="topic-row" data-topic="/imu/data">
+                      <td style="text-align: center;"><input type="radio" name="topic-select-radio" value="/imu/data"></td>
+                      <td><span class="topic-table-name font-mono">🧭 /imu/data</span></td>
+                      <td><span class="topic-table-type font-mono text-muted">sensor_msgs/msg/Imu</span></td>
+                      <td style="text-align: center;"><span class="topic-hz-badge" id="hz-badge-imu">50.0 Hz</span></td>
+                      <td style="text-align: center;"><span class="badge-pill badge-ok">Active</span></td>
+                      <td style="text-align: right;">
+                        <button type="button" class="btn btn-xs btn-accent btn-table-stream" data-topic="/imu/data">▶️ Stream</button>
+                        <button type="button" class="btn btn-xs btn-ghost btn-table-hz" data-topic="/imu/data">⚡ Hz</button>
+                      </td>
+                    </tr>
+                    <tr class="topic-row" data-topic="/battery">
+                      <td style="text-align: center;"><input type="radio" name="topic-select-radio" value="/battery"></td>
+                      <td><span class="topic-table-name font-mono">🔋 /battery</span></td>
+                      <td><span class="topic-table-type font-mono text-muted">sensor_msgs/msg/BatteryState</span></td>
+                      <td style="text-align: center;"><span class="topic-hz-badge hz-low" id="hz-badge-battery">1.0 Hz</span></td>
+                      <td style="text-align: center;"><span class="badge-pill badge-ok">Active</span></td>
+                      <td style="text-align: right;">
+                        <button type="button" class="btn btn-xs btn-accent btn-table-stream" data-topic="/battery">▶️ Stream</button>
+                        <button type="button" class="btn btn-xs btn-ghost btn-table-hz" data-topic="/battery">⚡ Hz</button>
+                      </td>
+                    </tr>
+                    <tr class="topic-row" data-topic="/cmd_vel">
+                      <td style="text-align: center;"><input type="radio" name="topic-select-radio" value="/cmd_vel"></td>
+                      <td><span class="topic-table-name font-mono">🎮 /cmd_vel</span></td>
+                      <td><span class="topic-table-type font-mono text-muted">geometry_msgs/msg/Twist</span></td>
+                      <td style="text-align: center;"><span class="topic-hz-badge hz-sub">Subscribed</span></td>
+                      <td style="text-align: center;"><span class="badge-pill badge-info">Sub</span></td>
+                      <td style="text-align: right;">
+                        <button type="button" class="btn btn-xs btn-accent btn-table-stream" data-topic="/cmd_vel">▶️ Stream</button>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <!-- Live Selected Topic Display HUD -->
+              <div class="ros2-live-hud-grid mt-3">
+                <div class="hud-metric-mini">
+                  <span class="hud-mini-label">Active Topic</span>
+                  <span class="hud-mini-val text-cyan font-mono" id="hud-topic-name">/odom/unfiltered</span>
+                </div>
+                <div class="hud-metric-mini">
+                  <span class="hud-mini-label">Loop Frequency (Hz)</span>
+                  <span class="hud-mini-val text-green font-mono" id="hud-topic-hz">50.0 Hz</span>
+                </div>
+                <div class="hud-metric-mini">
+                  <span class="hud-mini-label">Linear Vel X / Voltage</span>
+                  <span class="hud-mini-val text-purple font-mono" id="hud-topic-val1">0.00 m/s</span>
+                </div>
+                <div class="hud-metric-mini">
+                  <span class="hud-mini-label">Angular Vel Z / Accel</span>
+                  <span class="hud-mini-val text-accent font-mono" id="hud-topic-val2">0.00 rad/s</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- 9. Live Interactive Terminal & Robot SBC Console -->
+            <h3 class="sub-title mt-4">📟 9. Live Interactive Terminal & Robot SBC Console</h3>
+            <div class="web-serial-console-card">
+              <div class="console-toolbar">
+                <div class="console-controls-left">
+                  <!-- Local Runner Status -->
+                  <span class="runner-status-pill pill-checking" id="runner-status-pill" title="Local Python Execution Server">
+                    <span class="pulse-dot"></span>
+                    <span id="runner-status-text">Checking Runner...</span>
+                  </span>
+
+                  <span class="runner-status-pill pill-checking" id="exec-progress-pill" style="display:none;" title="Running task">
+                    <span class="pulse-dot"></span>
+                    <span id="exec-progress-text">Working…</span>
+                    <span id="exec-progress-timer" class="font-mono"></span>
+                  </span>
+
+                  <!-- Server / SBC Serial Monitor Stream Button -->
+                                    <!-- ROS 2 Live Topic Stream Controls -->
+                  <div class="ros2-stream-controls">
+                    <select id="ros2-topic-select" class="form-select form-select-sm font-mono" title="Select active ROS 2 topic to stream live in terminal">
+                      <option value="/odom/unfiltered" selected>/odom/unfiltered (Odometry @ 50Hz)</option>
+                      <option value="/imu/data">/imu/data (IMU @ 50Hz)</option>
+                      <option value="/battery">/battery (BatteryState)</option>
+                      <option value="/cmd_vel">/cmd_vel (Twist)</option>
+                    </select>
+                    <button type="button" id="btn-ros2-echo" class="btn btn-sm btn-accent" title="Stream live topic messages in terminal">
+                      <span id="ros2-echo-icon">📡</span> <span id="ros2-echo-text">Stream Topic</span>
+                    </button>
+                    <button type="button" id="btn-ros2-hz" class="btn btn-sm btn-success" title="Measure live publishing frequency (Hz)">
+                      <span>⚡ Hz Check</span>
+                    </button>
+                    <button type="button" id="btn-ros2-refresh" class="btn btn-sm btn-ghost" title="Re-scan active ROS 2 graph for new topics">
+                      <span>🔄 Scan</span>
+                    </button>
+                  </div>
+                  <button type="button" id="btn-sbc-monitor" class="btn btn-sm btn-primary" title="Stream live serial messages from Robot SBC (e.g. test_sensors, IMU, telemetry)">
+                    <span>📡 Stream SBC Serial</span>
+                  </button>
+
+                  <!-- Web Serial Port Controls (Direct Client USB) -->
+                  <button type="button" id="btn-serial-connect" class="btn btn-sm btn-secondary" title="Connect to USB Microcontroller via Web Serial (Client Browser USB)">
+                    <span id="serial-btn-icon">🔌</span>
+                    <span id="serial-btn-text">Browser USB</span>
+                  </button>
+                  <select id="serial-baud-select" class="form-select form-select-sm" title="Serial Baud Rate">
+                    <option value="1500000">1500000 Baud (1.5M High Speed)</option>
+                    <option value="921600" selected>921600 Baud (micro-ROS / Diagnostics)</option>
+                    <option value="460800">460800 Baud</option>
+                    <option value="115200">115200 Baud</option>
+                    <option value="57600">57600 Baud</option>
+                    <option value="9600">9600 Baud</option>
+                  </select>
+                  <span class="serial-status-pill pill-disconnected" id="serial-status-pill">
+                    <span id="serial-status-text">Serial: Off</span>
+                  </span>
+                </div>
+                <div class="console-controls-right">
+                  <button type="button" id="btn-cancel-exec" class="btn btn-xs btn-danger" style="display: none;" title="Abort running process">⏹️ Stop Process</button>
+                  <label class="checkbox-label-sm" title="Stream wireless UDP syslog messages into terminal">
+                    <input type="checkbox" id="chk-stream-syslog-terminal" checked>
+                    <span>📡 Syslog</span>
+                  </label>
+                  <label class="checkbox-label-sm">
+                    <input type="checkbox" id="chk-serial-autoscroll" checked>
+                    <span>Auto-scroll</span>
+                  </label>
+                  <button type="button" id="btn-serial-clear" class="btn btn-xs btn-ghost">🧹 Clear</button>
+                </div>
+              </div>
+
+              <!-- Terminal Output Display Screen -->
+              <div class="terminal-screen" id="serial-terminal-screen">
+                <div class="terminal-line terminal-dim">[Web Serial Console Initialized. Click 'Connect Serial Port' to stream live microcontroller logs.]</div>
+              </div>
+
+              <!-- Terminal Command Sender Input -->
+              <div class="terminal-input-bar">
+                <input type="text" id="serial-input-text" class="terminal-input" placeholder="Type serial command or character (e.g. 's' for I2C scan, 'r' for reset) and press Enter..." disabled>
+                <button type="button" id="btn-serial-send" class="btn btn-sm btn-secondary" disabled>Send</button>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+
+      </div>
+    </section>
+
+    <!-- Right Column: Live HUD, Safety Inspector & Code Artifacts -->
+    <section class="dashboard-panel">
+
+      <!-- Top Metrics HUD -->
+      <div class="hud-card">
+        <div class="hud-header">
+          <h2 class="hud-title">📊 Kinematics & Performance HUD</h2>
+          <span class="hud-badge" id="hud-base-tag">2WD Differential</span>
+        </div>
+
+        <div class="metrics-grid">
+          <div class="metric-card">
+            <span class="metric-label">Max Linear Speed</span>
+            <div class="metric-val-wrap">
+              <span class="metric-val" id="val-speed-ms">1.42</span>
+              <span class="metric-unit">m/s</span>
+            </div>
+            <span class="metric-sub" id="val-speed-kmh">5.13 km/h (85% Headroom)</span>
+          </div>
+
+          <div class="metric-card">
+            <span class="metric-label">Max Angular Speed</span>
+            <div class="metric-val-wrap">
+              <span class="metric-val" id="val-speed-rads">12.95</span>
+              <span class="metric-unit">rad/s</span>
+            </div>
+            <span class="metric-sub" id="val-speed-degs">741.8 deg/s</span>
+          </div>
+
+          <div class="metric-card">
+            <span class="metric-label">Resolution</span>
+            <div class="metric-val-wrap">
+              <span class="metric-val" id="val-ticks-m">5,730</span>
+              <span class="metric-unit">ticks/m</span>
+            </div>
+            <span class="metric-sub" id="val-wheel-circ">Circumference: 0.251 m</span>
+          </div>
+
+          <div class="metric-card">
+            <span class="metric-label">Est. Max Acceleration</span>
+            <div class="metric-val-wrap">
+              <span class="metric-val" id="val-max-accel">2.64</span>
+              <span class="metric-unit">m/s²</span>
+            </div>
+            <span class="metric-sub" id="val-thrust-sub">Thrust: 9.24 N @ 3.5 kg</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Real-Time Hardware & Electrical Safety Inspector -->
+      <div class="safety-card" id="safety-inspector-box">
+        <div class="safety-header">
+          <div class="safety-indicator-wrap">
+            <span class="status-dot status-ok" id="safety-status-dot"></span>
+            <h3 class="safety-title" id="safety-status-title">Hardware Safety Rules: PASSED</h3>
+          </div>
+          <span class="safety-badge badge-ok" id="safety-status-badge">0 Errors</span>
+        </div>
+        <div class="safety-messages" id="safety-messages-list">
+          <div class="safety-item item-ok">
+            <span class="item-icon">✅</span>
+            <span>All pin assignments and electrical limits are conflict-free.</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Multi-Artifact Code Generator Tabs -->
+      <div class="artifacts-card">
+        <div class="artifacts-header">
+          <div class="artifact-tabs">
+            <button class="artifact-tab active" data-artifact="tab-code-header" id="btn-art-header">
+              <span>📄 C++ Header</span>
+            </button>
+            <button class="artifact-tab" data-artifact="tab-code-pio" id="btn-art-pio">
+              <span>⚡ PlatformIO</span>
+            </button>
+            <button class="artifact-tab" data-artifact="tab-code-urdf" id="btn-art-urdf">
+              <span>🤖 ROS 2 URDF</span>
+            </button>
+            <button class="artifact-tab" data-artifact="tab-code-wiring" id="btn-art-wiring">
+              <span>🔌 Wiring Chart</span>
+            </button>
+            <button class="artifact-tab" data-artifact="tab-code-deploy" id="btn-art-deploy">
+              <span>🛠️ Deploy Script</span>
+            </button>
+            <button class="artifact-tab" data-artifact="tab-code-json" id="btn-art-json">
+              <span>📋 Spec JSON</span>
+            </button>
+          </div>
+
+          <div class="artifact-actions">
+            <button id="btn-merge-config" class="btn btn-sm btn-accent" title="Merge current modifications with existing base configuration">
+              <span>🔄 Merge & Diff</span>
+            </button>
+            <button id="btn-save-config" class="btn btn-sm btn-primary" title="Save configuration directly to config/custom/">
+              <span>💾 Save to Firmware</span>
+            </button>
+            <button id="btn-copy-code" class="btn btn-sm btn-ghost" title="Copy code to clipboard">
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+              </svg>
+              <span id="copy-btn-text">Copy</span>
+            </button>
+            <button id="btn-download-artifact" class="btn btn-sm btn-secondary" title="Download this file">
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
+              </svg>
+              <span>Download</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="code-viewer-wrap">
+          <pre class="code-viewer"><code id="code-display" class="language-cpp">// Generating...</code></pre>
+        </div>
+      </div>
+
+    </section>
+  </main>
+
+  <!-- Notification Toast -->
+  <div id="toast" class="toast">Action completed!</div>
+
+  <script src="app.js?v=2.1.0"></script>
+
+  <!-- Board Config Selector Modal -->
+  <div id="modal-board-select" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:9999;align-items:center;justify-content:center;">
+    <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:28px 32px;min-width:380px;max-width:520px;box-shadow:0 20px 60px rgba(0,0,0,0.5);">
+      <h3 style="margin:0 0 6px 0;font-size:1.1rem;">&#x1F50C; Load Board Configuration</h3>
+      <p style="margin:0 0 18px 0;font-size:0.82rem;color:var(--text-muted);">Reads <code>firmware/platformio.ini</code> and imports the matching config header for the selected board environment.</p>
+      <label style="display:block;margin-bottom:6px;font-size:0.85rem;font-weight:600;">Select PlatformIO Environment:</label>
+      <select id="board-select" class="form-input" style="width:100%;margin-bottom:18px;">
+        <option value="">Loading board list&#x2026;</option>
+      </select>
+      <div id="board-select-info" style="font-size:0.78rem;color:var(--text-muted);margin-bottom:14px;min-height:36px;"></div>
+      <div style="display:flex;gap:10px;justify-content:flex-end;">
+        <button id="btn-board-cancel" class="btn btn-ghost">Cancel</button>
+        <button id="btn-board-confirm" class="btn btn-primary" disabled>Load Config</button>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/tools/robot_config_engine/web/index.html
+++ b/tools/robot_config_engine/web/index.html
@@ -1,0 +1,1980 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Linorobot2 | Robot Configuration Engine</title>
+  <meta name="description" content="Automated Hardware Rule Validator, Kinematics Physics Calculator, and Firmware / ROS 2 Code Generator for Linorobot2.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <!-- Background Glow Accents -->
+  <div class="bg-glow glow-1"></div>
+  <div class="bg-glow glow-2"></div>
+  <div class="bg-glow glow-3"></div>
+
+  <!-- Top Navigation Header -->
+  <header class="app-header">
+    <div class="header-brand">
+      <div class="brand-logo">
+        <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="12" cy="12" r="9" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="9" cy="10" r="1.5" fill="currentColor"/>
+          <circle cx="15" cy="10" r="1.5" fill="currentColor"/>
+          <path d="M8 15h8" stroke-linecap="round"/>
+          <path d="M12 3v-2" stroke-linecap="round"/>
+          <circle cx="12" cy="1" r="1" fill="currentColor"/>
+          <path d="M3 12H1M23 12h-2" stroke-linecap="round"/>
+        </svg>
+      </div>
+      <div>
+        <h1 class="brand-title">Linorobot2 <span class="badge-accent">Config Engine</span></h1>
+        <p class="brand-subtitle">AI Hardware Rule Validator & Code Generator</p>
+      </div>
+    </div>
+
+    <div class="header-actions">
+      <!-- Robot name, branch, git version & reference build -->
+      <div class="reference-build-stack">
+        <div class="hdr-field">
+          <label for="cfg-robot-name">🤖 Robot Name:</label>
+          <input type="text" id="cfg-robot-name" class="form-input hdr-input" value="scout_pico2" placeholder="e.g. scout_pico2" pattern="^[a-z0-9_]+$" title="Lowercase alphanumeric &amp; underscores only">
+        </div>
+        <div class="hdr-field" id="hdr-branch-field">
+          <label for="auto-git-branch">⎇ Branch:</label>
+          <input type="text" id="auto-git-branch" class="form-input hdr-input" data-auto-managed="true" value="scout_pico2" placeholder="current branch" autocomplete="off" title="Robot SBC git branch. Click to pick an existing branch, or type a new name. Run Merge &amp; Commit checks it out (creating it if new).">
+          <button type="button" id="btn-branch-menu" class="hdr-caret" aria-expanded="false" aria-haspopup="listbox" title="Show branches on the Robot SBC">▾</button>
+          <div id="branch-menu" class="branch-menu" role="listbox" hidden></div>
+          <button type="button" id="btn-branch-to-name" class="hdr-btn" title="Set the branch to the robot name and switch to it">= name</button>
+        </div>
+        <div class="git-version-row">
+          <button id="git-version-badge" class="git-version-badge" type="button" aria-expanded="false"
+                  title="Repo version the web server started on — click for branch, remotes &amp; recent commits">
+            <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="3"/><line x1="3" y1="12" x2="9" y2="12"/><line x1="15" y1="12" x2="21" y2="12"/>
+            </svg>
+            <span id="git-version-text">·······</span>
+          </button>
+          <div id="git-version-popover" class="git-version-popover" hidden></div>
+        </div>
+        <div class="preset-selector-group">
+          <label for="preset-select" class="preset-label">⚡ Reference Build:</label>
+          <select id="preset-select" class="preset-select">
+            <option value="gendrv_serial_ld19" selected>🎮 Simulated Robot · Waveshare GenDrv · USB serial (no wiring)</option>
+            <option value="esp32_wifi_ld19">🎮 Simulated Robot · ESP32 · WiFi + LiDAR UDP (no wiring)</option>
+            <option value="bare">🧩 Bare Module — all pins N/C (safe default)</option>
+            <option value="pico2_diff">⚡ Pico 2 · 2WD Differential · BTS7960 (Fake IMU)</option>
+            <option value="pico2_mecanum">⚡ Pico 2 · 4WD Mecanum · BTS7960 (Fake IMU)</option>
+            <option value="pico2_skid">⚡ Pico 2 · 4WD Skid Steer · BTS7960 (Fake IMU)</option>
+            <option value="scout_pico2">Raspberry Pi Pico 2 (2WD Diff + TB6612 / L298N)</option>
+            <option value="mech_pico2">Raspberry Pi Pico 2 (4WD Mecanum + TB6612)</option>
+            <option value="mech_esp32">ESP32 (4WD Mecanum + WiFi UDP + BNO085)</option>
+            <option value="crawler_esp32s3">ESP32-S3 (4WD Skid + Sonar + ADC)</option>
+            <option value="waveshare_gendrv">Waveshare General Driver (ESP32 + BTS7960)</option>
+          </select>
+        </div>
+        <button type="button" id="btn-header-deploy" class="btn btn-accent hdr-deploy-btn"
+                title="Set Robot Name, press = name, then Run Full Deploy — build, flash & bring up live ROS 2 topics">
+          <span class="btn-icon">🚀</span>
+          <span><strong>Run Full Deploy</strong></span>
+        </button>
+      </div>
+
+      <!-- Header Workflow Settings: Build Engine, Agent Engine, Remote Flash & ROS 2 Distro -->
+      <div class="workflow-settings-stack">
+        <div class="hdr-wf-row">
+          <div class="hdr-field hdr-wf-field" title="Target ROS 2 Distribution (Jazzy, Lyrical, Rolling, Humble or Standalone)">
+            <label for="hdr-ros-distro">🌐 ROS 2:</label>
+            <select id="hdr-ros-distro" class="hdr-select">
+              <option value="jazzy" selected>Jazzy (Noble 24.04)</option>
+              <option value="lyrical">Lyrical (Resolute 26.04)</option>
+              <option value="rolling">Rolling (Nightly)</option>
+              <option value="humble">Humble (Container)</option>
+              <option value="none">Standalone (No ROS)</option>
+            </select>
+          </div>
+          <div class="hdr-field hdr-wf-field" title="Microcontroller Firmware Build Engine">
+            <label for="hdr-build-engine">🔨 Build:</label>
+            <select id="hdr-build-engine" class="hdr-select">
+              <option value="docker" selected>Docker (Rootless)</option>
+              <option value="podman">Podman (Rootless)</option>
+              <option value="native">Native (PlatformIO)</option>
+            </select>
+            <button type="button" id="btn-rootless-info" class="hdr-info-btn" title="Setup Rootless Docker Daemon on Linux to prevent root-owned files">❓ Guide</button>
+          </div>
+        </div>
+        <div class="hdr-wf-row">
+          <div class="hdr-field hdr-wf-field" title="micro-ROS Agent Runtime Engine">
+            <label for="hdr-agent-engine">🤖 Agent:</label>
+            <select id="hdr-agent-engine" class="hdr-select">
+              <option value="docker" selected>Docker (Rootless)</option>
+              <option value="podman_systemd">Podman + systemd</option>
+              <option value="podman">Podman (Container)</option>
+              <option value="native">Native (ROS 2 / ~/uros_ws)</option>
+            </select>
+          </div>
+          <div class="hdr-field hdr-wf-field" title="Container Registry for Builder & micro-ROS Images">
+            <label for="hdr-container-registry">📦 Registry:</label>
+            <select id="hdr-container-registry" class="hdr-select">
+              <option value="auto" selected>Auto (Cluster / Hub)</option>
+              <option value="cluster">Cluster / LAN registry</option>
+              <option value="dockerhub">Docker Hub (Direct)</option>
+              <option value="custom">Custom...</option>
+            </select>
+            <input type="text" id="hdr-custom-registry" class="form-input hdr-input" placeholder="host:port" style="display:none; width:120px;" autocomplete="off" spellcheck="false">
+          </div>
+          <div class="hdr-field hdr-wf-field" title="Target Robot SBC Host/IP for Remote Flashing (empty for Local Machine)">
+            <label for="hdr-remote-flash">⚡ Flash:</label>
+            <input type="text" id="hdr-remote-flash" class="form-input hdr-input" placeholder="user@host (empty=local)" autocomplete="off">
+            <span id="hdr-remote-badge" class="badge-pill badge-ok" style="font-size:0.7rem; padding:1px 6px;">💻 Local</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- OS Quick Indicator -->
+      <div class="os-quick-badge" id="header-os-badge" title="Auto-Detected Client Environment">
+        <span class="os-badge-icon" id="header-os-icon">🐧</span>
+        <span class="os-badge-text" id="header-os-text">Detecting OS...</span>
+      </div>
+
+      <!-- Action Buttons -->
+      <button id="btn-load-board" class="btn btn-secondary" title="Load board configuration from firmware/platformio.ini">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
+        </svg>
+        <span>Load Board Config</span>
+      </button>
+      <label class="btn btn-ghost btn-sm" for="import-json-file" title="Import saved JSON specification" style="font-size:0.78rem;padding:4px 10px;">
+        <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/>
+        </svg>
+        <span>Import JSON</span>
+        <input type="file" id="import-json-file" accept=".json" style="display: none;">
+      </label>
+
+      <button id="btn-export-json" class="btn btn-primary" title="Export complete JSON specification">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/>
+        </svg>
+        <span>Export Spec</span>
+      </button>
+
+      <a href="https://github.com/linorobot/linorobot2_hardware" target="_blank" rel="noopener noreferrer" class="github-link" title="Linorobot2 Hardware on GitHub">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
+        </svg>
+      </a>
+    </div>
+  </header>
+
+  <!-- Simulation-mode banner: this config does not drive a real robot -->
+  <div id="sim-mode-banner" role="status" style="display:none;">
+    <span class="sim-banner-icon">🎮</span>
+    <div class="sim-banner-text">
+      <strong>Simulation mode is on</strong> — <span id="sim-mode-what"></span>.
+      This firmware answers <code>cmd_vel</code> with made-up odometry, so teleop, SLAM and Nav2
+      work on a board with nothing wired to it.
+      <b>Turn it off in Robot Geometry &rarr; Simulation before flashing a real robot</b>, or the
+      real motors and encoders will be ignored.
+    </div>
+    <button type="button" id="btn-sim-banner-off" class="btn btn-sm">Turn off simulation</button>
+  </div>
+
+  <!-- Main Grid App Container -->
+  <main class="app-container">
+
+    <!-- Left Column: Configurator Panels -->
+    <section class="config-panel">
+      <!-- Nav Tabs -->
+      <nav class="nav-tabs" role="tablist">
+        <button class="nav-tab active" data-tab="tab-base" id="btn-tab-base">
+          <span class="tab-icon">🤖</span>
+          <span>1. Base & MCU</span>
+        </button>
+        <button class="nav-tab" data-tab="tab-drive" id="btn-tab-drive">
+          <span class="tab-icon">⚙️</span>
+          <span>2. Drive & Motors</span>
+        </button>
+        <button class="nav-tab" data-tab="tab-sensors" id="btn-tab-sensors">
+          <span class="tab-icon">🧭</span>
+          <span>3. Sensors</span>
+        </button>
+        <button class="nav-tab" data-tab="tab-pins" id="btn-tab-pins">
+          <span class="tab-icon">🔌</span>
+          <span>4. Pinout Matrix</span>
+        </button>
+        <button class="nav-tab" data-tab="tab-automation" id="btn-tab-automation">
+          <span class="tab-icon">🚀</span>
+          <span>5. Automation & Flash</span>
+        </button>
+      </nav>
+
+      <!-- Form Content Area -->
+      <div class="tab-content-wrapper">
+
+        <!-- Tab 1: Base & MCU -->
+        <div class="tab-pane active" id="tab-base">
+          <div class="form-section">
+            <h2 class="section-title">Robot Identity & Microcontroller</h2>
+
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="cfg-topic-prefix" class="form-label">ROS 2 Topic Prefix <span class="badge-optional">Optional</span></label>
+                <input type="text" id="cfg-topic-prefix" class="form-input font-mono" value="" placeholder="e.g. robot1  ->  /robot1/odom/unfiltered">
+                <span class="input-hint">Prepended to every published/subscribed topic (<code>#define TOPIC_PREFIX</code>). Leave blank for bare <code>/cmd_vel</code>, <code>/odom/unfiltered</code>, …</span>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-mcu" class="form-label">Microcontroller Unit (MCU)</label>
+                <select id="cfg-mcu" class="form-select">
+                  <option value="PICO2W" selected>Raspberry Pi Pico 2 W (RP2350 + WiFi for OTA/Syslog)</option>
+                  <option value="PICO2">Raspberry Pi Pico 2 (RP2350 - Native USB CDC)</option>
+                  <option value="PICOW">Raspberry Pi Pico W (RP2040 + WiFi for OTA/Syslog)</option>
+                  <option value="PICO">Raspberry Pi Pico (RP2040 - Native USB CDC)</option>
+                  <option value="ESP32">Espressif ESP32 (Dual Core / WiFi & Bluetooth)</option>
+                  <option value="ESP32S3">Espressif ESP32-S3 (SuperMini / Native USB CDC)</option>
+                  <option value="ESP32S2">Espressif ESP32-S2 (Single Core)</option>
+                  <option value="GENDRV">Waveshare ESP32 General Driver Board</option>
+                </select>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-transport" class="form-label">micro-ROS Transport</label>
+                <select id="cfg-transport" class="form-select">
+                  <option value="SERIAL" selected>USB Serial Transport (/dev/ttyACM0 or /dev/ttyUSB0)</option>
+                  <option value="WIFI_UDP">WiFi UDP (Micro-ROS Agent on Host)</option>
+                </select>
+              </div>
+
+              <div class="form-group" id="group-serial-baudrate">
+                <label for="cfg-baudrate" class="form-label">Serial Communication Baud Rate</label>
+                <select id="cfg-baudrate" class="form-select font-mono">
+                  <option value="1500000">1500000 (1.5M Baud — High-Throughput ESP32 / GenDrv CP2102N)</option>
+                  <option value="921600" selected>921600 (micro-ROS & Diagnostics Baseline)</option>
+                  <option value="460800">460800</option>
+                  <option value="230400">230400</option>
+                  <option value="115200">115200 (Legacy / Low Speed)</option>
+                </select>
+                <span class="input-hint">High-speed 1.5M / 921.6k baud ensures multi-topic 50.0 Hz telemetry throughput.</span>
+                <span id="cfg-baudrate-chip-hint" class="input-hint" style="display:none;"></span>
+              </div>
+
+              <div class="form-group" id="group-serial-interface">
+                <label for="cfg-serial-interface" class="form-label">Serial Interface (ESP32-S2 / ESP32-S3)</label>
+                <select id="cfg-serial-interface" class="form-select">
+                  <option value="CDC" selected>Native USB CDC (/dev/ttyACM0) — Direct On-Chip USB</option>
+                  <option value="BRIDGE">USB-to-UART Bridge (/dev/ttyUSB0) — CP2102/CH340/FTDI</option>
+                </select>
+                <span class="input-hint">Select whether your S2/S3 board uses native USB CDC or an onboard USB-UART bridge.</span>
+              </div>
+
+              <div class="form-group" id="group-wifi-telemetry">
+                <label class="checkbox-label" style="margin-top: 10px;">
+                  <input type="checkbox" id="cfg-wifi-telemetry" checked>
+                  <span><strong>Enable Background WiFi for OTA & Syslog</strong> (Pico W / Pico 2 W / ESP32)</span>
+                </label>
+                <span class="input-hint">Keeps micro-ROS on USB Serial while enabling wireless OTA flashing & Syslog</span>
+              </div>
+
+              <div class="form-group" id="group-dual-core">
+                <label class="checkbox-label" style="margin-top: 10px;">
+                  <input type="checkbox" id="cfg-dual-core" checked>
+                  <span><strong>Enable Dual-Core Task Allocation (Strict 50Hz Real-Time PID on Core 1)</strong> (ESP32)</span>
+                </label>
+                <span class="input-hint">Pins high-priority motor PID and encoder loop to Core 1 via FreeRTOS vTaskDelayUntil (20ms), isolating motor control from I2C bus and communication latency</span>
+              </div>
+
+              <div class="form-group" id="group-wdt">
+                <label class="checkbox-label" style="margin-top: 10px;">
+                  <input type="checkbox" id="cfg-wdt-enable">
+                  <span><strong>Enable Hardware Task Watchdog (WDT)</strong> (ESP32 / Pico)</span>
+                </label>
+                <span class="input-hint">Automatically resets MCU if main control loop hangs or micro-ROS locks up</span>
+              </div>
+
+              <div class="form-group" id="group-wdt-timeout" style="display: none;">
+                <label for="cfg-wdt-timeout" class="form-label">Watchdog Timeout (Seconds)</label>
+                <input type="number" id="cfg-wdt-timeout" class="form-input" value="60" min="1" max="300" step="1">
+                <span class="input-hint">Timeout period (default: 60s, recommended: 30–60s)</span>
+              </div>
+            </div>
+
+            <!-- WiFi Details (Conditional) -->
+            <div id="wifi-config-box" class="sub-panel" style="display: none;">
+              <h3 class="sub-title">📶 WiFi & micro-ROS Agent Settings</h3>
+              <div class="form-grid">
+                <div class="form-group">
+                  <label for="cfg-wifi-ssid" class="form-label">WiFi SSID</label>
+                  <input type="text" id="cfg-wifi-ssid" class="form-input" value="YOUR_WIFI_SSID">
+                </div>
+                <div class="form-group">
+                  <label for="cfg-wifi-pass" class="form-label">WiFi Password</label>
+                  <input type="password" id="cfg-wifi-pass" class="form-input" value="YOUR_WIFI_PASSWORD">
+                  <label class="checkbox-label" style="margin-top:4px;font-size:0.78rem;">
+                    <input type="checkbox" id="cfg-wifi-pass-show"> <span>Show password</span>
+                  </label>
+                </div>
+                <div class="form-group">
+                  <label for="cfg-agent-ip" class="form-label">Agent Host IP Address</label>
+                  <input type="text" id="cfg-agent-ip" class="form-input" value="192.168.1.100" data-auto-managed="true">
+                </div>
+                <div class="form-group">
+                  <label for="cfg-agent-port" class="form-label">Agent UDP Port</label>
+                  <input type="number" id="cfg-agent-port" class="form-input" value="8888">
+                </div>
+              </div>
+              <!-- UDP Syslog Server & Streamer Card -->
+              <div class="syslog-card" id="syslog-config-card">
+                <div class="syslog-header">
+                  <div class="syslog-title-wrap">
+                    <span class="syslog-icon">📡</span>
+                    <div>
+                      <h4 class="syslog-title">UDP Syslog Server & Telemetry Logger</h4>
+                      <span class="input-hint" style="margin:0;">Receives real-time wireless debug telemetry from robot MCU and saves to <code>logs/</code></span>
+                    </div>
+                  </div>
+                  <div class="syslog-status-badge stopped" id="syslog-status-badge">
+                    <span class="pulse-dot" id="syslog-status-dot"></span>
+                    <span id="syslog-status-text">Syslog: Offline</span>
+                  </div>
+                </div>
+
+                <div class="syslog-controls-grid">
+                  <div class="form-group" style="margin-bottom:0;">
+                    <label for="cfg-syslog-ip" class="form-label">Syslog Server IP</label>
+                    <input type="text" id="cfg-syslog-ip" class="form-input font-mono" value="192.168.1.100" data-auto-managed="true" placeholder="host running the UI">
+                    <span class="input-hint">Auto-set to this host when you launch the server below</span>
+                  </div>
+                  <div class="form-group" style="margin-bottom:0;">
+                    <label for="cfg-syslog-port" class="form-label">Syslog UDP Port</label>
+                    <input type="number" id="cfg-syslog-port" class="form-input font-mono" value="514" placeholder="514 or 5140">
+                  </div>
+                  <div class="form-group" style="margin-bottom:0;">
+                    <label for="cfg-wifi-monitor" class="form-label">Wi-Fi RSSI → syslog (min)</label>
+                    <input type="number" id="cfg-wifi-monitor" class="form-input font-mono" value="0" min="0" max="60" placeholder="0 = off">
+                    <span class="input-hint">Periodic <code>WIFI_MONITOR</code> RSSI report; 0 disables</span>
+                  </div>
+                  <div class="btn-group-row" style="margin-top:0;">
+                    <button type="button" id="btn-syslog-start" class="btn btn-sm btn-primary flex-1" title="Launch background UDP Syslog receiver">
+                      <span>▶️ Launch Syslog Server</span>
+                    </button>
+                    <button type="button" id="btn-syslog-stop" class="btn btn-sm btn-danger flex-1" style="display:none;" title="Stop UDP Syslog receiver">
+                      <span>⏹️ Stop Server</span>
+                    </button>
+                    <button type="button" id="btn-syslog-view-logs" class="btn btn-sm btn-ghost" title="Inspect recent syslog files in logs/">
+                      <span>📂 Logs</span>
+                    </button>
+                  </div>
+                </div>
+
+                <div class="syslog-stats-bar" id="syslog-stats-bar">
+                  <div class="syslog-stat-item">
+                    <span class="syslog-stat-label">Active Log:</span>
+                    <span class="syslog-stat-val" id="syslog-stat-file">logs/syslog_YYYYMMDD.log</span>
+                  </div>
+                  <div class="syslog-stat-item">
+                    <span class="syslog-stat-label">Packets:</span>
+                    <span class="syslog-stat-val" id="syslog-stat-packets">0</span>
+                  </div>
+                  <div class="syslog-stat-item">
+                    <span class="syslog-stat-label">Last Client:</span>
+                    <span class="syslog-stat-val" id="syslog-stat-client">--</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- LiDAR over WiFi UDP -->
+              <div class="sub-panel">
+                <h3 class="sub-title">🛰️ LiDAR over WiFi UDP</h3>
+                <label class="checkbox-label">
+                  <input type="checkbox" id="cfg-lidar-udp">
+                  <span>Forward raw LiDAR serial frames to a host over UDP</span>
+                </label>
+                <span class="input-hint">With a <em>real</em> LiDAR this still needs the sensor wired to the LiDAR RX pin &mdash; UDP only carries what the board receives. With <em>fake</em> LD19 it needs no wiring at all: the emulated scan is generated on the board and goes straight out over WiFi.</span>
+                <div class="form-grid mt-2">
+                  <div class="form-group">
+                    <label for="cfg-lidar-ip" class="form-label">LiDAR UDP Server IP</label>
+                    <input type="text" id="cfg-lidar-ip" class="form-input font-mono" value="192.168.1.100" data-auto-managed="true">
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-lidar-port" class="form-label">LiDAR UDP Port</label>
+                    <input type="number" id="cfg-lidar-port" class="form-input font-mono" value="8889">
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-lidar-uart" class="form-label">LiDAR UART Number</label>
+                    <input type="number" id="cfg-lidar-uart" class="form-input" value="1" min="0" max="3">
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-lidar-baud" class="form-label">LiDAR Baud Rate</label>
+                    <select id="cfg-lidar-baud" class="form-select font-mono">
+                      <option value="115200">115200 — LD14</option>
+                      <option value="230400" selected>230400 — LD06 / LD19 / LD14P / STL-06N / D300 / D500</option>
+                      <option value="460800">460800</option>
+                      <option value="921600">921600 — LD19 Plus / STL-27L</option>
+                      <option value="1000000">1000000</option>
+                    </select>
+                    <span class="input-hint">LDROBOT/LDLIDAR default rates (8N1). Match your model.</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Arduino OTA (settings — the "flash over OTA" action toggle is on Tab 5 §5) -->
+              <div class="sub-panel">
+                <h3 class="sub-title">📶 Arduino OTA (wireless flashing)</h3>
+                <span class="input-hint">Turn OTA flashing on/off next to the upload buttons on Tab 5 → “5. Standalone …”.</span>
+                <div class="form-grid mt-2">
+                  <div class="form-group">
+                    <label for="cfg-ota-ip" class="form-label">Device IP (OTA target)</label>
+                    <input type="text" id="cfg-ota-ip" class="form-input font-mono" value="" data-auto-managed="true" placeholder="auto from syslog / mDNS">
+                    <span class="input-hint">Filled from the last syslog client when available</span>
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-ota-hostname" class="form-label">mDNS Hostname</label>
+                    <input type="text" id="cfg-ota-hostname" class="form-input font-mono" value="" data-auto-managed="true" placeholder="robot name">
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-ota-password" class="form-label">OTA Password <span class="badge-optional">Optional</span></label>
+                    <input type="password" id="cfg-ota-password" class="form-input" value="">
+                    <label class="checkbox-label" style="margin-top:4px;font-size:0.78rem;">
+                      <input type="checkbox" id="cfg-ota-password-show"> <span>Show password</span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+
+
+            </div>
+          </div>
+        </div>
+
+        <!-- Tab 2: Drive & Motors -->
+        <div class="tab-pane" id="tab-drive">
+          <div class="form-section">
+            <h2 class="section-title">Kinematics Base</h2>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="cfg-kinematics" class="form-label">Kinematics Base Type</label>
+                <select id="cfg-kinematics" class="form-select">
+                  <option value="DIFFERENTIAL_DRIVE" selected>2WD Differential Drive (2 Motors)</option>
+                  <option value="SKID_STEER">4WD Skid Steer (4 Motors)</option>
+                  <option value="MECANUM">4WD Mecanum Drive (4 Motors)</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <h2 class="section-title">Motor Driver & Encoder Specifications</h2>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="cfg-driver-type" class="form-label">Motor Driver Type</label>
+                <select id="cfg-driver-type" class="form-select">
+                  <option value="BTS7960" selected>2 output pins — dual PWM, no enable (BTS7960 / DRV8833 / TB6612 / L298N driven PWM-only) — Recommended, saves I/O</option>
+                  <option value="GENERIC_2_IN">3 output pins — 2 direction + 1 enable/PWM (L298N or TB6612 with STBY, VNH5019)</option>
+                  <option value="GENERIC_1_IN">2 output pins — PWM + single direction (Cytron MD10C)</option>
+                  <option value="ESC">1 output pin — RC / ESC servo PWM</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label for="cfg-max-rpm" class="form-label">Rated Motor Max RPM</label>
+                <input type="number" id="cfg-max-rpm" class="form-input" value="400" min="10" max="5000">
+                <span class="input-hint">Max unloaded or rated RPM under operating voltage</span>
+              </div>
+              <div class="form-group">
+                <label for="cfg-cpr" class="form-label">Encoder Counts Per Revolution (CPR)</label>
+                <input type="number" id="cfg-cpr" class="form-input" value="1440" min="10" max="100000">
+                <span class="input-hint">Total quadrature ticks per full wheel turn</span>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Velocity PID Constants <span class="badge-optional">per-wheel closed loop</span></label>
+                <div class="form-grid" style="grid-template-columns:repeat(3,1fr);gap:8px;">
+                  <div>
+                    <label for="cfg-pid-kp" class="input-hint" style="display:block;">K_P</label>
+                    <input type="number" id="cfg-pid-kp" class="form-input font-mono" value="0.6" step="0.05" min="0">
+                  </div>
+                  <div>
+                    <label for="cfg-pid-ki" class="input-hint" style="display:block;">K_I</label>
+                    <input type="number" id="cfg-pid-ki" class="form-input font-mono" value="0.8" step="0.05" min="0">
+                  </div>
+                  <div>
+                    <label for="cfg-pid-kd" class="input-hint" style="display:block;">K_D</label>
+                    <input type="number" id="cfg-pid-kd" class="form-input font-mono" value="0.5" step="0.05" min="0">
+                  </div>
+                </div>
+                <span class="input-hint">Motor RPM PID gains (<code>K_P</code> / <code>K_I</code> / <code>K_D</code>). Defaults 0.6 / 0.8 / 0.5.</span>
+              </div>
+              <div class="form-group">
+                <label for="cfg-motor-voltage" class="form-label">Motor Operating Voltage (V)</label>
+                <input type="number" id="cfg-motor-voltage" class="form-input" value="12.0" step="0.5">
+              </div>
+              <div class="form-group">
+                <label for="cfg-motor-torque" class="form-label">Motor Rated Torque (kg·cm) <span class="badge-optional">Optional</span></label>
+                <input type="number" id="cfg-motor-torque" class="form-input" value="1.5" step="0.1" min="0.1" max="100.0">
+                <span class="input-hint">Rated / Stall torque per motor (1.5 kg·cm = 0.15 N·m)</span>
+              </div>
+            </div>
+
+          </div>
+
+          <div class="form-section">
+            <h2 class="section-title">Chassis Geometry &amp; Physics</h2>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="cfg-wheel-dia" class="form-label">Wheel Diameter (m)</label>
+                <input type="number" id="cfg-wheel-dia" class="form-input" value="0.08" step="0.005" min="0.01" max="1.0">
+                <span class="input-hint">e.g. 0.08m = 80mm</span>
+              </div>
+              <div class="form-group">
+                <label for="cfg-track-width" class="form-label">Track Width (LR Wheels Distance) (m)</label>
+                <input type="number" id="cfg-track-width" class="form-input" value="0.22" step="0.005" min="0.05" max="2.0">
+                <span class="input-hint">Center-to-center distance between Left and Right wheels</span>
+              </div>
+              <div class="form-group" id="group-wheelbase" style="display: none;">
+                <label for="cfg-wheelbase" class="form-label">Wheelbase (FR Wheels Distance) (m)</label>
+                <input type="number" id="cfg-wheelbase" class="form-input" value="0.20" step="0.005" min="0.05" max="2.0">
+                <span class="input-hint">Front-to-rear axle distance (for 4WD/Mecanum)</span>
+              </div>
+              <div class="form-group">
+                <label for="cfg-weight" class="form-label">Robot Total Weight (kg) <span class="badge-optional">Optional</span></label>
+                <input type="number" id="cfg-weight" class="form-input" value="3.5" step="0.1" min="0.1" max="200.0">
+              </div>
+              <div class="form-group">
+                <label class="checkbox-label" style="cursor:pointer; display:flex; align-items:center; gap:0.5rem;">
+                  <input type="checkbox" id="cfg-fake-wheel">
+                  <span>Fake wheel mode <span class="badge-optional">Simulation</span></span>
+                </label>
+                <span class="input-hint">Simulate the drivetrain on the board itself, for a
+                  <b>bare module with no motors, drivers or encoders attached</b>. cmd_vel drives
+                  simulated wheels whose encoders report back with noise, so odometry and the IMU
+                  move as on a real robot and the board can be driven, visualised and mapped on its
+                  own. The simulated mass follows Robot Total Weight above.</span>
+                <span class="input-hint">Used to calculate max linear acceleration &amp; inertia</span>
+              </div>
+              <div class="form-group" style="border-top: 1px dashed rgba(255,255,255,0.1); padding-top: 0.75rem; margin-top: 0.5rem;">
+                <label class="checkbox-label" style="cursor:pointer; display:flex; align-items:center; gap:0.5rem;">
+                  <input type="checkbox" id="cfg-fake-ld19">
+                  <span>Fake LD19 LiDAR Mode <span class="badge-optional">Simulation</span></span>
+                </label>
+                <span class="input-hint">Embed a real-time 2D raycast LD19 LiDAR emulator inside the firmware. Outputs standard 47-byte packets @ 230400 baud on <code>LIDAR_RXD</code> (and UDP 8889). The scan follows odometry driven by <code>/cmd_vel</code> so you can run SLAM, Nav2, and save maps on a bare module.</span>
+              </div>
+              <div id="fake-ld19-settings-block" style="display:none; padding:0.75rem; background:rgba(0,0,0,0.2); border-radius:6px; border:1px solid rgba(56,189,248,0.2); margin-top:0.5rem;">
+                <div style="display:grid; grid-template-columns:1fr 1fr; gap:0.75rem; margin-bottom:0.5rem;">
+                  <div>
+                    <label for="cfg-map-width" class="form-label" style="font-size:0.8rem;">Room Width (m)</label>
+                    <input type="number" id="cfg-map-width" class="form-input" value="10.0" step="0.5" min="1.0" max="50.0">
+                  </div>
+                  <div>
+                    <label for="cfg-map-height" class="form-label" style="font-size:0.8rem;">Room Height (m)</label>
+                    <input type="number" id="cfg-map-height" class="form-input" value="6.0" step="0.5" min="1.0" max="50.0">
+                  </div>
+                </div>
+                <div style="margin-top:0.25rem;">
+                  <label class="checkbox-label" style="cursor:pointer; display:flex; align-items:center; gap:0.5rem; font-size:0.85rem;">
+                    <input type="checkbox" id="cfg-wall-obstacle" checked>
+                    <span>Add Short Obstacle Wall in Room</span>
+                  </label>
+                  <div style="display:grid; grid-template-columns:1fr 1fr 1fr 1fr; gap:0.5rem; margin-top:0.25rem;">
+                    <div>
+                      <span class="input-hint" style="margin:0; font-size:0.75rem;">Start X</span>
+                      <input type="number" id="cfg-wall-x1" class="form-input font-mono" value="2.0" step="0.1" style="padding:0.25rem 0.5rem; font-size:0.8rem;">
+                    </div>
+                    <div>
+                      <span class="input-hint" style="margin:0; font-size:0.75rem;">Start Y</span>
+                      <input type="number" id="cfg-wall-y1" class="form-input font-mono" value="-1.5" step="0.1" style="padding:0.25rem 0.5rem; font-size:0.8rem;">
+                    </div>
+                    <div>
+                      <span class="input-hint" style="margin:0; font-size:0.75rem;">End X</span>
+                      <input type="number" id="cfg-wall-x2" class="form-input font-mono" value="2.0" step="0.1" style="padding:0.25rem 0.5rem; font-size:0.8rem;">
+                    </div>
+                    <div>
+                      <span class="input-hint" style="margin:0; font-size:0.75rem;">End Y</span>
+                      <input type="number" id="cfg-wall-y2" class="form-input font-mono" value="1.5" step="0.1" style="padding:0.25rem 0.5rem; font-size:0.8rem;">
+                    </div>
+                  </div>
+                  <span class="input-hint" style="font-size:0.75rem; margin-top:0.25rem;">Obstacle 1.0m ahead of robot (length 1.6m). Allows Nav2 to plan obstacle avoidance.</span>
+                </div>
+                <div style="margin-top:0.75rem; border-top:1px dashed rgba(255,255,255,0.1); padding-top:0.75rem;">
+                  <label class="checkbox-label" style="cursor:pointer; display:flex; align-items:center; gap:0.5rem; font-size:0.85rem;">
+                    <input type="checkbox" id="cfg-fake-sonar" checked>
+                    <span>Fake Sonar + Safety Stop</span>
+                  </label>
+                  <span class="input-hint" style="font-size:0.75rem; margin-top:0.25rem;">Publishes <code>/sonar</code> (<code>sensor_msgs/Range</code>) from the nearest return in a 30&deg; cone ahead, and stops the robot in firmware before it reaches an obstacle. Reverse stays available so you can back out. The stop state is published on <code>/safety_stop</code>. Needs no wiring &mdash; the range comes from the same raycast as the scan.</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Tab 3: Sensors -->
+        <div class="tab-pane" id="tab-sensors">
+          <!-- AI I2C Sensor Auto-Detection Card -->
+          <div class="card p-3 mb-3 border-accent-glow" style="background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.7)); border: 1px solid rgba(56, 189, 248, 0.3); border-radius: 8px; margin-bottom: 1.25rem;">
+            <div class="flex-between" style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+              <div>
+                <h4 style="color:#38bdf8; font-size:1.05rem; margin-bottom:0.25rem; font-weight: 600;">🤖 AI I2C Sensor Auto-Detection</h4>
+                <p class="text-muted" style="font-size:0.85rem; margin:0;">Probe active I2C bus, identify IMU / Mag / Current sensor chips via WHO_AM_I registers, and auto-select matching drivers.</p>
+              </div>
+              <button type="button" id="btn-auto-detect-i2c" class="btn btn-accent" style="white-space:nowrap; padding:0.6rem 1.2rem; cursor: pointer;">
+                <span class="btn-icon">⚡</span>
+                <span><strong>Auto-Detect Sensors</strong></span>
+              </button>
+            </div>
+            <div id="i2c-detect-results" class="mt-2" style="display:none; padding:0.6rem; background:rgba(0,0,0,0.3); border-radius:6px; font-size:0.85rem; margin-top: 0.75rem;"></div>
+          </div>
+
+          <div class="form-section">
+            <h2 class="section-title">IMU, Magnetometer & Battery Peripherals</h2>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="cfg-imu" class="form-label">Inertial Measurement Unit (IMU)</label>
+                <select id="cfg-imu" class="form-select">
+                  <option value="FAKE" selected>Fake IMU (Bare Module Default — Zero Drift / Zero Hang)</option>
+                  <optgroup label="Recommended — low drift / low noise">
+                    <option value="BNO085">BNO085 / BNO080 (best — onboard sensor fusion, state-machine recovery)</option>
+                    <option value="LSM6DSOX">LSM6DSOX (ST 6-DOF, low noise)</option>
+                    <option value="ICM20948">ICM-20948 (TDK 9-DOF, low noise; onboard AK09916 mag)</option>
+                    <option value="QMI8658">QMI8658 (6-DOF, Waveshare on-board IMU)</option>
+                  </optgroup>
+                  <optgroup label="Legacy — higher drift / noise (may cause SLAM drift)">
+                    <option value="MPU9250">MPU9250 (9-DOF IMU + Compass)</option>
+                    <option value="MPU6050">MPU6050 (6-DOF)</option>
+                    <option value="GY85">GY-85 (ADXL345 + ITG3200 + HMC5883L, 9-DOF)</option>
+                  </optgroup>
+                  <option value="NONE">None (Disabled)</option>
+                </select>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-mag" class="form-label">Magnetometer (Digital Compass)</label>
+                <select id="cfg-mag" class="form-select">
+                  <option value="NONE" selected>Fake Magnetometer (Default / Estimated)</option>
+                  <option value="ICM20948">ICM-20948 onboard AK09916 (needs ICM-20948 IMU)</option>
+                  <option value="AK09918">AK09918 (I2C Digital Compass)</option>
+                  <option value="QMC5883L">QMC5883L (I2C Digital Compass)</option>
+                  <option value="HMC5883L">HMC5883L (Legacy Compass)</option>
+                </select>
+              </div>
+
+              <div class="form-group" id="group-imu-tuning">
+                <label class="form-label">Magnetometer Hard-Iron Bias <span class="badge-optional">Optional</span></label>
+                <div class="form-grid" style="grid-template-columns:repeat(3,1fr);gap:8px;">
+                  <div>
+                    <label for="cfg-mag-bias-x" class="input-hint" style="display:block;">X (µT)</label>
+                    <input type="number" id="cfg-mag-bias-x" class="form-input font-mono" value="" step="0.1" placeholder="0">
+                  </div>
+                  <div>
+                    <label for="cfg-mag-bias-y" class="input-hint" style="display:block;">Y (µT)</label>
+                    <input type="number" id="cfg-mag-bias-y" class="form-input font-mono" value="" step="0.1" placeholder="0">
+                  </div>
+                  <div>
+                    <label for="cfg-mag-bias-z" class="input-hint" style="display:block;">Z (µT)</label>
+                    <input type="number" id="cfg-mag-bias-z" class="form-input font-mono" value="" step="0.1" placeholder="0">
+                  </div>
+                </div>
+                <span class="input-hint">Subtracted from each raw reading (<code>#define MAG_BIAS</code>). Leave all blank to skip.</span>
+              </div>
+
+              <div class="form-group" style="grid-column:1 / -1;">
+                <label class="form-label">Covariance Overrides <span class="badge-optional">Optional</span></label>
+                <div class="form-grid" style="grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px 16px;">
+                  <div>
+                    <label for="cfg-cov-accel" class="input-hint" style="display:block;">ACCEL_COV</label>
+                    <input type="number" id="cfg-cov-accel" class="form-input font-mono" value="" step="0.0001" placeholder="1e-5">
+                  </div>
+                  <div>
+                    <label for="cfg-cov-gyro" class="input-hint" style="display:block;">GYRO_COV</label>
+                    <input type="number" id="cfg-cov-gyro" class="form-input font-mono" value="" step="0.0001" placeholder="1e-5">
+                  </div>
+                  <div>
+                    <label for="cfg-cov-ori" class="input-hint" style="display:block;">ORI_COV</label>
+                    <input type="number" id="cfg-cov-ori" class="form-input font-mono" value="" step="0.0001" placeholder="1e-5">
+                  </div>
+                  <div>
+                    <label for="cfg-cov-mag" class="input-hint" style="display:block;">MAG_COV</label>
+                    <input type="number" id="cfg-cov-mag" class="form-input font-mono" value="" step="0.0001" placeholder="1e-5">
+                  </div>
+                  <div style="grid-column:1 / -1;">
+                    <label for="cfg-cov-pose" class="input-hint" style="display:block;">POSE_COV</label>
+                    <input type="text" id="cfg-cov-pose" class="form-input font-mono" value="" placeholder="scalar, or x,y,z,roll,pitch,yaw">
+                  </div>
+                  <div style="grid-column:1 / -1;">
+                    <label for="cfg-cov-twist" class="input-hint" style="display:block;">TWIST_COV</label>
+                    <input type="text" id="cfg-cov-twist" class="form-input font-mono" value="" placeholder="scalar, or x,y,z,roll,pitch,yaw">
+                  </div>
+                  <div style="grid-column:1 / -1;">
+                    <label for="cfg-cov-env" class="input-hint" style="display:block;">ENV_COV</label>
+                    <input type="text" id="cfg-cov-env" class="form-input font-mono" value="" placeholder="scalar, or pressure, temperature, humidity">
+                  </div>
+                </div>
+                <span class="input-hint">Diagonal covariance overrides. ACCEL / GYRO / ORI / MAG → <code>/imu/data*</code> (3 values); POSE / TWIST → <code>/odom/unfiltered</code> (6 values — a scalar expands, or list all 6); ENV → <code>/pressure /temperature /humidity</code> <code>.variance</code> (3 values). ACCEL / GYRO / MAG / ENV auto-fill from the selected sensor's datasheet — type to override, clear to fall back to the firmware default.</span>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-battery" class="form-label">Battery Voltage Monitoring</label>
+                <select id="cfg-battery" class="form-select">
+                  <option value="NONE" selected>None (Bare Module Default)</option>
+                  <option value="ADC_DIVIDER">ADC Resistor Voltage Divider (R1: 30kΩ, R2: 7.5kΩ)</option>
+                  <option value="INA219">INA219 (I2C Current & Voltage Sensor)</option>
+                </select>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-env" class="form-label">Environmental Sensor (Barometer)</label>
+                <select id="cfg-env" class="form-select">
+                  <option value="NONE" selected>None</option>
+                  <option value="BMP280">BMP280 (I2C pressure + temperature)</option>
+                  <option value="BME280">BME280 (I2C pressure + temperature + humidity)</option>
+                </select>
+                <span class="input-hint">Publishes <code>/pressure</code> + <code>/temperature</code> (and <code>/humidity</code> for a BME280) at 1 Hz. The driver auto-detects the chip at I2C <code>0x77</code>/<code>0x76</code> — BMP280 vs BME280 here just sets your expectation.</span>
+              </div>
+
+              <!-- Battery Parameters Sub-Panel -->
+              <div id="battery-params-box" class="sub-panel">
+                <h3 class="sub-title">🔋 Battery Capacity & Voltage Specs</h3>
+                <div class="form-grid">
+                  <div class="form-group">
+                    <label for="cfg-bat-cap" class="form-label">Battery Capacity (Ah)</label>
+                    <input type="number" id="cfg-bat-cap" class="form-input" value="2.2" step="0.1" min="0.1" max="100.0">
+                    <span class="input-hint">Rated capacity (enables /battery remaining capacity)</span>
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-bat-nom" class="form-label">Nominal Voltage (V)</label>
+                    <input type="number" id="cfg-bat-nom" class="form-input" value="11.1" step="0.1" min="1.0" max="60.0">
+                    <span class="input-hint">e.g. 11.1V (3S LiPo), 12.0V, 24.0V</span>
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-bat-min" class="form-label">Min Cutoff Voltage (0% V)</label>
+                    <input type="number" id="cfg-bat-min" class="form-input" value="9.0" step="0.1" min="1.0" max="50.0">
+                    <span class="input-hint">Low-voltage cutoff threshold</span>
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-bat-max" class="form-label">Max Full Voltage (100% V)</label>
+                    <input type="number" id="cfg-bat-max" class="form-input" value="12.6" step="0.1" min="1.0" max="65.0">
+                    <span class="input-hint">Full charge voltage threshold</span>
+                  </div>
+                  <div class="form-group">
+                    <label for="cfg-bat-dip" class="form-label">Voltage Drop Alert (DIP Ratio)</label>
+                    <input type="number" id="cfg-bat-dip" class="form-input" value="" step="0.01" min="0.5" max="1.0" placeholder="blank = off · e.g. 0.98">
+                    <span class="input-hint">Off by default (it adds an out-of-band <code>/battery</code> burst on sag, costing I2C/serial bandwidth). Set e.g. <code>0.98</code> to enable.</span>
+                  </div>
+                </div>
+
+                <!-- Voltage Divider Resistors & Filter Capacitor Config -->
+                <div id="adc-divider-config-box" class="mt-3">
+                  <h4 class="sub-title-sm">⚡ ADC Voltage Divider Resistors & Noise Filter</h4>
+                  <div class="form-grid">
+                    <div class="form-group">
+                      <label for="cfg-bat-r1" class="form-label">Upper Resistor R1 (Ω)</label>
+                      <input type="number" id="cfg-bat-r1" class="form-input" value="30000" step="100" min="100" max="1000000">
+                      <span class="input-hint">High-side resistor to +VBAT (e.g. 30kΩ, 33kΩ, 10kΩ)</span>
+                    </div>
+                    <div class="form-group">
+                      <label for="cfg-bat-r2" class="form-label">Lower Resistor R2 (Ω)</label>
+                      <input type="number" id="cfg-bat-r2" class="form-input" value="7500" step="100" min="100" max="1000000">
+                      <span class="input-hint">Low-side resistor to GND (e.g. 7.5kΩ, 10kΩ, 1kΩ)</span>
+                    </div>
+                    <div class="form-group">
+                      <label for="cfg-bat-cap" class="form-label">ADC Filter Capacitor C (pF)</label>
+                      <input type="number" id="cfg-bat-cap-val" class="form-input" value="1000" step="100" min="0" max="100000">
+                      <span class="input-hint">Parallel capacitor to GND (1000pF / 1nF recommended)</span>
+                    </div>
+                  </div>
+
+                  <!-- Real-time ADC Voltage & 3.0V Safety Warning Banner -->
+                  <div id="bat-adc-safety-banner" class="adc-safety-banner safe">
+                    <div class="safety-banner-icon" id="safety-banner-icon">🛡️</div>
+                    <div class="safety-banner-content">
+                      <div class="safety-banner-title" id="safety-banner-title">ADC Input Voltage: Safe (&le; 3.0V)</div>
+                      <div class="safety-banner-desc" id="safety-banner-desc">
+                        Divider Ratio: <code id="lbl-divider-ratio">0.2000 (1:5)</code> | Max ADC Pin Voltage: <code id="lbl-adc-max-v">2.52 V</code> at full charge (12.6V).
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <label for="cfg-sonar" class="form-label">Ultrasonic Sonar Range Sensor</label>
+                <select id="cfg-sonar" class="form-select">
+                  <option value="false" selected>Disabled (Bare Module Default)</option>
+                  <option value="true">Enabled (HC-SR04 on /sonar)</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Tab 4: Pinout Matrix -->
+        <div class="tab-pane" id="tab-pins">
+          <div class="form-section">
+            <div class="section-header-flex">
+              <h2 class="section-title">Microcontroller Pin Allocation</h2>
+              <button id="btn-smart-alloc" class="btn btn-sm btn-accent" title="Auto-assign verified conflict-free pins">
+                <span>⚡ Smart Auto-Assign</span>
+              </button>
+            </div>
+
+            <!-- LED Pin -->
+            <div class="form-grid mb-3">
+              <div class="form-group">
+                <label for="pin-led" class="form-label">Status LED Pin (GPIO)</label>
+                <input type="number" id="pin-led" class="form-input pin-input" value="25">
+              </div>
+            </div>
+
+            <!-- Motor Pins -->
+            <h3 class="sub-title">🏎️ Motor Driver Pins</h3>
+            <div class="pin-table-wrapper">
+              <table class="pin-table">
+                <thead>
+                  <tr id="motor-pin-headers">
+                    <th>Motor</th>
+                    <th>PWM / PWM_R</th>
+                    <th>IN_A / PWM_L</th>
+                    <th>IN_B / EN</th>
+                    <th title="Invert motor spin direction">Invert</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><strong>Motor 1 (Left)</strong></td>
+                    <td><input type="number" id="pin-m1-p1" class="form-input pin-input" value="14"></td>
+                    <td><input type="number" id="pin-m1-p2" class="form-input pin-input" value="15"></td>
+                    <td><input type="number" id="pin-m1-p3" class="form-input pin-input" value="13"></td>
+                  <td style="text-align:center;"><input type="checkbox" id="pin-m1-inv"></td>
+                  </tr>
+                  <tr>
+                    <td><strong>Motor 2 (Right)</strong></td>
+                    <td><input type="number" id="pin-m2-p1" class="form-input pin-input" value="16"></td>
+                    <td><input type="number" id="pin-m2-p2" class="form-input pin-input" value="17"></td>
+                    <td><input type="number" id="pin-m2-p3" class="form-input pin-input" value="12"></td>
+                  <td style="text-align:center;"><input type="checkbox" id="pin-m2-inv" checked></td>
+                  </tr>
+                  <tr id="row-motor-3" style="display: none;">
+                    <td><strong>Motor 3 (Rear L)</strong></td>
+                    <td><input type="number" id="pin-m3-p1" class="form-input pin-input" value="8"></td>
+                    <td><input type="number" id="pin-m3-p2" class="form-input pin-input" value="9"></td>
+                    <td><input type="number" id="pin-m3-p3" class="form-input pin-input" value="10"></td>
+                  <td style="text-align:center;"><input type="checkbox" id="pin-m3-inv"></td>
+                  </tr>
+                  <tr id="row-motor-4" style="display: none;">
+                    <td><strong>Motor 4 (Rear R)</strong></td>
+                    <td><input type="number" id="pin-m4-p1" class="form-input pin-input" value="11"></td>
+                    <td><input type="number" id="pin-m4-p2" class="form-input pin-input" value="18"></td>
+                    <td><input type="number" id="pin-m4-p3" class="form-input pin-input" value="19"></td>
+                  <td style="text-align:center;"><input type="checkbox" id="pin-m4-inv" checked></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <!-- Encoder Pins -->
+            <h3 class="sub-title mt-4">📟 Encoder Quadrature Pins</h3>
+            <div class="pin-table-wrapper">
+              <table class="pin-table">
+                <thead>
+                  <tr>
+                    <th>Channel</th>
+                    <th>Encoder Pin A (Interrupt)</th>
+                    <th>Encoder Pin B (Direction)</th>
+                    <th title="Invert encoder count direction">Invert</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><strong>Encoder 1 (Left)</strong></td>
+                    <td><input type="number" id="pin-enc-1a" class="form-input pin-input" value="2"></td>
+                    <td><input type="number" id="pin-enc-1b" class="form-input pin-input" value="3"></td>
+                    <td style="text-align:center;"><input type="checkbox" id="pin-enc-1-inv" title="Invert encoder 1 count"></td>
+                  </tr>
+                  <tr>
+                    <td><strong>Encoder 2 (Right)</strong></td>
+                    <td><input type="number" id="pin-enc-2a" class="form-input pin-input" value="4"></td>
+                    <td><input type="number" id="pin-enc-2b" class="form-input pin-input" value="5"></td>
+                    <td style="text-align:center;"><input type="checkbox" id="pin-enc-2-inv" title="Invert encoder 2 count"></td>
+                  </tr>
+                  <tr id="row-enc-3" style="display: none;">
+                    <td><strong>Encoder 3 (Rear L)</strong></td>
+                    <td><input type="number" id="pin-enc-3a" class="form-input pin-input" value="6"></td>
+                    <td><input type="number" id="pin-enc-3b" class="form-input pin-input" value="7"></td>
+                    <td style="text-align:center;"><input type="checkbox" id="pin-enc-3-inv" title="Invert encoder 3 count"></td>
+                  </tr>
+                  <tr id="row-enc-4" style="display: none;">
+                    <td><strong>Encoder 4 (Rear R)</strong></td>
+                    <td><input type="number" id="pin-enc-4a" class="form-input pin-input" value="20"></td>
+                    <td><input type="number" id="pin-enc-4b" class="form-input pin-input" value="21"></td>
+                    <td style="text-align:center;"><input type="checkbox" id="pin-enc-4-inv" title="Invert encoder 4 count"></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <!-- Auxiliary & Bus Pins -->
+            <h3 class="sub-title mt-4">🛰️ I2C Bus & Sensor Pins</h3>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="pin-i2c-sda" class="form-label">I2C SDA Pin</label>
+                <input type="number" id="pin-i2c-sda" class="form-input pin-input" value="8">
+              </div>
+              <div class="form-group">
+                <label for="pin-i2c-scl" class="form-label">I2C SCL Pin</label>
+                <input type="number" id="pin-i2c-scl" class="form-input pin-input" value="9">
+              </div>
+              <div class="form-group" id="box-battery-pin">
+                <label for="pin-battery" class="form-label">Battery ADC Pin</label>
+                <input type="number" id="pin-battery" class="form-input pin-input" value="26">
+                <span class="input-hint">Pico: GP26, GP27, GP28</span>
+              </div>
+              <div class="form-group" id="box-sonar-trig">
+                <label for="pin-sonar-trig" class="form-label">Sonar Trigger Pin</label>
+                <input type="number" id="pin-sonar-trig" class="form-input pin-input" value="18">
+              </div>
+              <div class="form-group" id="box-sonar-echo">
+                <label for="pin-sonar-echo" class="form-label">Sonar Echo Pin</label>
+                <input type="number" id="pin-sonar-echo" class="form-input pin-input" value="19">
+              </div>
+              <div class="form-group" id="box-lidar-rxd">
+                <label for="cfg-lidar-rxd" class="form-label">LiDAR Serial RX Pin</label>
+                <input type="number" id="cfg-lidar-rxd" class="form-input pin-input" value="-1">
+                <span class="input-hint"><strong>Needs a physical wire.</strong> This GPIO carries LiDAR serial data, so it only works once it is actually connected &mdash; leave it <code>-1</code> if it is not.
+                  <br>&bull; <strong>Real LD19 &rarr; UDP:</strong> wire the LiDAR's TX to this pin; the board forwards the frames to your computer.
+                  <br>&bull; <strong>Fake LD19 over serial:</strong> the board <em>transmits</em> the emulated scan on this pin, so wire it to whatever reads it (a USB-TTL adapter, or the SBC's UART).
+                  <br>&bull; <strong>Fake LD19 over WiFi UDP: no wire at all</strong> &mdash; the scan is sent over the network, so leave this at <code>-1</code>. This is the only LiDAR option that works on an untouched board.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Tab 5: Automation & Deployment -->
+        <div class="tab-pane" id="tab-automation">
+          <div class="form-section">
+            <h2 class="section-title">🚀 Robot SBC Host Automation & Flashing Hub</h2>
+            <p class="section-desc">Automate your entire workflow directly on the headless Robot Host Computer (e.g. Raspberry Pi 4/5, Jetson Orin, or x86 Mini-PC): detect robot SBC environment, install toolchains, configure ROS 2, merge generated C++ headers, flash connected microcontrollers, and run the micro-ROS agent.</p>
+
+            <!-- Robot Host Detection Banner -->
+            <div class="os-detect-banner" id="os-detect-banner">
+              <div class="os-detect-info">
+                <span class="os-icon-large" id="os-banner-icon">🤖</span>
+                <div>
+                  <div class="os-banner-title">
+                    <span id="os-banner-detected-text">Target Robot SBC: Auto-Detecting...</span>
+                    <span class="badge-pill badge-ok" id="os-banner-status">Robot Host Online</span>
+                  </div>
+                  <p class="os-banner-sub" id="os-banner-sub">Architecture: <strong id="os-banner-arch">aarch64</strong> | Connected MCU Ports: <span id="os-banner-ports" style="color:var(--accent); font-weight:600;">/dev/ttyACM0</span></p>
+                </div>
+              </div>
+              <button type="button" id="btn-redetect-os" class="btn btn-sm btn-ghost" title="Re-scan robot computer hardware and serial ports">
+                <span>🔄 Scan Robot SBC</span>
+              </button>
+            </div>
+
+                        <!-- Target Execution Mode: Auto-switched by setting Remote Host/IP -->
+            <div class="target-mode-card mt-3">
+              <div class="target-mode-header">
+                <div>
+                  <h4 class="target-mode-title">🎯 Robot Target & Deployment Host</h4>
+                  <p class="target-mode-desc">Enter remote robot PC IP or hostname to automatically enable Remote Target Mode (SSH). Leave blank for this local laptop.</p>
+                </div>
+                <div>
+                  <span id="target-mode-status-badge" class="badge-pill badge-ok">💻 Local Machine</span>
+                </div>
+              </div>
+
+              <!-- Docker Anywhere Builder & Flasher Row -->
+              <div class="docker-anywhere-row mt-3" style="background: rgba(15, 23, 42, 0.5); border: 1px solid rgba(56, 189, 248, 0.3); border-radius: 8px; padding: 0.85rem;">
+                <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 0.5rem;">
+                  <label class="checkbox-label" style="font-weight:600; color:#38bdf8; cursor: pointer; display: flex; align-items: center; gap: 0.5rem; margin: 0;">
+                    <input type="checkbox" id="chk-docker-builder" checked>
+                    <span>🐳 Build &amp; Flash inside Docker ("Docker Anywhere" — Zero toolchains on laptop &amp; robot PC)</span>
+                  </label>
+                  <div class="docker-status-indicators" style="display: flex; gap: 0.5rem; font-size: 0.75rem;">
+                    <span id="badge-docker-laptop" class="badge-pill badge-ok">💻 Laptop Docker: Ready</span>
+                    <span id="badge-docker-robot" class="badge-pill badge-neutral">🤖 Robot Docker: Checking...</span>
+                  </div>
+                </div>
+                <div id="docker-builder-details" class="mt-2" style="display:none; padding-top: 0.5rem; border-top: 1px dashed rgba(255,255,255,0.1);">
+                  <div class="form-grid" style="grid-template-columns: 2fr 1fr;">
+                    <div class="form-group">
+                      <label for="docker-builder-image" class="form-label">Docker Builder Image</label>
+                      <input type="text" id="docker-builder-image" class="form-input font-mono" value="linorobot2-builder:latest" placeholder="linorobot2-builder:latest">
+                    </div>
+                    <div class="form-group" style="align-self: flex-end;">
+                      <button type="button" id="btn-test-docker-builder" class="btn btn-sm btn-ghost" style="width: 100%;">
+                        <span>🔍 Test Docker Engine</span>
+                      </button>
+                    </div>
+                  </div>
+                  <div class="form-grid mt-2" style="grid-template-columns: 1fr 1fr;">
+                    <div class="form-group">
+                      <label for="cfg-container-registry" class="form-label">Container Registry</label>
+                      <select id="cfg-container-registry" class="form-select font-mono">
+                        <option value="auto" selected>Auto (Cluster / Docker Hub)</option>
+                        <option value="cluster">Cluster / LAN registry (host below)</option>
+                        <option value="dockerhub">Docker Hub (Direct)</option>
+                        <option value="custom">Custom Registry...</option>
+                      </select>
+                    </div>
+                    <div class="form-group" id="group-cfg-custom-registry" style="display:none;">
+                      <label for="cfg-custom-registry" class="form-label">Registry Host:Port</label>
+                      <input type="text" id="cfg-custom-registry" class="form-input font-mono" placeholder="registry.example.com:5000">
+                    </div>
+                  </div>
+                  <span class="input-hint">Compiles all micro-ROS firmware, sensor/motor tests, and I2C detector inside container. Leaves your host laptop 100% clean.</span>
+                </div>
+              </div>
+
+              <!-- Host Configuration Form -->
+              <div class="form-grid mt-3">
+                <div class="form-group">
+                  <label for="remote-ssh-host" class="form-label">🌐 Robot Host / IP (blank = Local Machine)</label>
+                  <input type="text" id="remote-ssh-host" class="form-input font-mono" placeholder="Leave blank for local; e.g. 192.168.1.50 or robot.local">
+                </div>
+                <div class="form-group" id="group-ssh-user" style="display:none;">
+                  <label for="remote-ssh-user" class="form-label">👤 SSH User</label>
+                  <input type="text" id="remote-ssh-user" class="form-input font-mono" value="ubuntu">
+                </div>
+                <div class="form-group" id="group-ssh-port" style="display:none;">
+                  <label for="remote-ssh-port" class="form-label">🔌 SSH Port</label>
+                  <input type="number" id="remote-ssh-port" class="form-input font-mono" value="22">
+                </div>
+                <div class="form-group" id="group-ssh-key" style="display:none;">
+                  <label for="remote-ssh-key" class="form-label">🔑 SSH Key (Optional)</label>
+                  <input type="text" id="remote-ssh-key" class="form-input font-mono" placeholder="~/.ssh/id_ed25519 (blank for default)">
+                </div>
+              </div>
+
+              <!-- Auto-detected Remote Status Bar -->
+              <div class="remote-actions-bar mt-2" id="remote-tools-bar" style="display:none;">
+                <div class="remote-badges">
+                  <span class="badge-pill badge-ok" id="badge-remote-ssh">SSH: Connected</span>
+                  <span class="badge-pill badge-ok" id="badge-remote-tools">Minimal Tools: Auto-Ready</span>
+                  <span class="badge-pill badge-neutral" id="badge-remote-docker">Docker: Checking...</span>
+                </div>
+                <div>
+                  <button type="button" id="btn-remote-probe-ports" class="btn btn-sm btn-ghost" title="Re-scan remote serial devices">
+                    <span>🔄 Re-scan Remote Ports</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <!-- HERO ACTION: 1-Click Full Deploy & Flash Control (Top of Tab 5) -->
+            <div class="deploy-hero-card mt-3">
+              <div class="deploy-hero-header">
+                <div>
+                  <h3 class="deploy-hero-title">🚀 1-Click Full Deploy & Live Telemetry</h3>
+                  <p class="deploy-hero-desc">Build firmware, release serial port, flash microcontroller (or BOOTSEL), establish micro-ROS agent handshake, and stream live ROS 2 topics.</p>
+                </div>
+                <div class="deploy-hero-badge" id="hero-deploy-badge">
+                  <span class="pulse-dot" id="hero-deploy-dot"></span> <span id="hero-deploy-status-text">Ready to Deploy</span> <span id="hero-deploy-timer" style="display:none;"></span>
+                </div>
+              </div>
+
+              <div class="form-grid mt-3">
+                <div class="form-group">
+                  <label for="auto-flash-target" class="form-label">🎯 Target Firmware Binary</label>
+                  <select id="auto-flash-target" class="form-select">
+                    <option value="firmware" selected>🏎️ Robot Firmware (Main micro-ROS Motor Controller)</option>
+                    <option value="test_sensors">🧭 Sensor Diagnostics Utility (test_sensors/)</option>
+                    <option value="test_motors">⚙️ Motor & Encoder Diagnostics (test_motors/)</option>
+                    <option value="test_acc">📈 Dynamic Acceleration Profiler (test_acc/)</option>
+                    <option value="i2c_detect">🔍 I2C Hardware Scanner & Auto-Identifier (tools/i2c_detect/)</option>
+                    <option value="adc_calibrate">🔋 ESP32 ADC Calibration & LUT Linearizer (adc_calibrate/)</option>
+                    <option value="bno085_cal">🧭 BNO085 IMU Calibration (bno085_cal/)</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label for="auto-flash-port" class="form-label">🔌 Upload Serial Port / BOOTSEL Protocol</label>
+                  <input type="text" id="auto-flash-port" class="form-input font-mono" data-auto-managed="true" value="/dev/ttyACM0" placeholder="/dev/ttyACM0, /dev/ttyUSB0, BOOTSEL, or AUTO">
+                  <div id="flash-port-chips" class="port-chips-wrap mt-1"></div>
+                </div>
+              </div>
+
+              <div class="btn-group-row mt-3">
+                <button type="button" id="btn-exec-deploy-script" class="btn btn-accent btn-hero-deploy flex-2" title="Execute complete 9-phase deployment lifecycle on Robot SBC">
+                  <span class="btn-icon">🚀</span>
+                  <span class="btn-text"><strong>Run Full Deploy</strong> (Build, Flash & Discover Topics)</span>
+                </button>
+                <button type="button" id="btn-exec-build-cmd" class="btn btn-secondary flex-1" title="Compile selected target firmware on Robot SBC">
+                  <span>🔨 Run Build</span>
+                </button>
+                <button type="button" id="btn-exec-upload-cmd" class="btn btn-primary flex-1" title="Compile and upload firmware on Robot SBC">
+                  <span>⚡ Flash MCU</span>
+                </button>
+                <button type="button" id="btn-download-deploy-script" class="btn btn-ghost" title="Download deploy_robot.sh script">
+                  <span>📥 Script</span>
+                </button>
+                <button type="button" id="btn-tab5-launch-syslog" class="btn btn-ghost" title="Launch or stop UDP Syslog Telemetry Server">
+                  <span id="tab5-syslog-icon">📡</span> <span id="tab5-syslog-text">Syslog Server</span>
+                </button>
+              </div>
+              <div class="deploy-time-hint mt-2">
+                <span class="hint-icon">⏱️</span>
+                <span><strong>Note for lower-spec PCs / SBCs:</strong> First-time build compiles micro-ROS IDLs & C++ libraries (may take 2–4 min on Raspberry Pi or older CPUs). Subsequent builds are cached and take &lt;10s.</span>
+              </div>
+            </div>
+
+            <!-- 1. OS & Workspace Environment -->
+            <h3 class="sub-title mt-4">🖥️ 1. Robot Host OS & Workspace Environment</h3>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="auto-os-select" class="form-label">Robot Host Operating System</label>
+                <select id="auto-os-select" class="form-select">
+                  <option value="ubuntu_2404">Ubuntu 24.04 LTS (Noble Numbat / Jazzy — RPi 5 / Jetson)</option>
+                  <option value="ubuntu_2604">Ubuntu 26.04 LTS (Resolute Raccoon / Lyrical)</option>
+                  <option value="ubuntu_2204">Ubuntu 22.04 LTS (Jammy Jellyfish — RPi 4 / Jetpack 5)</option>
+                  <option value="debian">Debian 12 / 13 (Bookworm / Raspberry Pi OS)</option>
+                  <option value="fedora">Fedora / Bluefin Linux</option>
+                  <option value="macos">macOS (Remote Workstation)</option>
+                  <option value="windows_wsl">Windows 10 / 11 (WSL2 Ubuntu)</option>
+                </select>
+                <span class="input-hint">Target environment where firmware builds and agent execute</span>
+              </div>
+
+              <div class="form-group">
+                <label for="auto-env-select" class="form-label">Runtime Environment Mode</label>
+                <select id="auto-env-select" class="form-select">
+                  <option value="native">Native Host System</option>
+                  <option value="distrobox">Distrobox Workspace Container (jazzy / resolute)</option>
+                  <option value="docker">Docker Container</option>
+                </select>
+                <span class="input-hint">Isolates build tools and compiler dependencies</span>
+              </div>
+
+              <div class="form-group">
+                <label for="auto-arch-select" class="form-label">Target CPU Architecture</label>
+                <select id="auto-arch-select" class="form-select">
+                  <option value="aarch64">aarch64 / arm64 (Raspberry Pi 4/5 / Jetson Orin / Apple Silicon)</option>
+                  <option value="x86_64">x86_64 (Intel NUC / AMD Mini-PC / PC)</option>
+                </select>
+              </div>
+            </div>
+
+            <!-- 2. Toolchain & Permissions Installer -->
+            <h3 class="sub-title mt-4">🛠️ 2. Toolchain & Hardware Permissions Installer</h3>
+            <div class="automation-options-grid">
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-install-pio" checked>
+                <span><strong>PlatformIO Core (<code>pio</code>)</strong> — Microcontroller compiler & flash engine</span>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-install-udev" checked>
+                <span><strong>Hardware udev Rules (<code>99-platformio-udev.rules</code>)</strong> — Grant non-root USB access</span>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-install-dialout" checked>
+                <span><strong>User Serial Groups</strong> — Add current user to <code>dialout</code> and <code>plugdev</code></span>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-install-buildtools" checked>
+                <span><strong>Build Essentials</strong> — <code>git</code>, <code>cmake</code>, <code>ninja-build</code>, <code>python3-pip</code></span>
+              </label>
+            </div>
+
+            <div class="quick-cmd-box">
+              <div class="quick-cmd-header">
+                <span class="quick-cmd-title">⚡ One-Click Toolchain Install Command</span>
+                <div class="quick-cmd-actions">
+                  <button type="button" id="btn-exec-tool-cmd" class="btn btn-xs btn-primary" title="Execute toolchain installer on Robot SBC">▶️ Run on Robot SBC</button>
+                  <button type="button" id="btn-copy-tool-cmd" class="btn btn-xs btn-ghost">📋 Copy</button>
+                </div>
+              </div>
+              <pre class="quick-cmd-code"><code id="preview-tool-cmd"># Updating...</code></pre>
+            </div>
+
+            <!-- 3. ROS 2 Distribution Selector & Setup -->
+            <h3 class="sub-title mt-4">🤖 3. ROS 2 Distribution Setup (Robot SBC)</h3>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="auto-ros-distro" class="form-label">ROS 2 Distribution</label>
+                <select id="auto-ros-distro" class="form-select">
+                  <option value="jazzy" selected>ROS 2 Jazzy Jalisco (Ubuntu 24.04 LTS — Recommended)</option>
+                  <option value="lyrical">ROS 2 Lyrical (Ubuntu 26.04 LTS)</option>
+                  <option value="rolling">ROS 2 Rolling Ridley (Continuous Release)</option>
+                  <option value="humble">ROS 2 Humble Hawksbill (Ubuntu 22.04 LTS — Containerized)</option>
+                  <option value="none">None / Standalone Firmware Only (Skip ROS 2)</option>
+                </select>
+                <span class="input-hint">Select your host ROS 2 distribution or skip for standalone MCU</span>
+              </div>
+
+              <div class="form-group" id="group-ros-install-type">
+                <label for="auto-ros-type" class="form-label">ROS 2 Package Bundle</label>
+                <select id="auto-ros-type" class="form-select">
+                  <option value="base" selected>Base Bundle (ros-distro-ros-base + Micro-ROS — Recommended for SBC)</option>
+                  <option value="desktop">Desktop Bundle (ros-distro-desktop + GUI Tools)</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="automation-options-grid mt-2" id="group-microros-agent">
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-build-microros-agent" checked>
+                <span><strong>Build micro-ROS Agent Workspace</strong> — Clone and compile <code>micro_ros_agent</code> for DDS bridging</span>
+              </label>
+            </div>
+
+            <div class="quick-cmd-box" id="box-ros-cmd">
+              <div class="quick-cmd-header">
+                <span class="quick-cmd-title">⚡ One-Click ROS 2 Setup Command</span>
+                <div class="quick-cmd-actions">
+                  <button type="button" id="btn-exec-ros-cmd" class="btn btn-xs btn-primary" title="Execute ROS 2 setup on Robot SBC">▶️ Run on Robot SBC</button>
+                  <button type="button" id="btn-copy-ros-cmd" class="btn btn-xs btn-ghost">📋 Copy</button>
+                </div>
+              </div>
+              <pre class="quick-cmd-code"><code id="preview-ros-cmd"># Updating...</code></pre>
+            </div>
+
+            <!-- 4. Merge Generated Headers & Git Commit -->
+            <h3 class="sub-title mt-4">🔀 4. Merge Generated Headers & Git Commit Automation</h3>
+            <p class="input-hint" style="margin-bottom:0.5rem;">Runs on the <strong>Branch</strong> set in the header (top-right) — <strong>Run Merge &amp; Commit</strong> checks that branch out first, creating it if it doesn't exist.</p>
+            <p class="input-hint" style="margin-bottom:0.5rem;">🔀 <strong>Merges, never overwrites:</strong> if <code>config/custom/&lt;robot&gt;_config.h</code> already exists on the Robot SBC, the settings you've changed here win field-for-field — everything else already in that file (hand-added <code>#define</code>s, a previously calibrated ADC LUT, …) is kept. This same merge runs automatically before every direct upload (<code>test_sensors</code>, <code>adc_calibrate</code>, …) and Full Deploy, not just this button.</p>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="auto-git-commit-msg" class="form-label">Git Commit Message</label>
+                <input type="text" id="auto-git-commit-msg" class="form-input" data-auto-managed="true" value="feat(config): add configuration for scout_pico2" placeholder="Commit message">
+              </div>
+            </div>
+
+            <div class="automation-options-grid mt-2">
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-merge-header" checked>
+                <span>Write <code>config/custom/&lt;robot&gt;_config.h</code> and register in <code>config/config.h</code></span>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-merge-pio-firmware" checked>
+                <span>Append <code>[env:&lt;robot&gt;]</code> to <code>firmware/platformio.ini</code> (automatically inherited by <code>test_motors</code> & <code>test_sensors</code>)</span>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-merge-urdf" checked>
+                <span>Generate <code>urdf/&lt;robot&gt;_properties.urdf.xacro</code></span>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" id="chk-auto-commit" checked>
+                <span>Stage changes and create Git commit automatically</span>
+              </label>
+            </div>
+
+            <div class="quick-cmd-box">
+              <div class="quick-cmd-header">
+                <span class="quick-cmd-title">⚡ One-Click Merge & Git Commit Command</span>
+                <div class="quick-cmd-actions">
+                  <button type="button" id="btn-exec-merge-cmd" class="btn btn-xs btn-primary" title="Execute header merge and Git commit on Robot SBC">▶️ Run Merge & Commit</button>
+                  <button type="button" id="btn-copy-merge-cmd" class="btn btn-xs btn-ghost">📋 Copy</button>
+                </div>
+              </div>
+              <pre class="quick-cmd-code"><code id="preview-merge-cmd"># Updating...</code></pre>
+            </div>
+
+            <!-- 5. Standalone Diagnostics & Utilities -->
+            <h3 class="sub-title mt-4">⚡ 5. Standalone Diagnostics & Direct Microcontroller Uploads</h3>
+
+            <!-- Direct 1-Click Upload Action Grid -->
+            <div class="direct-upload-section mt-3">
+              <label class="checkbox-label mb-2">
+                <input type="checkbox" id="cfg-ota-enable">
+                <span><strong>Flash over WiFi (OTA)</strong> — uses the device IP &amp; password from the Sensors tab instead of the USB port</span>
+              </label>
+              <label class="form-label mb-2">🚀 Direct 1-Click Microcontroller Uploads</label>
+              <div class="direct-upload-grid">
+                <button type="button" id="btn-upload-sensors" class="btn-direct-upload btn-upload-sensors" title="Compile & Upload Sensor Diagnostics on Robot SBC">
+                  <span class="direct-upload-icon">🧭</span>
+                  <div class="direct-upload-info">
+                    <span class="direct-upload-title">Upload <code>test_sensors</code></span>
+                    <span class="direct-upload-desc">I2C Scanner & Sensor Telemetry</span>
+                  </div>
+                  <span class="direct-upload-badge">⚡ Upload</span>
+                </button>
+
+                <button type="button" id="btn-upload-motors" class="btn-direct-upload btn-upload-motors" title="Compile & Upload Motor Diagnostics on Robot SBC">
+                  <span class="direct-upload-icon">⚙️</span>
+                  <div class="direct-upload-info">
+                    <span class="direct-upload-title">Upload <code>test_motors</code></span>
+                    <span class="direct-upload-desc">Sequential Motor & CPR Test</span>
+                  </div>
+                  <span class="direct-upload-badge">⚡ Upload</span>
+                </button>
+
+                <button type="button" id="btn-upload-acc" class="btn-direct-upload btn-upload-acc" title="Compile & Upload Acceleration Profiler on Robot SBC">
+                  <span class="direct-upload-icon">📈</span>
+                  <div class="direct-upload-info">
+                    <span class="direct-upload-title">Upload <code>test_acc</code></span>
+                    <span class="direct-upload-desc">Dynamic Acceleration Profiler</span>
+                  </div>
+                  <span class="direct-upload-badge">⚡ Upload</span>
+                </button>
+
+                <button type="button" id="btn-upload-adc" class="btn-direct-upload btn-upload-adc" title="Compile & Upload ESP32 ADC Calibration on Robot SBC">
+                  <span class="direct-upload-icon">🔋</span>
+                  <div class="direct-upload-info">
+                    <span class="direct-upload-title">Upload <code>adc_calibrate</code></span>
+                    <span class="direct-upload-desc">Hardware DAC ADC Linearization</span>
+                  </div>
+                  <span class="direct-upload-badge">⚡ Upload</span>
+                </button>
+
+                <button type="button" id="btn-upload-firmware" class="btn-direct-upload btn-upload-firmware" title="Compile & Upload Main Robot Controller on Robot SBC">
+                  <span class="direct-upload-icon">🏎️</span>
+                  <div class="direct-upload-info">
+                    <span class="direct-upload-title">Upload <code>firmware</code></span>
+                    <span class="direct-upload-desc">Main micro-ROS Robot Controller</span>
+                  </div>
+                  <span class="direct-upload-badge">⚡ Upload</span>
+                </button>
+              </div>
+            </div>
+
+
+
+
+            <!-- 6. ADC Calibration Studio & LUT Visualizer -->
+            <h3 class="sub-title mt-4">🔋 6. ESP32 ADC Calibration Studio & LUT Linearizer</h3>
+            <div class="adc-studio-card" id="adc-studio-card">
+              <div class="adc-studio-header">
+                <div class="adc-studio-title-wrap">
+                  <span class="adc-studio-icon">🔋</span>
+                  <div>
+                    <h4 class="adc-studio-title">Hardware DAC Sweep & 12-Bit Inverse Lookup Table (LUT)</h4>
+                    <p class="adc-studio-subtitle">Linearizes ESP32 ADC battery & sensor readings across the full 0–3.3V range</p>
+                  </div>
+                </div>
+                <div class="adc-studio-actions">
+                  <button type="button" id="btn-adc-run-cal" class="btn btn-sm btn-primary" title="Upload adc_calibrate, sweep, capture the LUT, merge it into the robot config, and commit it — one click">
+                    <span>⚡ Run Hardware Calibration</span>
+                  </button>
+                </div>
+              </div>
+              <p class="input-hint mb-2">Sweeps the DAC, captures a real 4096-point LUT, charts it, merges it into <code>config/custom/&lt;robot&gt;_config.h</code> and commits — all in this one action. If that file already exists it's <strong>merged</strong>, not overwritten: settings you haven't touched here (hand-added <code>#define</code>s, a previous calibration) are kept.</p>
+
+              <!-- DAC pin selector + no-DAC notice -->
+              <div class="adc-dacpin-row" id="adc-dacpin-row">
+                <label for="cfg-dac-pin" class="form-label-xs">DAC Output Pin (sweep source)</label>
+                <select id="cfg-dac-pin" class="form-input form-input-sm font-mono" data-auto-managed="true">
+                  <option value="25">GPIO 25 — ESP32 DAC1</option>
+                  <option value="26">GPIO 26 — ESP32 DAC2</option>
+                  <option value="17">GPIO 17 — ESP32-S2 DAC1</option>
+                  <option value="18">GPIO 18 — ESP32-S2 DAC2</option>
+                </select>
+                <span class="input-hint">Jumper this pin to the battery ADC input for the calibration sweep. Emitted as <code>#define DAC_PIN</code>.</span>
+              </div>
+              <div class="adc-nodac-note" id="adc-nodac-note" style="display:none;">
+                ⚠️ ADC calibration needs a hardware DAC — available only on the <strong>ESP32</strong> and <strong>ESP32-S2</strong>. This MCU has none, so <code>adc_calibrate</code> is disabled.
+              </div>
+
+              <!-- Setup Instruction & CAD Schematic Banner -->
+              <div class="adc-setup-banner">
+                <span class="adc-setup-badge">🔌 Hardware Wiring</span>
+                <span class="adc-setup-text">Connect the <strong>DAC output pin</strong> (selected above) to your <strong>Battery ADC Input Pin</strong> (e.g. GPIO 33) for calibration. Use a <strong>1000pF filter capacitor</strong> to ground for noise suppression.</span>
+              </div>
+
+              <!-- CAD Circuit Schematic Viewer -->
+              <div class="adc-cad-schematic-card mt-3 mb-3">
+                <div class="schematic-header">
+                  <div class="schematic-title-wrap">
+                    <span class="schematic-icon">📐</span>
+                    <div>
+                      <h4 class="schematic-title">Interactive CAD Circuit Schematic (ADC Voltage Divider, 1000pF Filter & DAC Calibration)</h4>
+                      <p class="schematic-subtitle">Hardware topology for battery sensing with transient noise filter & hardware DAC sweep</p>
+                    </div>
+                  </div>
+                  <div class="schematic-badges">
+                    <span class="schematic-badge" id="cad-badge-ratio">Ratio: 0.2000 (1:5)</span>
+                    <span class="schematic-badge badge-safe" id="cad-badge-safety">🛡️ V_ADC: 2.52V &le; 3.0V</span>
+                  </div>
+                </div>
+
+                <div class="schematic-svg-container">
+                  <svg id="adc-circuit-svg" viewBox="0 0 760 220" class="schematic-svg" xmlns="http://www.w3.org/2000/svg">
+                    <defs>
+                      <!-- userSpaceOnUse + explicit coords, not the default
+                           objectBoundingBox: this gradient strokes a
+                           perfectly horizontal <line> (the ADC-node-to-MCU
+                           bus below), whose bounding box has zero height —
+                           objectBoundingBox gradients on a zero-height (or
+                           zero-width) shape resolve to a degenerate
+                           transform and render invisibly in Chromium, which
+                           made the bus wire (and everything tapped off it,
+                           like the filter capacitor's upper lead) look
+                           disconnected. -->
+                      <linearGradient id="grad-wire" gradientUnits="userSpaceOnUse" x1="340" y1="56" x2="570" y2="56">
+                        <stop offset="0%" stop-color="#38bdf8"/>
+                        <stop offset="100%" stop-color="#818cf8"/>
+                      </linearGradient>
+                      <linearGradient id="grad-dac" x1="0%" y1="0%" x2="100%" y2="0%">
+                        <stop offset="0%" stop-color="#f59e0b"/>
+                        <stop offset="100%" stop-color="#10b981"/>
+                      </linearGradient>
+                    </defs>
+
+                    <!-- Battery / Power In -->
+                    <g class="cad-component" id="cad-comp-battery">
+                      <rect x="20" y="35" width="85" height="42" rx="6" fill="#1e293b" stroke="#38bdf8" stroke-width="2"/>
+                      <text x="62" y="55" fill="#f8fafc" font-size="12" font-weight="bold" text-anchor="middle">+VBAT</text>
+                      <text x="62" y="69" fill="#94a3b8" font-size="10" text-anchor="middle" id="cad-svg-vbat">12.6 V (Full)</text>
+                      <!-- Lead line -->
+                      <line x1="105" y1="56" x2="150" y2="56" stroke="#38bdf8" stroke-width="2.5"/>
+                    </g>
+
+                    <!-- Resistor R1 (Upper Divider) -->
+                    <g class="cad-component" id="cad-comp-r1">
+                      <!-- Resistor Box -->
+                      <rect x="150" y="44" width="90" height="24" rx="4" fill="#0f172a" stroke="#38bdf8" stroke-width="2"/>
+                      <text x="195" y="60" fill="#38bdf8" font-size="11" font-family="monospace" font-weight="bold" text-anchor="middle" id="cad-svg-r1">R1: 30.0 kΩ</text>
+                      <text x="195" y="36" fill="#94a3b8" font-size="9" text-anchor="middle">Upper Resistor</text>
+                      <!-- Wire to central node -->
+                      <line x1="240" y1="56" x2="340" y2="56" stroke="#38bdf8" stroke-width="2.5"/>
+                    </g>
+
+                    <!-- Central ADC Node -->
+                    <circle cx="340" cy="56" r="5" fill="#818cf8"/>
+                    <text x="340" y="36" fill="#c084fc" font-size="10" font-weight="bold" text-anchor="middle">ADC NODE</text>
+
+                    <!-- Resistor R2 (Lower Divider to GND) -->
+                    <g class="cad-component" id="cad-comp-r2">
+                      <line x1="300" y1="56" x2="300" y2="90" stroke="#818cf8" stroke-width="2.5"/>
+                      <rect x="270" y="90" width="60" height="36" rx="4" fill="#0f172a" stroke="#818cf8" stroke-width="2"/>
+                      <text x="300" y="108" fill="#818cf8" font-size="10" font-family="monospace" font-weight="bold" text-anchor="middle" id="cad-svg-r2">R2</text>
+                      <text x="300" y="120" fill="#94a3b8" font-size="9" font-family="monospace" text-anchor="middle" id="cad-svg-r2-val">7.5 kΩ</text>
+                      <line x1="300" y1="126" x2="300" y2="160" stroke="#64748b" stroke-width="2.5"/>
+                      <!-- GND Symbol -->
+                      <line x1="288" y1="160" x2="312" y2="160" stroke="#94a3b8" stroke-width="2"/>
+                      <line x1="292" y1="165" x2="308" y2="165" stroke="#94a3b8" stroke-width="2"/>
+                      <line x1="296" y1="170" x2="304" y2="170" stroke="#94a3b8" stroke-width="2"/>
+                    </g>
+
+                    <!-- Filter Capacitor (1000pF across ADC to GND) -->
+                    <g class="cad-component" id="cad-comp-cap">
+                      <line x1="380" y1="56" x2="380" y2="95" stroke="#818cf8" stroke-width="2.5"/>
+                      <!-- Capacitor Plates -->
+                      <line x1="365" y1="95" x2="395" y2="95" stroke="#10b981" stroke-width="3"/>
+                      <line x1="365" y1="105" x2="395" y2="105" stroke="#10b981" stroke-width="3"/>
+                      <text x="435" y="104" fill="#10b981" font-size="10" font-family="monospace" font-weight="bold" text-anchor="start" id="cad-svg-cap">C: 1000 pF (1nF)</text>
+                      <text x="435" y="117" fill="#6ee7b7" font-size="8" text-anchor="start">Noise Reduction Filter</text>
+                      <line x1="380" y1="105" x2="380" y2="160" stroke="#64748b" stroke-width="2.5"/>
+                      <!-- GND Symbol -->
+                      <line x1="368" y1="160" x2="392" y2="160" stroke="#94a3b8" stroke-width="2"/>
+                      <line x1="372" y1="165" x2="388" y2="165" stroke="#94a3b8" stroke-width="2"/>
+                      <line x1="376" y1="170" x2="384" y2="170" stroke="#94a3b8" stroke-width="2"/>
+                    </g>
+
+                    <!-- Horizontal Bus Connection to ADC Pin -->
+                    <line x1="340" y1="56" x2="570" y2="56" stroke="url(#grad-wire)" stroke-width="2.5"/>
+
+                    <!-- MCU ADC Input Pin -->
+                    <g class="cad-component" id="cad-comp-mcu">
+                      <rect x="570" y="32" width="165" height="48" rx="6" fill="#1e1b4b" stroke="#a855f7" stroke-width="2"/>
+                      <text x="652" y="52" fill="#e9d5ff" font-size="11" font-weight="bold" text-anchor="middle" id="cad-svg-adc-pin">ESP32 ADC (GPIO 33)</text>
+                      <text x="652" y="68" fill="#c084fc" font-size="10" font-family="monospace" text-anchor="middle" id="cad-svg-vadc-read">V_ADC = 2.52 V (Max)</text>
+                    </g>
+
+                    <!-- Hardware DAC Sweep Line (Calibration Mode) -->
+                    <g class="cad-component" id="cad-comp-dac">
+                      <!-- DAC Box on bottom left -->
+                      <rect x="20" y="130" width="135" height="45" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+                      <text x="87" y="148" fill="#fcd34d" font-size="11" font-weight="bold" text-anchor="middle" id="cad-svg-dac-pin">ESP32 DAC (GPIO 25)</text>
+                      <text x="87" y="163" fill="#94a3b8" font-size="9" text-anchor="middle">Hardware Sweep 0–3.3V</text>
+                      <!-- Calibration Jumper Line to Node -->
+                      <path d="M 155 152 L 240 152 L 240 70 L 335 58" fill="none" stroke="url(#grad-dac)" stroke-width="2" stroke-dasharray="4,4"/>
+                      <circle cx="155" cy="152" r="3.5" fill="#f59e0b"/>
+                      <text x="200" y="145" fill="#f59e0b" font-size="8" font-family="monospace">CALIBRATION JUMPER</text>
+                    </g>
+
+                    <!-- 3.0V Safety Warning Box in SVG -->
+                    <g id="cad-svg-warning-box" style="display: none;">
+                      <rect x="490" y="130" width="245" height="45" rx="6" fill="#450a0a" stroke="#f43f5e" stroke-width="2"/>
+                      <text x="612" y="148" fill="#fca5a5" font-size="11" font-weight="bold" text-anchor="middle">⚠️ EXCEEDS 3.0V LIMIT!</text>
+                      <text x="612" y="163" fill="#fecdd3" font-size="9" text-anchor="middle" id="cad-svg-warning-text">V_ADC exceeds safe linear range</text>
+                    </g>
+                  </svg>
+                </div>
+              </div>
+
+              <!-- ADC Studio Content Grid -->
+              <div class="adc-studio-grid">
+                <!-- Left: Interactive Canvas Chart -->
+                <div class="adc-chart-pane">
+                  <div class="adc-chart-toolbar">
+                    <span class="adc-chart-title">📊 ADC Transfer Function & Linearization Plot</span>
+                    <div class="adc-chart-legend">
+                      <span class="legend-item legend-raw"><span class="legend-dot" style="background:#f43f5e;"></span> Raw Non-Linear</span>
+                      <span class="legend-item legend-ideal"><span class="legend-dot" style="background:#38bdf8;"></span> Ideal (0-4095)</span>
+                      <span class="legend-item legend-calibrated"><span class="legend-dot" style="background:#10b981;"></span> Calibrated Output</span>
+                    </div>
+                  </div>
+                  <div class="adc-canvas-container">
+                    <canvas id="adc-chart-canvas" width="600" height="320"></canvas>
+                    <div id="adc-chart-tooltip" class="adc-chart-tooltip" style="display: none;"></div>
+                  </div>
+                  <div class="adc-metrics-row">
+                    <div class="adc-metric-box">
+                      <span class="metric-label">Resolution</span>
+                      <span class="metric-val">12-Bit (4096 pts)</span>
+                    </div>
+                    <div class="adc-metric-box">
+                      <span class="metric-label">Low Knee Deadband</span>
+                      <span class="metric-val" id="metric-knee-low">~0.15 V (0-180 ADC)</span>
+                    </div>
+                    <div class="adc-metric-box">
+                      <span class="metric-label">High Knee Compression</span>
+                      <span class="metric-val" id="metric-knee-high">~3.15 V (3920-4095)</span>
+                    </div>
+                    <div class="adc-metric-box">
+                      <span class="metric-label">Max Correction Δ</span>
+                      <span class="metric-val text-accent" id="metric-max-delta">±142 ADC</span>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Right: LUT Code / Stream Inspector -->
+                <div class="adc-lut-pane">
+                  <div class="adc-lut-header">
+                    <span class="adc-lut-title">📋 Generated <code>ADC_LUT[4096]</code></span>
+                    <button type="button" id="btn-copy-lut-code" class="btn btn-xs btn-ghost">📋 Copy LUT</button>
+                  </div>
+                  <div class="adc-lut-code-wrap">
+                    <pre class="adc-lut-code" id="adc-lut-code-display"><code>// Click "Run Hardware Calibration" or "Generate Model LUT" to build LUT table...
+const int16_t ADC_LUT[4096] = { /* insert adc_calibrate data here */ };</code></pre>
+                  </div>
+                  <div class="adc-status-bar" id="adc-status-bar">
+                    <span class="pulse-dot"></span>
+                    <span id="adc-status-text">Ready for calibration. Pin 25 (DAC1) -> Pin 33/34 (Battery ADC).</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- 7. micro-ROS Agent Host Runner -->
+            <h3 class="sub-title mt-4">📡 7. micro-ROS Agent Host Bridge (Robot SBC)</h3>
+            <div class="quick-cmd-box" id="box-agent-cmd">
+              <div class="quick-cmd-header">
+                <span class="quick-cmd-title">⚡ Live micro-ROS Agent Runner</span>
+                <div class="quick-cmd-actions">
+                  <button type="button" id="btn-exec-agent-serial" class="btn btn-xs btn-success" title="Launch Serial micro-ROS Agent for single MCU">▶️ Single Serial</button>
+                  <button type="button" id="btn-exec-agent-multiserial" class="btn btn-xs btn-accent" title="Launch Multi-Serial micro-ROS Agent for multiple MCUs simultaneously">▶️ Multi-Serial</button>
+                  <button type="button" id="btn-exec-agent-udp" class="btn btn-xs btn-primary" title="Launch UDP WiFi micro-ROS Agent on Robot SBC">▶️ UDP WiFi</button>
+                  <button type="button" id="btn-copy-agent-cmd" class="btn btn-xs btn-ghost">📋 Copy</button>
+                </div>
+              </div>
+              <div class="agent-config-row mt-2 mb-2">
+                <div class="form-group flex-1">
+                  <label for="auto-agent-multiserial-ports" class="form-label-xs">Multi-Serial Devices (space-separated for multi-MCU robots)</label>
+                  <input type="text" id="auto-agent-multiserial-ports" class="form-input form-input-sm font-mono" value="/dev/ttyACM0 /dev/ttyUSB0" placeholder="/dev/ttyACM0 /dev/ttyUSB0">
+                </div>
+              </div>
+              <div id="agent-port-status-bar" class="agent-port-status-bar mt-2 mb-2 p-2 rounded" style="display: flex; align-items: center; justify-content: space-between; font-size: 0.8rem; background: rgba(0,0,0,0.25); border: 1px solid var(--border-color, #333);">
+                <div style="display: flex; align-items: center; gap: 6px;">
+                  <span id="agent-port-indicator-icon">🔍</span>
+                  <span id="agent-port-indicator-text" class="text-secondary">Port check ready</span>
+                </div>
+                <div style="display: flex; gap: 6px;">
+                  <button type="button" id="btn-check-agent-port" class="btn btn-xs btn-ghost" title="Check if any agent or process is using this port">🔄 Check Port</button>
+                  <button type="button" id="btn-release-agent-port" class="btn btn-xs btn-warning" style="display: none;" title="Stop conflicting container/process holding this port">🛑 Release Port</button>
+                </div>
+              </div>
+              <p class="input-hint mt-1">Agent baud follows <strong>Serial Communication Baud Rate</strong> on Tab 1 (the firmware <code>BAUDRATE</code>).</p>
+              <pre class="quick-cmd-code"><code id="preview-agent-cmd">ros2 run micro_ros_agent micro_ros_agent serial --dev /dev/ttyUSB0 -b 921600</code></pre>
+            </div>
+
+                                    <!-- 8. Live ROS 2 Topic Frequency (Hz) Monitor & Stream Inspector -->
+            <h3 class="sub-title mt-4">📡 8. Live ROS 2 Topic Monitor & Frequency (Hz) Table</h3>
+            <div class="ros2-inspector-card" id="ros2-inspector-card">
+              <div class="ros2-inspector-header">
+                <div class="ros2-inspector-title-wrap">
+                  <span class="ros2-inspector-icon">📡</span>
+                  <div>
+                    <h4 class="ros2-inspector-title">Active ROS 2 Graph & Real-Time Hz Table</h4>
+                    <p class="ros2-inspector-subtitle">Select any topic row in the table to stream live telemetry into the console and verify the 50.0 Hz control loop</p>
+                  </div>
+                </div>
+                <div class="ros2-inspector-actions">
+                  <span class="badge-pill badge-ok" id="ros2-graph-status">● micro-ROS Active</span>
+                  <button type="button" id="btn-measure-all-hz" class="btn btn-xs btn-success" title="Measure live Hz for all active topics">⚡ Measure All Hz</button>
+                  <button type="button" id="btn-ros2-inspector-refresh" class="btn btn-xs btn-ghost" title="Re-scan ROS 2 graph">🔄 Refresh Topics</button>
+                </div>
+              </div>
+
+              <!-- Interactive Topic Hz Table -->
+              <div class="ros2-table-wrapper mt-3">
+                <table class="ros2-topic-table" id="ros2-topic-table">
+                  <thead>
+                    <tr>
+                      <th style="width: 45px; text-align: center;">Sel</th>
+                      <th>Topic Name</th>
+                      <th>Message Type</th>
+                      <th style="width: 130px; text-align: center;">Frequency (Hz)</th>
+                      <th style="width: 100px; text-align: center;">Status</th>
+                      <th style="width: 140px; text-align: right;">Live Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody id="ros2-topic-table-body">
+                    <tr class="topic-row active" data-topic="/odom/unfiltered">
+                      <td style="text-align: center;"><input type="radio" name="topic-select-radio" value="/odom/unfiltered" checked></td>
+                      <td><span class="topic-table-name font-mono">🏎️ /odom/unfiltered</span></td>
+                      <td><span class="topic-table-type font-mono text-muted">nav_msgs/msg/Odometry</span></td>
+                      <td style="text-align: center;"><span class="topic-hz-badge" id="hz-badge-odom">50.0 Hz</span></td>
+                      <td style="text-align: center;"><span class="badge-pill badge-ok">Active</span></td>
+                      <td style="text-align: right;">
+                        <button type="button" class="btn btn-xs btn-accent btn-table-stream" data-topic="/odom/unfiltered">▶️ Stream</button>
+                        <button type="button" class="btn btn-xs btn-ghost btn-table-hz" data-topic="/odom/unfiltered">⚡ Hz</button>
+                      </td>
+                    </tr>
+                    <tr class="topic-row" data-topic="/imu/data">
+                      <td style="text-align: center;"><input type="radio" name="topic-select-radio" value="/imu/data"></td>
+                      <td><span class="topic-table-name font-mono">🧭 /imu/data</span></td>
+                      <td><span class="topic-table-type font-mono text-muted">sensor_msgs/msg/Imu</span></td>
+                      <td style="text-align: center;"><span class="topic-hz-badge" id="hz-badge-imu">50.0 Hz</span></td>
+                      <td style="text-align: center;"><span class="badge-pill badge-ok">Active</span></td>
+                      <td style="text-align: right;">
+                        <button type="button" class="btn btn-xs btn-accent btn-table-stream" data-topic="/imu/data">▶️ Stream</button>
+                        <button type="button" class="btn btn-xs btn-ghost btn-table-hz" data-topic="/imu/data">⚡ Hz</button>
+                      </td>
+                    </tr>
+                    <tr class="topic-row" data-topic="/battery">
+                      <td style="text-align: center;"><input type="radio" name="topic-select-radio" value="/battery"></td>
+                      <td><span class="topic-table-name font-mono">🔋 /battery</span></td>
+                      <td><span class="topic-table-type font-mono text-muted">sensor_msgs/msg/BatteryState</span></td>
+                      <td style="text-align: center;"><span class="topic-hz-badge hz-low" id="hz-badge-battery">1.0 Hz</span></td>
+                      <td style="text-align: center;"><span class="badge-pill badge-ok">Active</span></td>
+                      <td style="text-align: right;">
+                        <button type="button" class="btn btn-xs btn-accent btn-table-stream" data-topic="/battery">▶️ Stream</button>
+                        <button type="button" class="btn btn-xs btn-ghost btn-table-hz" data-topic="/battery">⚡ Hz</button>
+                      </td>
+                    </tr>
+                    <tr class="topic-row" data-topic="/cmd_vel">
+                      <td style="text-align: center;"><input type="radio" name="topic-select-radio" value="/cmd_vel"></td>
+                      <td><span class="topic-table-name font-mono">🎮 /cmd_vel</span></td>
+                      <td><span class="topic-table-type font-mono text-muted">geometry_msgs/msg/Twist</span></td>
+                      <td style="text-align: center;"><span class="topic-hz-badge hz-sub">Subscribed</span></td>
+                      <td style="text-align: center;"><span class="badge-pill badge-info">Sub</span></td>
+                      <td style="text-align: right;">
+                        <button type="button" class="btn btn-xs btn-accent btn-table-stream" data-topic="/cmd_vel">▶️ Stream</button>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <!-- Live Selected Topic Display HUD -->
+              <div class="ros2-live-hud-grid mt-3">
+                <div class="hud-metric-mini">
+                  <span class="hud-mini-label">Active Topic</span>
+                  <span class="hud-mini-val text-cyan font-mono" id="hud-topic-name">/odom/unfiltered</span>
+                </div>
+                <div class="hud-metric-mini">
+                  <span class="hud-mini-label">Loop Frequency (Hz)</span>
+                  <span class="hud-mini-val text-green font-mono" id="hud-topic-hz">50.0 Hz</span>
+                </div>
+                <div class="hud-metric-mini">
+                  <span class="hud-mini-label">Linear Vel X / Voltage</span>
+                  <span class="hud-mini-val text-purple font-mono" id="hud-topic-val1">0.00 m/s</span>
+                </div>
+                <div class="hud-metric-mini">
+                  <span class="hud-mini-label">Angular Vel Z / Accel</span>
+                  <span class="hud-mini-val text-accent font-mono" id="hud-topic-val2">0.00 rad/s</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- 9. Live Interactive Terminal & Robot SBC Console -->
+            <h3 class="sub-title mt-4">📟 9. Live Interactive Terminal & Robot SBC Console</h3>
+            <div class="web-serial-console-card">
+              <div class="console-toolbar">
+                <div class="console-controls-left">
+                  <!-- Local Runner Status -->
+                  <span class="runner-status-pill pill-checking" id="runner-status-pill" title="Local Python Execution Server">
+                    <span class="pulse-dot"></span>
+                    <span id="runner-status-text">Checking Runner...</span>
+                  </span>
+
+                  <span class="runner-status-pill pill-checking" id="exec-progress-pill" style="display:none;" title="Running task">
+                    <span class="pulse-dot"></span>
+                    <span id="exec-progress-text">Working…</span>
+                    <span id="exec-progress-timer" class="font-mono"></span>
+                  </span>
+
+                  <!-- Server / SBC Serial Monitor Stream Button -->
+                                    <!-- ROS 2 Live Topic Stream Controls -->
+                  <div class="ros2-stream-controls">
+                    <select id="ros2-topic-select" class="form-select form-select-sm font-mono" title="Select active ROS 2 topic to stream live in terminal">
+                      <option value="/odom/unfiltered" selected>/odom/unfiltered (Odometry @ 50Hz)</option>
+                      <option value="/imu/data">/imu/data (IMU @ 50Hz)</option>
+                      <option value="/battery">/battery (BatteryState)</option>
+                      <option value="/cmd_vel">/cmd_vel (Twist)</option>
+                    </select>
+                    <button type="button" id="btn-ros2-echo" class="btn btn-sm btn-accent" title="Stream live topic messages in terminal">
+                      <span id="ros2-echo-icon">📡</span> <span id="ros2-echo-text">Stream Topic</span>
+                    </button>
+                    <button type="button" id="btn-ros2-hz" class="btn btn-sm btn-success" title="Measure live publishing frequency (Hz)">
+                      <span>⚡ Hz Check</span>
+                    </button>
+                    <button type="button" id="btn-ros2-refresh" class="btn btn-sm btn-ghost" title="Re-scan active ROS 2 graph for new topics">
+                      <span>🔄 Scan</span>
+                    </button>
+                  </div>
+                  <button type="button" id="btn-sbc-monitor" class="btn btn-sm btn-primary" title="Stream live serial messages from Robot SBC (e.g. test_sensors, IMU, telemetry)">
+                    <span>📡 Stream SBC Serial</span>
+                  </button>
+
+                  <!-- Web Serial Port Controls (Direct Client USB) -->
+                  <button type="button" id="btn-serial-connect" class="btn btn-sm btn-secondary" title="Connect to USB Microcontroller via Web Serial (Client Browser USB)">
+                    <span id="serial-btn-icon">🔌</span>
+                    <span id="serial-btn-text">Browser USB</span>
+                  </button>
+                  <select id="serial-baud-select" class="form-select form-select-sm" data-auto-managed="true" title="Serial baud rate — follows Tab 1 BAUDRATE until you pick one here (override for bootloader / MicroPython / non-linorobot boards)">
+                    <option value="1500000">1500000 Baud (1.5M High Speed)</option>
+                    <option value="921600" selected>921600 Baud (micro-ROS / Diagnostics)</option>
+                    <option value="460800">460800 Baud</option>
+                    <option value="230400">230400 Baud</option>
+                    <option value="115200">115200 Baud</option>
+                    <option value="57600">57600 Baud</option>
+                    <option value="9600">9600 Baud</option>
+                  </select>
+                  <span class="serial-status-pill pill-disconnected" id="serial-status-pill">
+                    <span id="serial-status-text">Serial: Off</span>
+                  </span>
+                </div>
+                <div class="console-controls-right">
+                  <button type="button" id="btn-cancel-exec" class="btn btn-xs btn-danger" style="display: none;" title="Abort running process">⏹️ Stop Process</button>
+                  <label class="checkbox-label-sm" title="Stream wireless UDP syslog messages into terminal">
+                    <input type="checkbox" id="chk-stream-syslog-terminal" checked>
+                    <span>📡 Syslog</span>
+                  </label>
+                  <label class="checkbox-label-sm">
+                    <input type="checkbox" id="chk-serial-autoscroll" checked>
+                    <span>Auto-scroll</span>
+                  </label>
+                  <button type="button" id="btn-serial-clear" class="btn btn-xs btn-ghost">🧹 Clear</button>
+                </div>
+              </div>
+
+              <!-- Terminal Output Display Screen -->
+              <div class="terminal-screen" id="serial-terminal-screen">
+                <div class="terminal-line terminal-dim">[Web Serial Console Initialized. Click 'Connect Serial Port' to stream live microcontroller logs.]</div>
+              </div>
+
+              <!-- Terminal Command Sender Input -->
+              <div class="terminal-input-bar">
+                <input type="text" id="serial-input-text" class="terminal-input" placeholder="Type serial command or character (e.g. 's' for I2C scan, 'r' for reset) and press Enter..." disabled>
+                <button type="button" id="btn-serial-send" class="btn btn-sm btn-secondary" disabled>Send</button>
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+
+      </div>
+    </section>
+
+    <!-- Right Column: Live HUD, Safety Inspector & Code Artifacts -->
+    <section class="dashboard-panel">
+
+      <!-- Top Metrics HUD -->
+      <div class="hud-card">
+        <div class="hud-header">
+          <h2 class="hud-title">📊 Kinematics & Performance HUD</h2>
+          <span class="hud-badge" id="hud-base-tag">2WD Differential</span>
+        </div>
+
+        <div class="metrics-grid">
+          <div class="metric-card">
+            <span class="metric-label">Max Linear Speed</span>
+            <div class="metric-val-wrap">
+              <span class="metric-val" id="val-speed-ms">1.42</span>
+              <span class="metric-unit">m/s</span>
+            </div>
+            <span class="metric-sub" id="val-speed-kmh">5.13 km/h (85% Headroom)</span>
+          </div>
+
+          <div class="metric-card">
+            <span class="metric-label">Max Angular Speed</span>
+            <div class="metric-val-wrap">
+              <span class="metric-val" id="val-speed-rads">12.95</span>
+              <span class="metric-unit">rad/s</span>
+            </div>
+            <span class="metric-sub" id="val-speed-degs">741.8 deg/s</span>
+          </div>
+
+          <div class="metric-card">
+            <span class="metric-label">Resolution</span>
+            <div class="metric-val-wrap">
+              <span class="metric-val" id="val-ticks-m">5,730</span>
+              <span class="metric-unit">ticks/m</span>
+            </div>
+            <span class="metric-sub" id="val-wheel-circ">Circumference: 0.251 m</span>
+          </div>
+
+          <div class="metric-card">
+            <span class="metric-label">Est. Max Acceleration</span>
+            <div class="metric-val-wrap">
+              <span class="metric-val" id="val-max-accel">2.64</span>
+              <span class="metric-unit">m/s²</span>
+            </div>
+            <span class="metric-sub" id="val-thrust-sub">Thrust: 9.24 N @ 3.5 kg</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Real-Time Hardware & Electrical Safety Inspector -->
+      <div class="safety-card" id="safety-inspector-box">
+        <div class="safety-header">
+          <div class="safety-indicator-wrap">
+            <span class="status-dot status-ok" id="safety-status-dot"></span>
+            <h3 class="safety-title" id="safety-status-title">Hardware Safety Rules: PASSED</h3>
+          </div>
+          <span class="safety-badge badge-ok" id="safety-status-badge">0 Errors</span>
+        </div>
+        <div class="safety-messages" id="safety-messages-list">
+          <div class="safety-item item-ok">
+            <span class="item-icon">✅</span>
+            <span>All pin assignments and electrical limits are conflict-free.</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Multi-Artifact Code Generator Tabs -->
+      <div class="artifacts-card">
+        <div class="artifacts-header">
+          <div class="artifact-tabs">
+            <button class="artifact-tab active" data-artifact="tab-code-header" id="btn-art-header">
+              <span>📄 C++ Header</span>
+            </button>
+            <button class="artifact-tab" data-artifact="tab-code-pio" id="btn-art-pio">
+              <span>⚡ PlatformIO</span>
+            </button>
+            <button class="artifact-tab" data-artifact="tab-code-urdf" id="btn-art-urdf">
+              <span>🤖 ROS 2 URDF</span>
+            </button>
+            <button class="artifact-tab" data-artifact="tab-code-wiring" id="btn-art-wiring">
+              <span>🔌 Wiring Chart</span>
+            </button>
+            <button class="artifact-tab" data-artifact="tab-code-deploy" id="btn-art-deploy">
+              <span>🛠️ Deploy Script</span>
+            </button>
+            <button class="artifact-tab" data-artifact="tab-code-json" id="btn-art-json">
+              <span>📋 Spec JSON</span>
+            </button>
+          </div>
+
+          <div class="artifact-actions">
+            <button id="btn-merge-save-config" class="btn btn-sm btn-primary" title="Search config/custom/<robot>_config.h for an existing file, merge these settings into it (your changes win, anything else there is kept), and write the result">
+              <span>🔀 Sync to Config</span>
+            </button>
+            <button id="btn-copy-code" class="btn btn-sm btn-ghost" title="Copy code to clipboard">
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+              </svg>
+              <span id="copy-btn-text">Copy</span>
+            </button>
+            <button id="btn-download-artifact" class="btn btn-sm btn-secondary" title="Download this file">
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
+              </svg>
+              <span>Download</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="code-viewer-wrap">
+          <pre class="code-viewer"><code id="code-display" class="language-cpp">// Generating...</code></pre>
+        </div>
+      </div>
+
+    </section>
+  </main>
+
+  <!-- Notification Toast -->
+  <div id="toast" class="toast">Action completed!</div>
+
+  <script src="app.js?v=2.1.0"></script>
+
+  <!-- Board Config Selector Modal -->
+  <div id="modal-board-select" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:9999;align-items:center;justify-content:center;">
+    <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:28px 32px;min-width:380px;max-width:520px;box-shadow:0 20px 60px rgba(0,0,0,0.5);">
+      <h3 style="margin:0 0 6px 0;font-size:1.1rem;">&#x1F50C; Load Board Configuration</h3>
+      <p style="margin:0 0 18px 0;font-size:0.82rem;color:var(--text-muted);">Reads <code>firmware/platformio.ini</code> and imports the matching config header for the selected board environment.</p>
+      <label style="display:block;margin-bottom:6px;font-size:0.85rem;font-weight:600;">Select PlatformIO Environment:</label>
+      <select id="board-select" class="form-input" style="width:100%;margin-bottom:18px;">
+        <option value="">Loading board list&#x2026;</option>
+      </select>
+      <div id="board-select-info" style="font-size:0.78rem;color:var(--text-muted);margin-bottom:14px;min-height:36px;"></div>
+      <div style="display:flex;gap:10px;justify-content:flex-end;">
+        <button id="btn-board-cancel" class="btn btn-ghost">Cancel</button>
+        <button id="btn-board-confirm" class="btn btn-primary" disabled>Load Config</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Rootless Docker Daemon & Podman Setup Guide Modal -->
+  <div id="modal-rootless-docker" class="modal-overlay" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.75);z-index:9999;align-items:center;justify-content:center;backdrop-filter:blur(8px);">
+    <div class="modal-card" style="background:var(--bg-card-elevated, #111827);border:1px solid var(--border-glow, #38bdf8);border-radius:14px;padding:26px 30px;min-width:420px;max-width:680px;width:90%;box-shadow:0 25px 65px rgba(0,0,0,0.7);max-height:90vh;overflow-y:auto;">
+      <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:12px;">
+        <div style="display:flex;align-items:center;gap:10px;">
+          <span style="font-size:1.6rem;">🐳</span>
+          <div>
+            <h3 style="margin:0;font-size:1.15rem;color:#f8fafc;">Linux Rootless Container Guide</h3>
+            <p style="margin:2px 0 0 0;font-size:0.8rem;color:#94a3b8;">Prevent root file ownership on bind-mounted directories</p>
+          </div>
+        </div>
+        <button type="button" id="btn-close-rootless-modal" class="btn btn-xs btn-ghost" style="font-size:1.1rem;padding:2px 8px;">✕</button>
+      </div>
+
+      <div style="background:rgba(56, 189, 248, 0.1);border:1px solid rgba(56, 189, 248, 0.3);border-radius:8px;padding:12px 14px;margin-bottom:16px;">
+        <div style="font-weight:600;font-size:0.84rem;color:#38bdf8;margin-bottom:4px;">💡 Why Rootless Docker on Linux?</div>
+        <p style="margin:0;font-size:0.8rem;color:#cbd5e1;line-height:1.45;">
+          When standard (rootful) Docker executes container builds with volume mounts (<code>-v "$(pwd):/workspace"</code>), all generated files (such as <code>config/custom/*.h</code>, <code>.pio/build/</code>, and <code>urdf/</code>) are written as <strong>root:root</strong>. This causes local Git commit errors and permission denies during local development.
+          <strong>Rootless Docker</strong> and <strong>Podman</strong> run completely inside your user namespace, guaranteeing all files stay owned by your normal user account.
+        </p>
+      </div>
+
+      <div style="margin-bottom:14px;">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;">
+          <span style="font-size:0.82rem;font-weight:600;color:#e2e8f0;">⚡ 1-Click Setup: Ubuntu / Debian / Raspberry Pi OS</span>
+          <button type="button" id="btn-copy-rootless-ubuntu" class="btn btn-xs btn-ghost" style="font-size:0.75rem;">📋 Copy Script</button>
+        </div>
+        <pre style="background:rgba(15,23,42,0.9);border:1px solid rgba(255,255,255,0.1);padding:10px 12px;border-radius:6px;font-family:var(--font-mono, monospace);font-size:0.75rem;color:#38bdf8;overflow-x:auto;margin:0;"><code id="code-rootless-ubuntu"># 1. Install prerequisites
+sudo apt-get update && sudo apt-get install -y uidmap dbus-user-session slirp4netns
+# 2. Run official rootless installer (non-root)
+dockerd-rootless-setuptool.sh install
+# 3. Enable user systemd service and persistent lingering
+systemctl --user enable --now docker.service
+loginctl enable-linger $USER
+# 4. Point DOCKER_HOST to your user socket
+export DOCKER_HOST="unix://${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/docker.sock"
+grep -q "DOCKER_HOST" ~/.bashrc || echo 'export DOCKER_HOST="unix://${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/docker.sock"' >> ~/.bashrc</code></pre>
+      </div>
+
+      <div style="margin-bottom:14px;">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;">
+          <span style="font-size:0.82rem;font-weight:600;color:#e2e8f0;">🦭 Alternative: Podman (Rootless by Default — No Daemon!)</span>
+          <button type="button" id="btn-copy-rootless-podman" class="btn btn-xs btn-ghost" style="font-size:0.75rem;">📋 Copy</button>
+        </div>
+        <pre style="background:rgba(15,23,42,0.9);border:1px solid rgba(255,255,255,0.1);padding:10px 12px;border-radius:6px;font-family:var(--font-mono, monospace);font-size:0.75rem;color:#a78bfa;overflow-x:auto;margin:0;"><code id="code-rootless-podman">sudo apt-get install -y podman  # Fedora: sudo dnf install -y podman
+# Podman works immediately with zero daemon configuration:
+podman run --rm hello-world</code></pre>
+      </div>
+
+      <div style="margin-bottom:18px;">
+        <span style="font-size:0.82rem;font-weight:600;color:#e2e8f0;display:block;margin-bottom:6px;">🖥️ Windows &amp; macOS Note</span>
+        <p style="margin:0;font-size:0.78rem;color:#94a3b8;line-height:1.4;">
+          On Windows (WSL2 / Docker Desktop) and macOS (Docker Desktop / Colima), volume mount permissions are already automatically mapped to the host user by the hypervisor layer. No rootless daemon configuration is required.
+        </p>
+      </div>
+
+      <div style="display:flex;gap:10px;justify-content:space-between;align-items:center;border-top:1px solid rgba(255,255,255,0.1);padding-top:14px;">
+        <div id="rootless-status-text" style="font-size:0.78rem;color:#38bdf8;">Status: Checking local container engine...</div>
+        <div style="display:flex;gap:8px;">
+          <button type="button" id="btn-setup-rootless-docker" class="btn btn-sm btn-accent" style="background:#0284c7;color:#fff;">⚡ Setup Rootless Now</button>
+          <button type="button" id="btn-test-rootless-daemon" class="btn btn-sm btn-secondary">🔍 Test Daemon</button>
+          <button type="button" id="btn-close-rootless-modal-ok" class="btn btn-sm btn-primary">Got It</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/tools/robot_config_engine/web/server.py
+++ b/tools/robot_config_engine/web/server.py
@@ -1,0 +1,1354 @@
+#!/usr/bin/env python3
+"""
+Linorobot2 Robot Configuration Engine - Local HTTP Server with Live Command Execution & Config Merge API
+Zero-Dependency, Pure Standard Library Python 3 (Multi-Threaded)
+
+Usage:
+    python3 server.py [PORT]
+    (Defaults to port 8000)
+"""
+
+import os
+import sys
+import json
+import time
+import signal
+import socket
+import datetime
+import collections
+import queue
+import platform
+import threading
+import subprocess
+import glob
+import shutil
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+from urllib.parse import urlparse, parse_qs
+import re
+
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8000
+
+
+def running_in_container():
+    """True when this server itself runs inside a container (distrobox, podman, docker).
+
+    Nested `distrobox enter` is not supported, so when we are already inside a
+    container we must run commands directly in our own environment.
+    """
+    if os.environ.get("CONTAINER_ID") or os.environ.get("DISTROBOX_ENTER_PATH"):
+        return True
+    return os.path.exists("/run/.containerenv") or os.path.exists("/.dockerenv")
+
+
+IN_CONTAINER = running_in_container()
+
+WEB_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(WEB_DIR, "..", "..", ".."))
+
+# Add REPO_ROOT to sys.path so we can import generator and parser
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+from tools.robot_config_engine.generator import generate_config_header
+from tools.robot_config_engine.validator import validate_robot_spec
+from tools.robot_config_engine.parser import parse_header_to_spec, merge_configurations, merge_wifi_config
+
+active_process = None
+active_process_lock = threading.Lock()
+
+
+def _wifi_config_content():
+    """Contents of the git-ignored config/custom/wifi_config.h, or '' if absent."""
+    p = os.path.join(REPO_ROOT, "config", "custom", "wifi_config.h")
+    try:
+        with open(p, "r", encoding="utf-8") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+class SyslogManager:
+    """
+    Lightweight, multi-threaded UDP Syslog server & real-time telemetry broadcaster.
+    Listens on UDP (default port 514 with auto-fallback to 5140 for non-root),
+    appends timestamped telemetry logs to repo logs/syslog_YYYYMMDD.log,
+    and broadcasts events in real-time to Web UI SSE subscribers.
+    """
+    def __init__(self, repo_root):
+        self.repo_root = repo_root
+        self.logs_dir = os.path.join(repo_root, "logs")
+        os.makedirs(self.logs_dir, exist_ok=True)
+        self.sock = None
+        self.thread = None
+        self.is_running = False
+        self.port = 514
+        self.bound_port = 514
+        self.packets_received = 0
+        self.last_sender = ""
+        self.last_message = ""
+        self.last_timestamp = ""
+        self.recent_logs = collections.deque(maxlen=200)
+        self.subscribers = set()
+        self.subscribers_lock = threading.Lock()
+        self.lock = threading.Lock()
+
+    def get_current_log_filepath(self):
+        date_str = datetime.datetime.now().strftime("%Y%m%d")
+        return os.path.join(self.logs_dir, f"syslog_{date_str}.log")
+
+    def start(self, requested_port=514):
+        with self.lock:
+            if self.is_running:
+                return {
+                    "status": "already_running",
+                    "host_ip": self._host_ip(),
+                    "port": self.bound_port,
+                    "logfile": os.path.relpath(self.get_current_log_filepath(), self.repo_root),
+                    "packets": self.packets_received
+                }
+
+            try:
+                self.port = int(requested_port)
+            except Exception:
+                self.port = 514
+
+            ports_to_try = [self.port]
+            if self.port != 5140 and 5140 not in ports_to_try:
+                ports_to_try.append(5140)
+            if 5514 not in ports_to_try:
+                ports_to_try.append(5514)
+
+            bound = False
+            last_err = None
+            for p in ports_to_try:
+                try:
+                    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                    s.bind(("0.0.0.0", p))
+                    self.sock = s
+                    self.bound_port = p
+                    bound = True
+                    break
+                except Exception as e:
+                    last_err = e
+                    continue
+
+            if not bound:
+                raise RuntimeError(f"Could not bind UDP syslog port (tried {ports_to_try}): {last_err}")
+
+            self.is_running = True
+            self.thread = threading.Thread(target=self._listen_loop, daemon=True)
+            self.thread.start()
+
+            return {
+                "status": "running",
+                "host_ip": self._host_ip(),
+                "port": self.bound_port,
+                "requested_port": self.port,
+                "logfile": os.path.relpath(self.get_current_log_filepath(), self.repo_root),
+                "packets": self.packets_received,
+                "fallback": self.bound_port != self.port
+            }
+
+    def stop(self):
+        with self.lock:
+            if not self.is_running:
+                return {"status": "stopped", "port": self.bound_port, "packets": self.packets_received}
+            self.is_running = False
+            if self.sock:
+                try:
+                    dummy = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                    dummy.sendto(b"__SHUTDOWN__", ("127.0.0.1", self.bound_port))
+                    dummy.close()
+                    self.sock.close()
+                except Exception:
+                    pass
+                self.sock = None
+
+            return {"status": "stopped", "port": self.bound_port, "packets": self.packets_received}
+
+    def _listen_loop(self):
+        while self.is_running:
+            try:
+                if not self.sock:
+                    break
+                data, addr = self.sock.recvfrom(4096)
+                if not self.is_running:
+                    break
+                if data == b"__SHUTDOWN__":
+                    continue
+
+                raw_text = data.decode("utf-8", errors="replace").strip()
+                now = datetime.datetime.now()
+                time_str = now.strftime("%Y-%m-%d %H:%M:%S")
+                client_str = f"{addr[0]}:{addr[1]}"
+
+                pri = None
+                clean_text = raw_text
+                if raw_text.startswith("<") and ">" in raw_text[:6]:
+                    pri_end = raw_text.index(">")
+                    try:
+                        pri = int(raw_text[1:pri_end])
+                        clean_text = raw_text[pri_end+1:].strip()
+                    except ValueError:
+                        pass
+
+                log_entry = {
+                    "time": time_str,
+                    "sender": client_str,
+                    "ip": addr[0],
+                    "port": addr[1],
+                    "pri": pri,
+                    "message": clean_text,
+                    "raw": raw_text
+                }
+
+                formatted_line = f"[{time_str}] [{client_str}] {clean_text}\n"
+
+                # Append to log file
+                log_file = self.get_current_log_filepath()
+                try:
+                    with open(log_file, "a", encoding="utf-8") as f:
+                        f.write(formatted_line)
+                except Exception:
+                    pass
+
+                self.packets_received += 1
+                self.last_sender = client_str
+                self.last_message = clean_text
+                self.last_timestamp = time_str
+                self.recent_logs.append(log_entry)
+
+                self._broadcast(log_entry)
+            except Exception:
+                if not self.is_running:
+                    break
+                time.sleep(0.05)
+
+    def subscribe(self, q):
+        with self.subscribers_lock:
+            self.subscribers.add(q)
+
+    def unsubscribe(self, q):
+        with self.subscribers_lock:
+            self.subscribers.discard(q)
+
+    def _broadcast(self, log_entry):
+        with self.subscribers_lock:
+            for q in list(self.subscribers):
+                try:
+                    q.put_nowait(log_entry)
+                except Exception:
+                    pass
+
+    @staticmethod
+    def _host_ip():
+        """Best-effort primary LAN IP of this host (no traffic actually sent)."""
+        import socket as _s
+        for probe in ("10.255.255.255", "192.168.255.255", "8.8.8.8"):
+            try:
+                k = _s.socket(_s.AF_INET, _s.SOCK_DGRAM)
+                k.connect((probe, 1)); ip = k.getsockname()[0]; k.close()
+                if ip and not ip.startswith("127."):
+                    return ip
+            except Exception:
+                pass
+        try:
+            return _s.gethostbyname(_s.gethostname())
+        except Exception:
+            return "127.0.0.1"
+
+    def get_status(self):
+        cur_file = self.get_current_log_filepath()
+        file_size = os.path.getsize(cur_file) if os.path.exists(cur_file) else 0
+        return {
+            "running": self.is_running,
+            "host_ip": self._host_ip(),
+            "port": self.bound_port,
+            "requested_port": self.port,
+            "logfile": os.path.relpath(cur_file, self.repo_root),
+            "filesize": file_size,
+            "packets": self.packets_received,
+            "last_sender": self.last_sender,
+            "last_message": self.last_message,
+            "last_timestamp": self.last_timestamp,
+            "recent_count": len(self.recent_logs)
+        }
+
+syslog_manager = SyslogManager(REPO_ROOT)
+
+
+def _mcu_from_platformio(platform: str, board: str, env: str = "") -> str:
+    """MCU family from platformio.ini `platform =` / `board =` (authoritative)."""
+    b = (board or "").lower().strip()
+    p = (platform or "").lower()
+    e = (env or "").lower()
+    if b.startswith("teensy") or "teensy" in p:
+        return "TEENSY"
+    if b in ("rpipico2w",) or "pico2w" in b:
+        return "PICO2W"
+    if b in ("rpipico2",) or "pico2" in b or "rp2350" in b:
+        return "PICO2"
+    if b in ("rpipicow",) or "picow" in b:
+        return "PICOW"
+    if b in ("rpipico",) or "pico" in b or "rp2040" in b:
+        return "PICO"
+    if "esp32-s3" in b or "esp32s3" in b:
+        return "ESP32S3"
+    if "esp32-s2" in b or "esp32s2" in b:
+        return "ESP32S2"
+    if "espressif32" in p or b in ("nodemcu-32s",) or "esp32" in b:
+        return "GENDRV" if e.startswith("gendrv") else "ESP32"
+    return ""
+
+
+def _parse_platformio_boards(ini_path: str) -> list:
+    """
+    Parse firmware/platformio.ini and return a list of board environment dicts:
+      env, config_file, config_macro, transport, wifi, board, monitor_speed, display_name
+    Only environments with a USE_*_CONFIG define in build_flags are included.
+    """
+    # Macro → relative path from REPO_ROOT
+    MACRO_TO_CONFIG = {
+        "USE_GENDRV_CONFIG":  "config/custom/gendrv_config.h",
+        "USE_ESP32_CONFIG":   "config/custom/esp32_config.h",
+        "USE_ESP32S2_CONFIG": "config/custom/esp32s2_config.h",
+        "USE_ESP32S3_CONFIG": "config/custom/esp32s3_config.h",
+        "USE_PICO_CONFIG":    "config/custom/pico_config.h",
+        "USE_VATTENKAR_CONFIG": "config/custom/vattenkar_config.h",
+        "USE_TEENSY_CONFIG":  "config/lino_base_config.h",
+    }
+    # Friendly display names
+    ENV_DISPLAY = {
+        "teensy41": "Teensy 4.1",
+        "teensy40": "Teensy 4.0",
+        "teensy36": "Teensy 3.6",
+        "teensy35": "Teensy 3.5",
+        "teensy31": "Teensy 3.1 / 3.2",
+        "vattenkar": "Vattenkar (Teensy 4.0)",
+        "gendrv": "Waveshare General Driver (ESP32, Serial)",
+        "gendrv_wifi": "Waveshare General Driver (ESP32, WiFi)",
+        "esp32": "ESP32 DevKit (Serial)",
+        "esp32_wifi": "ESP32 DevKit (WiFi)",
+        "esp32s2": "ESP32-S2 (Serial)",
+        "esp32s2_wifi": "ESP32-S2 (WiFi)",
+        "esp32s3": "ESP32-S3 (Serial)",
+        "esp32s3_wifi": "ESP32-S3 (WiFi)",
+        "pico": "Raspberry Pi Pico (RP2040, Serial)",
+        "picow": "Raspberry Pi Pico W (RP2040, Serial)",
+        "picow_wifi": "Raspberry Pi Pico W (RP2040, WiFi)",
+        "pico2": "Raspberry Pi Pico 2 (RP2350, Serial)",
+        "pico2w": "Raspberry Pi Pico 2W (RP2350, Serial)",
+        "pico2w_wifi": "Raspberry Pi Pico 2W (RP2350, WiFi)",
+    }
+
+    if not os.path.isfile(ini_path):
+        return []
+
+    with open(ini_path, "r", encoding="utf-8") as f:
+        raw = f.read()
+
+    # Split into sections
+    section_re = re.compile(r'^\[env:([^\]]+)\]', re.MULTILINE)
+    positions = [(m.start(), m.group(1)) for m in section_re.finditer(raw)]
+
+    boards = []
+    for idx, (pos, env_name) in enumerate(positions):
+        end = positions[idx + 1][0] if idx + 1 < len(positions) else len(raw)
+        section_text = raw[pos:end]
+
+        # Extract build_flags block (multi-line, continuation lines indented)
+        bf_match = re.search(r'build_flags\s*=\s*((?:.*\n(?:[ \t]+.*\n)*)*)', section_text)
+        build_flags = bf_match.group(1) if bf_match else ""
+
+        # Find USE_*_CONFIG macro
+        macro_match = re.search(r'-D\s+(USE_\w+_CONFIG)', build_flags)
+        if not macro_match:
+            # Teensy boards use generic config (no USE_*_CONFIG)
+            # They inherit from [env] which has no USE_*_CONFIG, but we can
+            # identify them by board type
+            board_val = re.search(r'^board\s*=\s*(\S+)', section_text, re.MULTILINE)
+            bv = board_val.group(1) if board_val else ""
+            if "teensy" in bv or "vattenkar" in env_name.lower():
+                config_macro = "USE_TEENSY_CONFIG"
+                config_file = MACRO_TO_CONFIG.get("USE_TEENSY_CONFIG", "config/lino_base_config.h")
+            else:
+                continue
+        else:
+            config_macro = macro_match.group(1)
+            config_file = MACRO_TO_CONFIG.get(config_macro, "")
+            if not config_file:
+                # Generic: USE_<NAME>_CONFIG -> config/custom/<name>_config.h
+                stem = config_macro[len("USE_"):-len("_CONFIG")].lower() if config_macro.startswith("USE_") and config_macro.endswith("_CONFIG") else ""
+                for cand in (stem, env_name.lower()):
+                    if cand and os.path.isfile(os.path.join(REPO_ROOT, "config", "custom", f"{cand}_config.h")):
+                        config_file = f"config/custom/{cand}_config.h"
+                        break
+
+        # Transport detection
+        wifi = (
+            re.search(r'^board_microros_transport\s*=\s*wifi', section_text, re.MULTILINE) is not None
+            or "-D USE_WIFI" in build_flags
+        )
+        transport = "WIFI_UDP" if wifi else "SERIAL"
+
+        # Board hardware ID + platform
+        board_hw = ""
+        bm = re.search(r'^board\s*=\s*(\S+)', section_text, re.MULTILINE)
+        if bm:
+            board_hw = bm.group(1)
+        platform_hw = ""
+        pm = re.search(r'^platform\s*=\s*(\S+)', section_text, re.MULTILINE)
+        if pm:
+            platform_hw = pm.group(1)
+        # env `[env]` section has no `board` (teensy default lives there) —
+        # fall back to the file-level platform for teensy child envs.
+        if not platform_hw and "teensy" in board_hw:
+            platform_hw = "teensy"
+
+        # Monitor speed
+        monitor_speed = None
+        ms_m = re.search(r'^monitor_speed\s*=\s*(\d+)', section_text, re.MULTILINE)
+        if ms_m:
+            monitor_speed = int(ms_m.group(1))
+
+        # Only include if config file exists on disk
+        config_exists = bool(config_file) and os.path.isfile(os.path.join(REPO_ROOT, config_file))
+
+        boards.append({
+            "env":           env_name,
+            "display_name":  ENV_DISPLAY.get(env_name, env_name),
+            "mcu":           _mcu_from_platformio(platform_hw, board_hw, env_name),
+            "platform":      platform_hw,
+            "config_macro":  config_macro,
+            "config_file":   config_file,
+            "config_exists": config_exists,
+            "transport":     transport,
+            "wifi":          wifi,
+            "board":         board_hw,
+            "monitor_speed": monitor_speed,
+        })
+
+    return boards
+
+
+
+def get_port_usb_details(port_path):
+    port_name = os.path.basename(port_path)
+    info = {
+        "port": port_path,
+        "vid": "",
+        "pid": "",
+        "product": "",
+        "manufacturer": "",
+        "chip": "Generic USB Serial",
+        "accessible": os.access(port_path, os.R_OK | os.W_OK),
+        "read": os.access(port_path, os.R_OK),
+        "write": os.access(port_path, os.W_OK)
+    }
+
+    # Inspect Linux sysfs for USB Vendor & Product ID
+    sys_device_path = f"/sys/class/tty/{port_name}/device"
+    if os.path.exists(sys_device_path):
+        curr = os.path.realpath(sys_device_path)
+        for _ in range(6):
+            vid_path = os.path.join(curr, "idVendor")
+            pid_path = os.path.join(curr, "idProduct")
+            if os.path.exists(vid_path) and os.path.exists(pid_path):
+                try:
+                    with open(vid_path, "r") as f:
+                        info["vid"] = f.read().strip().lower()
+                    with open(pid_path, "r") as f:
+                        info["pid"] = f.read().strip().lower()
+                    prod_path = os.path.join(curr, "product")
+                    mfg_path = os.path.join(curr, "manufacturer")
+                    if os.path.exists(prod_path):
+                        with open(prod_path, "r") as f:
+                            info["product"] = f.read().strip()
+                    if os.path.exists(mfg_path):
+                        with open(mfg_path, "r") as f:
+                            info["manufacturer"] = f.read().strip()
+                except Exception:
+                    pass
+                break
+            curr = os.path.dirname(curr)
+
+    # Hardware MCU / Serial Bridge Identification Matrix
+    vid = info["vid"]
+    pid = info["pid"]
+    if vid == "2e8a":
+        if pid in ["0003", "000a"]:
+            info["chip"] = "Raspberry Pi Pico (RP2040)"
+        elif pid in ["000f", "0005"]:
+            info["chip"] = "Raspberry Pi Pico 2 (RP2350)"
+        else:
+            info["chip"] = "Raspberry Pi (RP2040/RP2350)"
+    elif vid == "303a":
+        if pid in ["1001", "1002"]:
+            info["chip"] = "ESP32-S3 (Native USB CDC)"
+        elif pid == "0002":
+            info["chip"] = "ESP32-S2 (Native USB CDC)"
+        elif pid == "1000":
+            info["chip"] = "ESP32-C3 (Native USB CDC)"
+        else:
+            info["chip"] = "Espressif USB Serial"
+    elif vid == "10c4" and pid == "ea60":
+        info["chip"] = "CP2102N USB Bridge (ESP32/GenDrv)"
+    elif vid == "1a86" and pid in ["7523", "5523", "7522"]:
+        info["chip"] = "CH340/CH341 USB Bridge (Arduino/ESP32)"
+    elif vid == "0403" and pid in ["6001", "6010", "6015"]:
+        info["chip"] = "FTDI USB Serial Bridge"
+    elif vid == "16c0" and pid in ["0483", "0487", "0488"]:
+        info["chip"] = "Teensy USB Serial"
+
+    return info
+
+
+def get_robot_host_info():
+    info = {
+        "system": platform.system(),
+        "node": platform.node(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "distro_id": "",
+        "distro_name": platform.system(),
+        "has_apt": shutil.which("apt-get") is not None,
+        "has_dnf": shutil.which("dnf") is not None,
+        "has_distrobox": shutil.which("distrobox") is not None,
+        "is_container": os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"),
+        "has_pio": shutil.which("pio") is not None or os.path.exists(os.path.expanduser("~/.platformio/penv/bin/pio")),
+        "installed_ros_distros": [],
+        "serial_ports": []
+    }
+    # Check OS Release
+    if os.path.exists("/etc/os-release"):
+        try:
+            with open("/etc/os-release", "r") as f:
+                for line in f:
+                    if line.startswith("ID="):
+                        info["distro_id"] = line.split("=", 1)[1].strip().strip('"').lower()
+                    elif line.startswith("PRETTY_NAME="):
+                        info["distro_name"] = line.split("=", 1)[1].strip().strip('"')
+        except Exception:
+            pass
+
+    # Check installed ROS 2 distros
+    if os.path.isdir("/opt/ros"):
+        try:
+            info["installed_ros_distros"] = sorted(os.listdir("/opt/ros"))
+        except Exception:
+            pass
+
+    # Scan attached MCU serial ports, inspect USB VID:PID, and verify access rights
+    patterns = ["/dev/ttyACM*", "/dev/ttyUSB*", "/dev/ttyTHS*", "/dev/serial0"]
+    found_ports = []
+    port_details = []
+    seen_syspaths = set()
+    for pat in patterns:
+        for p in glob.glob(pat):
+            found_ports.append(p)
+            det = get_port_usb_details(p)
+            port_details.append(det)
+            if det.get("syspath"):
+                try:
+                    seen_syspaths.add(os.path.realpath(det["syspath"]))
+                except Exception:
+                    pass
+
+    # Scan for connected USB ROM bootloaders / Mass Storage devices lacking tty drivers (e.g. RP2 Boot / BOOTSEL)
+    for dev_dir in sorted(glob.glob("/sys/bus/usb/devices/*")):
+        idv_f = os.path.join(dev_dir, "idVendor")
+        idp_f = os.path.join(dev_dir, "idProduct")
+        if os.path.exists(idv_f) and os.path.exists(idp_f):
+            try:
+                with open(idv_f) as f: vid = f.read().strip().lower()
+                with open(idp_f) as f: pid = f.read().strip().lower()
+                real_sys = os.path.realpath(dev_dir)
+                # If already mapped to a tty port, skip
+                if any(real_sys.startswith(s) or s.startswith(real_sys) for s in seen_syspaths):
+                    continue
+
+                prod = ""
+                mfg = ""
+                if os.path.exists(os.path.join(dev_dir, "product")):
+                    with open(os.path.join(dev_dir, "product")) as f: prod = f.read().strip()
+                if os.path.exists(os.path.join(dev_dir, "manufacturer")):
+                    with open(os.path.join(dev_dir, "manufacturer")) as f: mfg = f.read().strip()
+
+                is_bootsel = False
+                chip_name = ""
+                mcu_hint = ""
+                if vid == "2e8a":
+                    if pid in ["0003", "000a"]:
+                        is_bootsel = True
+                        chip_name = "Raspberry Pi Pico (RP2040) [BOOTSEL Mode]"
+                        mcu_hint = "PICO"
+                    elif pid in ["000f", "0005"]:
+                        is_bootsel = True
+                        chip_name = "Raspberry Pi Pico 2 (RP2350) [BOOTSEL Mode]"
+                        mcu_hint = "PICO2"
+                    else:
+                        chip_name = f"Raspberry Pi RP2 Device [{vid}:{pid}]"
+                        mcu_hint = "PICO"
+                        is_bootsel = True
+                elif vid == "303a" and pid in ["0002", "1001", "1002"]:
+                    chip_name = "ESP32-S2/S3 (ROM Bootloader Mode)"
+                    mcu_hint = "ESP32S3"
+                    is_bootsel = True
+
+                if is_bootsel:
+                    boot_entry = {
+                        "port": "BOOTSEL",
+                        "accessible": True,
+                        "vid": vid,
+                        "pid": pid,
+                        "product": prod or "RP2 Boot",
+                        "manufacturer": mfg or "Raspberry Pi",
+                        "chip": chip_name or f"USB Bootloader [{vid}:{pid}]",
+                        "is_bootsel": True,
+                        "mcu_hint": mcu_hint,
+                        "post_flash_port": "/dev/ttyACM0"
+                    }
+                    found_ports.append("BOOTSEL")
+                    port_details.append(boot_entry)
+            except Exception:
+                pass
+
+    info["serial_ports"] = sorted(list(set(found_ports)))
+    info["port_details"] = port_details
+
+    # Check user dialout/plugdev group permissions
+    has_dialout = False
+    try:
+        import grp
+        user = os.environ.get("USER", "")
+        if user:
+            dialout_group = grp.getgrnam("dialout")
+            has_dialout = user in dialout_group.gr_mem
+    except Exception:
+        pass
+    info["has_dialout"] = has_dialout
+
+    return info
+
+
+class LinorobotEngineHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=WEB_DIR, **kwargs)
+
+    def end_headers(self):
+        self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+        super().end_headers()
+
+    def do_HEAD(self):
+        parsed = urlparse(self.path)
+        if parsed.path in ["/api/status", "/api/configs"]:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            return
+        return super().do_HEAD()
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        
+        if parsed.path == "/api/syslog/status":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({"status": "ok", **syslog_manager.get_status()}).encode("utf-8"))
+            except Exception:
+                pass
+            return
+
+        if parsed.path == "/api/syslog/logs":
+            # List available log files and optionally read tail lines
+            qs = parse_qs(parsed.query)
+            tail_count = int(qs.get("tail", [50])[0])
+            files = []
+            if os.path.exists(syslog_manager.logs_dir):
+                for f in sorted(os.listdir(syslog_manager.logs_dir), reverse=True):
+                    if f.endswith(".log"):
+                        fp = os.path.join(syslog_manager.logs_dir, f)
+                        files.append({
+                            "name": f,
+                            "path": os.path.relpath(fp, REPO_ROOT),
+                            "size": os.path.getsize(fp),
+                            "mtime": os.path.getmtime(fp)
+                        })
+
+            current_log = syslog_manager.get_current_log_filepath()
+            lines = []
+            if os.path.exists(current_log):
+                try:
+                    with open(current_log, "r", encoding="utf-8", errors="replace") as f:
+                        all_lines = f.readlines()
+                        lines = [l.strip() for l in all_lines[-tail_count:]]
+                except Exception:
+                    pass
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({
+                    "status": "ok",
+                    "files": files,
+                    "current_file": os.path.relpath(current_log, REPO_ROOT),
+                    "lines": lines
+                }).encode("utf-8"))
+            except Exception:
+                pass
+            return
+
+        if parsed.path == "/api/syslog/stream":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+
+            q = queue.Queue(maxsize=100)
+            syslog_manager.subscribe(q)
+
+            # Send initial status
+            try:
+                status_init = f"event: status\ndata: {json.dumps(syslog_manager.get_status())}\n\n"
+                self.wfile.write(status_init.encode("utf-8"))
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                syslog_manager.unsubscribe(q)
+                return
+
+            try:
+                while True:
+                    try:
+                        entry = q.get(timeout=2.0)
+                        msg = f"event: syslog\ndata: {json.dumps(entry)}\n\n"
+                        self.wfile.write(msg.encode("utf-8"))
+                        self.wfile.flush()
+                    except queue.Empty:
+                        self.wfile.write(b": ping\n\n")
+                        self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            finally:
+                syslog_manager.unsubscribe(q)
+            return
+
+        if parsed.path == "/api/ros2/topics":
+            # Discover active ROS 2 topics, message types, and default known rates
+            topics = []
+            try:
+                setup_bash = ""
+                for distro in ["jazzy", "lyrical", "rolling", "humble"]:
+                    p = f"/opt/ros/{distro}/setup.bash"
+                    if os.path.exists(p):
+                        setup_bash = p
+                        break
+                
+                cmd = f"source {setup_bash} 2>/dev/null && ros2 topic list -t"
+                res = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True, timeout=3.5)
+                if res.returncode == 0:
+                    for line in res.stdout.strip().split("\n"):
+                        line = line.strip()
+                        if line and " [" in line and line.endswith("]"):
+                            t_name, t_type = line.split(" [", 1)
+                            t_name = t_name.strip()
+                            t_type = t_type[:-1].strip()
+                            
+                            # Estimate nominal rate
+                            hz_str = "--"
+                            status_str = "active"
+                            if "odom" in t_name:
+                                hz_str = "50.0 Hz"
+                            elif "imu" in t_name:
+                                hz_str = "50.0 Hz"
+                            elif "battery" in t_name:
+                                hz_str = "1.0 Hz"
+                            elif "cmd_vel" in t_name:
+                                hz_str = "Subscribed"
+                                status_str = "sub"
+                            elif "sonar" in t_name:
+                                hz_str = "20.0 Hz"
+                            elif "parameter_events" in t_name or "rosout" in t_name:
+                                hz_str = "Event"
+
+                            topics.append({
+                                "topic": t_name,
+                                "type": t_type,
+                                "hz": hz_str,
+                                "status": status_str
+                            })
+            except Exception as e:
+                pass
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({"status": "ok", "topics": topics}).encode("utf-8"))
+            except Exception:
+                pass
+            return
+
+        if parsed.path == "/api/ros2/hz_single":
+            # Quick single-shot frequency measurement
+            qs = parse_qs(parsed.query)
+            topic = qs.get("topic", ["/odom/unfiltered"])[0].strip()
+            rate_val = "0.0"
+            try:
+                setup_bash = ""
+                for distro in ["jazzy", "lyrical", "rolling", "humble"]:
+                    p = f"/opt/ros/{distro}/setup.bash"
+                    if os.path.exists(p):
+                        setup_bash = p
+                        break
+                cmd = f"source {setup_bash} 2>/dev/null && timeout 2.5 stdbuf -oL -eL ros2 topic hz {topic}"
+                res = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True)
+                for line in res.stdout.split("\n"):
+                    if "average rate:" in line:
+                        m = re.search(r"average rate:\s*([0-9.]+)", line)
+                        if m:
+                            rate_val = f"{float(m.group(1)):.1f} Hz"
+            except Exception:
+                pass
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({"status": "ok", "topic": topic, "hz": rate_val}).encode("utf-8"))
+            except Exception:
+                pass
+            return
+
+        if parsed.path == "/api/ros2/stream":
+            qs = parse_qs(parsed.query)
+            topic = qs.get("topic", ["/odom/unfiltered"])[0].strip()
+            mode = qs.get("mode", ["echo"])[0].strip()
+
+            setup_bash = ""
+            for distro in ["jazzy", "lyrical", "rolling", "humble"]:
+                p = f"/opt/ros/{distro}/setup.bash"
+                if os.path.exists(p):
+                    setup_bash = p
+                    break
+
+            if mode == "hz":
+                cmd = f"source {setup_bash} 2>/dev/null && stdbuf -oL -eL ros2 topic hz {topic}"
+            else:
+                cmd = f"source {setup_bash} 2>/dev/null && stdbuf -oL -eL ros2 topic echo {topic}"
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+
+            init_msg = json.dumps({"type": "start", "topic": topic, "mode": mode, "text": f"--- Streaming ROS 2 topic {topic} ({mode}) ---"})
+            try:
+                self.wfile.write(f"data: {init_msg}\n\n".encode("utf-8"))
+                self.wfile.flush()
+            except Exception:
+                return
+
+            proc = None
+            try:
+                proc = subprocess.Popen(
+                    ["bash", "-c", cmd],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    bufsize=1,
+                    preexec_fn=os.setsid
+                )
+
+                for line in iter(proc.stdout.readline, ""):
+                    if not line:
+                        break
+                    line_data = json.dumps({"type": "line", "text": line.rstrip()})
+                    self.wfile.write(f"data: {line_data}\n\n".encode("utf-8"))
+                    self.wfile.flush()
+            except Exception:
+                pass
+            finally:
+                if proc:
+                    try:
+                        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                    except Exception:
+                        pass
+                    try:
+                        proc.kill()
+                    except Exception:
+                        pass
+            return
+
+        if parsed.path == "/api/boards":
+            # Parse firmware/platformio.ini and return all board environments
+            # with their config file path, transport mode, and baud rate.
+            ini_path = os.path.join(REPO_ROOT, "firmware", "platformio.ini")
+            boards = []
+            try:
+                boards = _parse_platformio_boards(ini_path)
+            except Exception as e:
+                pass
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({"status": "ok", "boards": boards}).encode("utf-8"))
+            except Exception:
+                pass
+            return
+
+        if parsed.path == "/api/status":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            host_info = get_robot_host_info()
+            status_data = {
+                "status": "ok",
+                "exec_supported": True,
+                "os": host_info["system"],
+                "node": host_info["node"],
+                "release": host_info["release"],
+                "machine": host_info["machine"],
+                "distro_id": host_info["distro_id"],
+                "distro_name": host_info["distro_name"],
+                "has_apt": host_info["has_apt"],
+                "has_dnf": host_info["has_dnf"],
+                "has_distrobox": host_info["has_distrobox"],
+                "is_container": host_info["is_container"],
+                "has_pio": host_info["has_pio"],
+                "installed_ros_distros": host_info["installed_ros_distros"],
+                "serial_ports": host_info["serial_ports"],
+                "port_details": host_info.get("port_details", []),
+                "has_dialout": host_info.get("has_dialout", False),
+                "host_ip": SyslogManager._host_ip(),
+                "repo_root": REPO_ROOT
+            }
+            try:
+                self.wfile.write(json.dumps(status_data).encode("utf-8"))
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            return
+
+        if parsed.path == "/api/configs":
+            # List available custom configurations in config/custom/
+            custom_dir = os.path.join(REPO_ROOT, "config", "custom")
+            configs = []
+            if os.path.isdir(custom_dir):
+                for f in sorted(os.listdir(custom_dir)):
+                    if f.endswith("_config.h"):
+                        full_path = os.path.join(custom_dir, f)
+                        try:
+                            with open(full_path, "r", encoding="utf-8") as hf:
+                                content = hf.read()
+                                spec = parse_header_to_spec(content)
+                                configs.append({
+                                    "filename": f,
+                                    "path": os.path.relpath(full_path, REPO_ROOT),
+                                    "robot_name": spec.get("robot_name", f[:-9]),
+                                    "kinematics": spec.get("kinematics", "UNKNOWN"),
+                                    "mcu": spec.get("mcu", "UNKNOWN"),
+                                    "imu": spec.get("sensors", {}).get("imu_type", "UNKNOWN"),
+                                    "mag": spec.get("sensors", {}).get("mag_type", "UNKNOWN"),
+                                    "wifi": spec.get("telemetry", {}).get("use_wifi", False),
+                                    "content": content
+                                })
+                        except Exception:
+                            pass
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({"configs": configs}).encode("utf-8"))
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            return
+
+        try:
+            return super().do_GET()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS, HEAD")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def do_POST(self):
+        global active_process
+        parsed = urlparse(self.path)
+
+        if parsed.path == "/api/syslog/start":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                data = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                data = {}
+            req_port = data.get("port", 514)
+            try:
+                res = syslog_manager.start(req_port)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps(res).encode("utf-8"))
+            except Exception as e:
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(e)}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/syslog/stop":
+            res = syslog_manager.stop()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(res).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/load_board_config":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                data = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                data = {}
+            env_name = data.get("env", "")
+            try:
+                ini_path = os.path.join(REPO_ROOT, "firmware", "platformio.ini")
+                boards = _parse_platformio_boards(ini_path)
+                board_info = next((b for b in boards if b["env"] == env_name), None)
+                if not board_info:
+                    raise ValueError(f"Board environment '{env_name}' not found in platformio.ini")
+                config_rel = board_info.get("config_file", "")
+                if not config_rel:
+                    raise ValueError(f"No config file mapped for environment '{env_name}'")
+                config_path = os.path.join(REPO_ROOT, config_rel)
+                if not os.path.isfile(config_path):
+                    raise FileNotFoundError(f"Config file not found: {config_path}")
+                with open(config_path, "r", encoding="utf-8") as hf:
+                    header_content = hf.read()
+                spec = parse_header_to_spec(header_content)
+                # The board header pulls WiFi creds from the git-ignored
+                # config/custom/wifi_config.h via __has_include — read them so
+                # the form shows the real SSID / password / host IPs.
+                merge_wifi_config(spec, _wifi_config_content())
+                # Override transport/wifi from platformio.ini flags (authoritative)
+                if board_info.get("wifi"):
+                    spec["telemetry"]["use_wifi"] = True
+                    spec["telemetry"]["transport"] = "WIFI_UDP"
+                else:
+                    spec["telemetry"]["use_wifi"] = False
+                    spec["telemetry"]["transport"] = "SERIAL"
+                if board_info.get("monitor_speed"):
+                    spec["telemetry"]["baudrate"] = board_info["monitor_speed"]
+                # MCU family from platformio.ini platform=/board= (authoritative);
+                # env-name map is only a fallback for odd/legacy envs.
+                pio_mcu = _mcu_from_platformio(board_info.get("platform", ""),
+                                               board_info.get("board", ""), env_name)
+                env_to_mcu = {
+                    "gendrv": "GENDRV", "gendrv_wifi": "GENDRV",
+                    "esp32": "ESP32", "esp32_wifi": "ESP32",
+                    "esp32s2": "ESP32S2", "esp32s2_wifi": "ESP32S2",
+                    "esp32s3": "ESP32S3", "esp32s3_wifi": "ESP32S3",
+                    "pico": "PICO", "picow": "PICOW", "picow_wifi": "PICOW",
+                    "pico2": "PICO2", "pico2w": "PICO2W", "pico2w_wifi": "PICO2W",
+                    "teensy41": "TEENSY", "teensy40": "TEENSY",
+                    "teensy36": "TEENSY", "teensy35": "TEENSY", "teensy31": "TEENSY",
+                    "vattenkar": "TEENSY",
+                }
+                if pio_mcu:
+                    spec["mcu"] = pio_mcu
+                elif env_name in env_to_mcu:
+                    spec["mcu"] = env_to_mcu[env_name]
+                # Attach board metadata
+                spec["_board_env"] = env_name
+                spec["_board_info"] = board_info
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"status": "ok", "spec": spec, "board": board_info}).encode("utf-8"))
+            except Exception as e:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(e)}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/parse":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+            try:
+                data = json.loads(body.decode("utf-8"))
+                content = data.get("content", "")
+                if data.get("is_json", False):
+                    spec = json.loads(content)
+                else:
+                    spec = parse_header_to_spec(content)
+                    if '__has_include("wifi_config.h")' in content or "WIFI_AP_LIST" in content:
+                        merge_wifi_config(spec, _wifi_config_content())
+
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"status": "ok", "spec": spec}).encode("utf-8"))
+            except Exception as e:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": f"Parse error: {e}"}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/merge":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+            try:
+                data = json.loads(body.decode("utf-8"))
+                base_spec = data.get("base_spec", {})
+                override_spec = data.get("override_spec", {})
+                if not base_spec and "base_content" in data:
+                    base_spec = parse_header_to_spec(data["base_content"])
+
+                merged_spec, changes = merge_configurations(base_spec, override_spec)
+                generated_header = generate_config_header(merged_spec)
+
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    "status": "ok",
+                    "merged_spec": merged_spec,
+                    "changes": changes,
+                    "header": generated_header
+                }).encode("utf-8"))
+            except Exception as e:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": f"Merge error: {e}"}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/save":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+            try:
+                data = json.loads(body.decode("utf-8"))
+                filename = data.get("filename", "")
+                header_content = data.get("header", "")
+                if not filename:
+                    robot_name = data.get("spec", {}).get("robot_name", "custom")
+                    filename = f"{robot_name}_config.h"
+
+                save_path = os.path.join(REPO_ROOT, "config", "custom", filename)
+                os.makedirs(os.path.dirname(save_path), exist_ok=True)
+                with open(save_path, "w", encoding="utf-8") as sf:
+                    sf.write(header_content)
+
+                # WiFi credentials (if any) go to the git-ignored wifi_config.h,
+                # never into the tracked robot header. Don't clobber an existing one.
+                wifi_config = data.get("wifi_config", "") or ""
+                wifi_written = False
+                wifi_path = os.path.join(REPO_ROOT, "config", "custom", "wifi_config.h")
+                if wifi_config.strip() and not os.path.exists(wifi_path):
+                    with open(wifi_path, "w", encoding="utf-8") as wf:
+                        wf.write(wifi_config)
+                    wifi_written = True
+
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    "status": "saved",
+                    "path": os.path.relpath(save_path, REPO_ROOT),
+                    "filename": filename,
+                    "wifi_config_written": wifi_written
+                }).encode("utf-8"))
+            except Exception as e:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": f"Save error: {e}"}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/kill":
+            with active_process_lock:
+                if active_process and active_process.poll() is None:
+                    try:
+                        active_process.terminate()
+                        time.sleep(0.2)
+                        if active_process.poll() is None:
+                            active_process.kill()
+                    except Exception:
+                        pass
+                    active_process = None
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({"status": "killed"}).encode("utf-8"))
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            return
+
+        if parsed.path == "/api/exec":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+            try:
+                data = json.loads(body.decode("utf-8"))
+            except Exception as e:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": f"Invalid JSON: {e}"}).encode("utf-8"))
+                return
+
+            command = data.get("command", "").strip()
+            cwd = data.get("cwd", REPO_ROOT)
+            if not os.path.isabs(cwd):
+                cwd = os.path.join(REPO_ROOT, cwd)
+
+            if not command:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "Empty command"}).encode("utf-8"))
+                return
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+
+            env = os.environ.copy()
+            env["PYTHONUNBUFFERED"] = "1"
+            penv_path = os.path.expanduser("~/.platformio/penv/bin")
+            local_bin = os.path.expanduser("~/.local/bin")
+            env["PATH"] = f"{penv_path}:{local_bin}:{env.get('PATH', '')}"
+            ros_distro = (data.get("ros_distro") or "").strip()
+            if not ros_distro:
+                ros_distro = env.get("ROS_DISTRO") or "jazzy"
+            env["ROS_DISTRO"] = ros_distro
+
+            def send_event(event_type, payload):
+                msg = f"event: {event_type}\ndata: {json.dumps(payload)}\n\n"
+                try:
+                    self.wfile.write(msg.encode("utf-8"))
+                    self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+            # Adaptive execution: on a bare host that lacks /opt/ros, route ROS commands into
+            # the distrobox named after the requested distro. Never do this when we are already
+            # inside a container -- nested `distrobox enter` is unsupported and would hang or fail.
+            has_distrobox = shutil.which("distrobox") is not None
+            has_host_ros = os.path.exists("/opt/ros")
+            needs_ros = "ros2" in command or "source /opt/ros" in command
+            if IN_CONTAINER:
+                if needs_ros and not has_host_ros:
+                    send_event("output", {
+                        "line": f"[INFO] Running inside container '{os.environ.get('CONTAINER_ID', 'container')}'; "
+                                f"executing directly (no nested distrobox).\n"
+                    })
+            elif (not has_host_ros) and has_distrobox and needs_ros:
+                escaped_cmd = command.replace("\\", "\\\\").replace('"', '\\"')
+                command = (
+                    f'distrobox enter {ros_distro} -- bash -c '
+                    f'"source /opt/ros/{ros_distro}/setup.bash 2>/dev/null; '
+                    f'[ -f $HOME/uros_ws/install/setup.bash ] && source $HOME/uros_ws/install/setup.bash; '
+                    f'{escaped_cmd}"'
+                )
+
+            send_event("start", {"command": command, "cwd": cwd})
+
+                        # Proactively stop serial-transport micro-ROS agent and free USB port if flashing (WiFi agent kept running)
+            if any(k in command for k in ["-t upload", "picotool", "flash", "deploy"]):
+                try:
+                    subprocess.run(["pkill", "-f", "micro_ros_agent.*serial"], capture_output=True, timeout=2.0)
+                    subprocess.run(["pkill", "-f", "micro_ros_agent.*multiserial"], capture_output=True, timeout=2.0)
+                    subprocess.run(["pkill", "-f", "miniterm"], capture_output=True, timeout=2.0)
+                except Exception:
+                    pass
+
+            try:
+                with active_process_lock:
+                    active_process = subprocess.Popen(
+                        command,
+                        cwd=cwd,
+                        shell=True,
+                        executable="/bin/bash",
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        bufsize=1,
+                        env=env,
+                        preexec_fn=os.setsid if hasattr(os, "setsid") else None
+                    )
+
+                if active_process and active_process.stdout:
+                    for line in iter(active_process.stdout.readline, ""):
+                        if not line:
+                            break
+                        send_event("output", {"line": line, "text": line})
+
+                active_process.wait()
+                exit_code = active_process.returncode
+                send_event("done", {"code": exit_code, "exit_code": exit_code})
+            except Exception as e:
+                send_event("error", {"error": str(e)})
+            finally:
+                with active_process_lock:
+                    active_process = None
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+
+if __name__ == "__main__":
+    print(f"============================================================")
+    print(f" Linorobot2 Robot Configuration Engine & Web Studio")
+    print(f" Live HTTP Server listening on port {PORT}")
+    print(f" Web UI: http://localhost:{PORT}")
+    print(f" Repository Root: {REPO_ROOT}")
+    print(f" Press Ctrl+C to terminate.")
+    print(f"============================================================")
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), LinorobotEngineHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down server...")
+        server.server_close()

--- a/tools/robot_config_engine/web/server.py
+++ b/tools/robot_config_engine/web/server.py
@@ -80,7 +80,7 @@ def _git(*args, cwd=REPO_ROOT):
 
 
 def collect_git_info():
-    """Snapshot of the checked-out repo: 8-char commit, branch, remotes, last 10 commits."""
+    """Snapshot of the checked-out repo: 7-char commit, branch, remotes, last 10 commits."""
     remotes = []
     for line in _git("remote", "-v").splitlines():
         parts = line.split()
@@ -96,7 +96,7 @@ def collect_git_info():
                 "date": f[3], "reldate": f[4],
             })
     return {
-        "version": (_git("rev-parse", "--short=8", "HEAD") or "unknown")[:8],
+        "version": (_git("rev-parse", "--short=7", "HEAD") or "unknown")[:7],
         "full": _git("rev-parse", "HEAD"),
         "branch": _git("rev-parse", "--abbrev-ref", "HEAD") or "(detached)",
         "dirty": bool(_git("status", "--porcelain")),
@@ -106,7 +106,7 @@ def collect_git_info():
 
 
 # The commit the web server was started on ("the version we start the web").
-GIT_VERSION_AT_START = (_git("rev-parse", "--short=8", "HEAD") or "unknown")[:8]
+GIT_VERSION_AT_START = (_git("rev-parse", "--short=7", "HEAD") or "unknown")[:7]
 
 
 class SyslogManager:
@@ -937,7 +937,7 @@ class LinorobotEngineHandler(SimpleHTTPRequestHandler):
             return
 
         if parsed.path == "/api/gitinfo":
-            # Git provenance for the header version badge: the 8-char commit the
+            # Git provenance for the header version badge: the 7-char commit the
             # server booted on, plus the live branch / remotes / last 10 commits
             # shown when the badge is clicked.
             info = collect_git_info()

--- a/tools/robot_config_engine/web/server.py
+++ b/tools/robot_config_engine/web/server.py
@@ -109,12 +109,19 @@ def collect_git_info():
 GIT_VERSION_AT_START = (_git("rev-parse", "--short=7", "HEAD") or "unknown")[:7]
 
 
+# Rolling cap for the on-disk syslog capture: a chatty robot streaming for days
+# would otherwise fill the disk. At the limit the file is rotated to a single
+# .1 backup (so at most ~2x this per day).
+SYSLOG_MAX_BYTES = 10 * 1024 * 1024
+
+
 class SyslogManager:
     """
     Lightweight, multi-threaded UDP Syslog server & real-time telemetry broadcaster.
     Listens on UDP (default port 514 with auto-fallback to 5140 for non-root),
-    appends timestamped telemetry logs to repo logs/syslog_YYYYMMDD.log,
-    and broadcasts events in real-time to Web UI SSE subscribers.
+    appends timestamped telemetry logs to repo logs/syslog_YYYYMMDD.log (rotated
+    at SYSLOG_MAX_BYTES with one .1 backup), and broadcasts events in real-time
+    to Web UI SSE subscribers.
     """
     def __init__(self, repo_root):
         self.repo_root = repo_root
@@ -133,16 +140,63 @@ class SyslogManager:
         self.subscribers = set()
         self.subscribers_lock = threading.Lock()
         self.lock = threading.Lock()
+        # Persistent append handle for the current log file (avoids an open()
+        # per packet and lets us track size for rotation).
+        self._log_fh = None
+        self._log_path = None
+        self._log_bytes = 0
 
     def get_current_log_filepath(self):
         date_str = datetime.datetime.now().strftime("%Y%m%d")
         return os.path.join(self.logs_dir, f"syslog_{date_str}.log")
+
+    def _close_log(self):
+        if self._log_fh:
+            try:
+                self._log_fh.close()
+            except Exception:
+                pass
+        self._log_fh = None
+        self._log_path = None
+        self._log_bytes = 0
+
+    def _write_log_line(self, line):
+        """Append one line, opening/rotating the day's log file as needed."""
+        path = self.get_current_log_filepath()
+        try:
+            if self._log_fh is None or self._log_path != path:
+                # First write, or the date rolled over past midnight.
+                self._close_log()
+                self._log_path = path
+                self._log_fh = open(path, "a", encoding="utf-8")
+                try:
+                    self._log_bytes = os.path.getsize(path)
+                except OSError:
+                    self._log_bytes = 0
+
+            encoded_len = len(line.encode("utf-8"))
+            if self._log_bytes + encoded_len > SYSLOG_MAX_BYTES:
+                # Rotate: current -> <name>.1 (replacing any previous backup).
+                self._log_fh.close()
+                try:
+                    os.replace(path, path + ".1")
+                except OSError:
+                    pass
+                self._log_fh = open(path, "a", encoding="utf-8")
+                self._log_bytes = 0
+
+            self._log_fh.write(line)
+            self._log_fh.flush()
+            self._log_bytes += encoded_len
+        except Exception:
+            self._close_log()
 
     def start(self, requested_port=514):
         with self.lock:
             if self.is_running:
                 return {
                     "status": "already_running",
+                    "running": True,
                     "host_ip": self._host_ip(),
                     "port": self.bound_port,
                     "logfile": os.path.relpath(self.get_current_log_filepath(), self.repo_root),
@@ -184,6 +238,7 @@ class SyslogManager:
 
             return {
                 "status": "running",
+                "running": True,
                 "host_ip": self._host_ip(),
                 "port": self.bound_port,
                 "requested_port": self.port,
@@ -195,7 +250,7 @@ class SyslogManager:
     def stop(self):
         with self.lock:
             if not self.is_running:
-                return {"status": "stopped", "port": self.bound_port, "packets": self.packets_received}
+                return {"status": "stopped", "running": False, "port": self.bound_port, "packets": self.packets_received}
             self.is_running = False
             if self.sock:
                 try:
@@ -206,8 +261,9 @@ class SyslogManager:
                 except Exception:
                     pass
                 self.sock = None
+            self._close_log()
 
-            return {"status": "stopped", "port": self.bound_port, "packets": self.packets_received}
+            return {"status": "stopped", "running": False, "port": self.bound_port, "packets": self.packets_received}
 
     def _listen_loop(self):
         while self.is_running:
@@ -247,13 +303,8 @@ class SyslogManager:
 
                 formatted_line = f"[{time_str}] [{client_str}] {clean_text}\n"
 
-                # Append to log file
-                log_file = self.get_current_log_filepath()
-                try:
-                    with open(log_file, "a", encoding="utf-8") as f:
-                        f.write(formatted_line)
-                except Exception:
-                    pass
+                # Append to log file (rotates at SYSLOG_MAX_BYTES)
+                self._write_log_line(formatted_line)
 
                 self.packets_received += 1
                 self.last_sender = client_str
@@ -1310,6 +1361,21 @@ class LinorobotEngineHandler(SimpleHTTPRequestHandler):
                 self.wfile.write(json.dumps({"error": "Empty command"}).encode("utf-8"))
                 return
 
+            # Single-flight: one build/deploy at a time. Without this a tab that
+            # crashed mid-deploy and was reopened could start a second parallel
+            # `pio` compile -- ~4 heavy cc1plus jobs on a 4 GB SBC, i.e. OOM.
+            with active_process_lock:
+                busy = active_process is not None and active_process.poll() is None
+            if busy:
+                self.send_response(409)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    "error": "A command is already running. Stop it (Cancel) before starting another."
+                }).encode("utf-8"))
+                return
+
             self.send_response(200)
             self.send_header("Content-Type", "text/event-stream; charset=utf-8")
             self.send_header("Cache-Control", "no-cache")
@@ -1327,13 +1393,16 @@ class LinorobotEngineHandler(SimpleHTTPRequestHandler):
                 ros_distro = env.get("ROS_DISTRO") or "jazzy"
             env["ROS_DISTRO"] = ros_distro
 
+            client_gone = False
+
             def send_event(event_type, payload):
+                nonlocal client_gone
                 msg = f"event: {event_type}\ndata: {json.dumps(payload)}\n\n"
                 try:
                     self.wfile.write(msg.encode("utf-8"))
                     self.wfile.flush()
                 except (BrokenPipeError, ConnectionResetError):
-                    pass
+                    client_gone = True
 
             # Adaptive execution: on a bare host that lacks /opt/ros, route ROS commands into
             # the distrobox named after the requested distro. Never do this when we are already
@@ -1387,6 +1456,20 @@ class LinorobotEngineHandler(SimpleHTTPRequestHandler):
                         if not line:
                             break
                         send_event("output", {"line": line, "text": line})
+                        if client_gone:
+                            # Browser closed/crashed: kill the whole process
+                            # group so a long build doesn't run unwatched.
+                            try:
+                                os.killpg(os.getpgid(active_process.pid), signal.SIGTERM)
+                                active_process.wait(timeout=5)
+                            except subprocess.TimeoutExpired:
+                                try:
+                                    os.killpg(os.getpgid(active_process.pid), signal.SIGKILL)
+                                except Exception:
+                                    pass
+                            except Exception:
+                                pass
+                            break
 
                 active_process.wait()
                 exit_code = active_process.returncode

--- a/tools/robot_config_engine/web/server.py
+++ b/tools/robot_config_engine/web/server.py
@@ -65,6 +65,50 @@ def _wifi_config_content():
     except OSError:
         return ""
 
+
+def _git(*args, cwd=REPO_ROOT):
+    """Run `git <args>` in the repo; return stripped stdout, or '' on any failure."""
+    try:
+        out = subprocess.run(
+            ["git", *args], cwd=cwd, capture_output=True, text=True, timeout=5.0
+        )
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except Exception:
+        pass
+    return ""
+
+
+def collect_git_info():
+    """Snapshot of the checked-out repo: 8-char commit, branch, remotes, last 10 commits."""
+    remotes = []
+    for line in _git("remote", "-v").splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[2] == "(fetch)":
+            remotes.append({"name": parts[0], "url": parts[1]})
+    commits = []
+    log = _git("log", "-10", "--pretty=format:%h\x1f%s\x1f%an\x1f%ad\x1f%ar", "--date=short")
+    for line in log.splitlines():
+        f = line.split("\x1f")
+        if len(f) == 5:
+            commits.append({
+                "hash": f[0], "subject": f[1], "author": f[2],
+                "date": f[3], "reldate": f[4],
+            })
+    return {
+        "version": (_git("rev-parse", "--short=8", "HEAD") or "unknown")[:8],
+        "full": _git("rev-parse", "HEAD"),
+        "branch": _git("rev-parse", "--abbrev-ref", "HEAD") or "(detached)",
+        "dirty": bool(_git("status", "--porcelain")),
+        "remotes": remotes,
+        "commits": commits,
+    }
+
+
+# The commit the web server was started on ("the version we start the web").
+GIT_VERSION_AT_START = (_git("rev-parse", "--short=8", "HEAD") or "unknown")[:8]
+
+
 class SyslogManager:
     """
     Lightweight, multi-threaded UDP Syslog server & real-time telemetry broadcaster.
@@ -890,6 +934,26 @@ class LinorobotEngineHandler(SimpleHTTPRequestHandler):
                         proc.kill()
                     except Exception:
                         pass
+            return
+
+        if parsed.path == "/api/gitinfo":
+            # Git provenance for the header version badge: the 8-char commit the
+            # server booted on, plus the live branch / remotes / last 10 commits
+            # shown when the badge is clicked.
+            info = collect_git_info()
+            info["version_at_start"] = GIT_VERSION_AT_START
+            info["moved_since_start"] = (
+                info.get("version") != GIT_VERSION_AT_START
+                and GIT_VERSION_AT_START != "unknown"
+            )
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps(info).encode("utf-8"))
+            except (BrokenPipeError, ConnectionResetError):
+                pass
             return
 
         if parsed.path == "/api/boards":

--- a/tools/robot_config_engine/web/server.py
+++ b/tools/robot_config_engine/web/server.py
@@ -894,9 +894,17 @@ class LinorobotEngineHandler(SimpleHTTPRequestHandler):
             return
 
         if parsed.path == "/api/ros2/hz_single":
-            # Quick single-shot frequency measurement
+            # Single-shot frequency measurement. `secs` (default 6, 3..20) is the
+            # sampling window — a 1 Hz topic needs several seconds to average
+            # meaningfully, so the caller can ask for a longer window on slow
+            # topics. The LAST `average rate:` line (most settled) is reported.
             qs = parse_qs(parsed.query)
             topic = qs.get("topic", ["/odom/unfiltered"])[0].strip()
+            try:
+                secs = int(round(float(qs.get("secs", ["6"])[0])))
+            except Exception:
+                secs = 6
+            secs = max(3, min(secs, 20))
             rate_val = "0.0"
             try:
                 setup_bash = ""
@@ -905,13 +913,13 @@ class LinorobotEngineHandler(SimpleHTTPRequestHandler):
                     if os.path.exists(p):
                         setup_bash = p
                         break
-                cmd = f"source {setup_bash} 2>/dev/null && timeout 2.5 stdbuf -oL -eL ros2 topic hz {topic}"
-                res = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True)
-                for line in res.stdout.split("\n"):
-                    if "average rate:" in line:
-                        m = re.search(r"average rate:\s*([0-9.]+)", line)
-                        if m:
-                            rate_val = f"{float(m.group(1)):.1f} Hz"
+                cmd = (f"source {setup_bash} 2>/dev/null && "
+                       f"timeout {secs} stdbuf -oL -eL ros2 topic hz --window 10000 {topic}")
+                res = subprocess.run(["bash", "-c", cmd], capture_output=True,
+                                     text=True, timeout=secs + 5)
+                rates = re.findall(r"average rate:\s*([0-9.]+)", res.stdout)
+                if rates:
+                    rate_val = f"{float(rates[-1]):.2f} Hz"
             except Exception:
                 pass
 

--- a/tools/robot_config_engine/web/server.py
+++ b/tools/robot_config_engine/web/server.py
@@ -1,0 +1,2664 @@
+#!/usr/bin/env python3
+"""
+Linorobot2 Robot Configuration Engine - Local HTTP Server with Live Command Execution & Config Merge API
+Zero-Dependency, Pure Standard Library Python 3 (Multi-Threaded)
+
+Usage:
+    python3 server.py [PORT]
+    (Defaults to port 8000)
+"""
+
+import os
+import sys
+import json
+import time
+import signal
+import socket
+import datetime
+import collections
+import queue
+import platform
+import threading
+import subprocess
+import glob
+import shutil
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+from urllib.parse import urlparse, parse_qs
+import re
+
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 and sys.argv[1].isdigit() else 8000
+
+
+def running_in_container():
+    """True when this server itself runs inside a container (distrobox, podman, docker).
+
+    Nested `distrobox enter` is not supported, so when we are already inside a
+    container we must run commands directly in our own environment.
+    """
+    if os.environ.get("CONTAINER_ID") or os.environ.get("DISTROBOX_ENTER_PATH"):
+        return True
+    return os.path.exists("/run/.containerenv") or os.path.exists("/.dockerenv")
+
+
+IN_CONTAINER = running_in_container()
+
+WEB_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(WEB_DIR, "..", "..", ".."))
+
+# Add REPO_ROOT to sys.path so we can import generator and parser
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+from tools.robot_config_engine.generator import generate_config_header
+from tools.robot_config_engine.validator import validate_robot_spec
+from tools.robot_config_engine.parser import parse_header_to_spec, merge_configurations, merge_wifi_config
+
+active_process = None
+active_process_lock = threading.Lock()
+
+
+def _wifi_config_content():
+    """Contents of the git-ignored config/custom/wifi_config.h, or '' if absent."""
+    p = os.path.join(REPO_ROOT, "config", "custom", "wifi_config.h")
+    try:
+        with open(p, "r", encoding="utf-8") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
+def _git(*args, cwd=REPO_ROOT):
+    """Run `git <args>` in the repo; return stripped stdout, or '' on any failure."""
+    try:
+        out = subprocess.run(
+            ["git", *args], cwd=cwd, capture_output=True, text=True, timeout=5.0
+        )
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except Exception:
+        pass
+    return ""
+
+
+def collect_git_info():
+    """Snapshot of the checked-out repo: 7-char commit, branch, remotes, last 10 commits."""
+    remotes = []
+    for line in _git("remote", "-v").splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[2] == "(fetch)":
+            remotes.append({"name": parts[0], "url": parts[1]})
+    commits = []
+    log = _git("log", "-10", "--pretty=format:%h\x1f%s\x1f%an\x1f%ad\x1f%ar", "--date=short")
+    for line in log.splitlines():
+        f = line.split("\x1f")
+        if len(f) == 5:
+            commits.append({
+                "hash": f[0], "subject": f[1], "author": f[2],
+                "date": f[3], "reldate": f[4],
+            })
+    cur_branch = _git("rev-parse", "--abbrev-ref", "HEAD") or "(detached)"
+    # Local branches, most-recently-committed first, current branch pinned to the top.
+    branches = [
+        b for b in _git(
+            "for-each-ref", "--sort=-committerdate",
+            "--format=%(refname:short)", "refs/heads"
+        ).splitlines() if b
+    ]
+    if cur_branch in branches:
+        branches = [cur_branch] + [b for b in branches if b != cur_branch]
+    return {
+        "version": (_git("rev-parse", "--short=7", "HEAD") or "unknown")[:7],
+        "full": _git("rev-parse", "HEAD"),
+        "branch": cur_branch,
+        "branches": branches,
+        "dirty": bool(_git("status", "--porcelain")),
+        "remotes": remotes,
+        "commits": commits,
+    }
+
+
+# The commit the web server was started on ("the version we start the web").
+GIT_VERSION_AT_START = (_git("rev-parse", "--short=7", "HEAD") or "unknown")[:7]
+
+
+# Rolling cap for the on-disk syslog capture: a chatty robot streaming for days
+# would otherwise fill the disk. At the limit the file is rotated to a single
+# .1 backup (so at most ~2x this per day).
+SYSLOG_MAX_BYTES = 10 * 1024 * 1024
+
+
+class SyslogManager:
+    """
+    Lightweight, multi-threaded UDP Syslog server & real-time telemetry broadcaster.
+    Listens on UDP (default port 514 with auto-fallback to 5140 for non-root),
+    appends timestamped telemetry logs to repo logs/syslog_YYYYMMDD.log (rotated
+    at SYSLOG_MAX_BYTES with one .1 backup), and broadcasts events in real-time
+    to Web UI SSE subscribers.
+    """
+    def __init__(self, repo_root):
+        self.repo_root = repo_root
+        self.logs_dir = os.path.join(repo_root, "logs")
+        os.makedirs(self.logs_dir, exist_ok=True)
+        self.sock = None
+        self.thread = None
+        self.is_running = False
+        self.port = 514
+        self.bound_port = 514
+        self.packets_received = 0
+        self.last_sender = ""
+        self.last_message = ""
+        self.last_timestamp = ""
+        self.recent_logs = collections.deque(maxlen=200)
+        self.subscribers = set()
+        self.subscribers_lock = threading.Lock()
+        self.lock = threading.Lock()
+        # Persistent append handle for the current log file (avoids an open()
+        # per packet and lets us track size for rotation).
+        self._log_fh = None
+        self._log_path = None
+        self._log_bytes = 0
+
+    def get_current_log_filepath(self):
+        date_str = datetime.datetime.now().strftime("%Y%m%d")
+        return os.path.join(self.logs_dir, f"syslog_{date_str}.log")
+
+    def _close_log(self):
+        if self._log_fh:
+            try:
+                self._log_fh.close()
+            except Exception:
+                pass
+        self._log_fh = None
+        self._log_path = None
+        self._log_bytes = 0
+
+    def _write_log_line(self, line):
+        """Append one line, opening/rotating the day's log file as needed."""
+        path = self.get_current_log_filepath()
+        try:
+            if self._log_fh is None or self._log_path != path:
+                # First write, or the date rolled over past midnight.
+                self._close_log()
+                self._log_path = path
+                self._log_fh = open(path, "a", encoding="utf-8")
+                try:
+                    self._log_bytes = os.path.getsize(path)
+                except OSError:
+                    self._log_bytes = 0
+
+            encoded_len = len(line.encode("utf-8"))
+            if self._log_bytes + encoded_len > SYSLOG_MAX_BYTES:
+                # Rotate: current -> <name>.1 (replacing any previous backup).
+                self._log_fh.close()
+                try:
+                    os.replace(path, path + ".1")
+                except OSError:
+                    pass
+                self._log_fh = open(path, "a", encoding="utf-8")
+                self._log_bytes = 0
+
+            self._log_fh.write(line)
+            self._log_fh.flush()
+            self._log_bytes += encoded_len
+        except Exception:
+            self._close_log()
+
+    def start(self, requested_port=514):
+        with self.lock:
+            if self.is_running:
+                return {
+                    "status": "already_running",
+                    "running": True,
+                    "host_ip": self._host_ip(),
+                    "port": self.bound_port,
+                    "logfile": os.path.relpath(self.get_current_log_filepath(), self.repo_root),
+                    "packets": self.packets_received
+                }
+
+            try:
+                self.port = int(requested_port)
+            except Exception:
+                self.port = 514
+
+            ports_to_try = [self.port]
+            if self.port != 5140 and 5140 not in ports_to_try:
+                ports_to_try.append(5140)
+            if 5514 not in ports_to_try:
+                ports_to_try.append(5514)
+
+            bound = False
+            last_err = None
+            for p in ports_to_try:
+                try:
+                    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                    s.bind(("0.0.0.0", p))
+                    self.sock = s
+                    self.bound_port = p
+                    bound = True
+                    break
+                except Exception as e:
+                    last_err = e
+                    continue
+
+            if not bound:
+                raise RuntimeError(f"Could not bind UDP syslog port (tried {ports_to_try}): {last_err}")
+
+            self.is_running = True
+            self.thread = threading.Thread(target=self._listen_loop, daemon=True)
+            self.thread.start()
+
+            return {
+                "status": "running",
+                "running": True,
+                "host_ip": self._host_ip(),
+                "port": self.bound_port,
+                "requested_port": self.port,
+                "logfile": os.path.relpath(self.get_current_log_filepath(), self.repo_root),
+                "packets": self.packets_received,
+                "fallback": self.bound_port != self.port
+            }
+
+    def stop(self):
+        with self.lock:
+            if not self.is_running:
+                return {"status": "stopped", "running": False, "port": self.bound_port, "packets": self.packets_received}
+            self.is_running = False
+            if self.sock:
+                try:
+                    dummy = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                    dummy.sendto(b"__SHUTDOWN__", ("127.0.0.1", self.bound_port))
+                    dummy.close()
+                    self.sock.close()
+                except Exception:
+                    pass
+                self.sock = None
+            self._close_log()
+
+            return {"status": "stopped", "running": False, "port": self.bound_port, "packets": self.packets_received}
+
+    def _listen_loop(self):
+        while self.is_running:
+            try:
+                if not self.sock:
+                    break
+                data, addr = self.sock.recvfrom(4096)
+                if not self.is_running:
+                    break
+                if data == b"__SHUTDOWN__":
+                    continue
+
+                raw_text = data.decode("utf-8", errors="replace").strip()
+                now = datetime.datetime.now()
+                time_str = now.strftime("%Y-%m-%d %H:%M:%S")
+                client_str = f"{addr[0]}:{addr[1]}"
+
+                pri = None
+                clean_text = raw_text
+                if raw_text.startswith("<") and ">" in raw_text[:6]:
+                    pri_end = raw_text.index(">")
+                    try:
+                        pri = int(raw_text[1:pri_end])
+                        clean_text = raw_text[pri_end+1:].strip()
+                    except ValueError:
+                        pass
+
+                log_entry = {
+                    "time": time_str,
+                    "sender": client_str,
+                    "ip": addr[0],
+                    "port": addr[1],
+                    "pri": pri,
+                    "message": clean_text,
+                    "raw": raw_text
+                }
+
+                formatted_line = f"[{time_str}] [{client_str}] {clean_text}\n"
+
+                # Append to log file (rotates at SYSLOG_MAX_BYTES)
+                self._write_log_line(formatted_line)
+
+                self.packets_received += 1
+                self.last_sender = client_str
+                self.last_message = clean_text
+                self.last_timestamp = time_str
+                self.recent_logs.append(log_entry)
+
+                self._broadcast(log_entry)
+            except Exception:
+                if not self.is_running:
+                    break
+                time.sleep(0.05)
+
+    def subscribe(self, q):
+        with self.subscribers_lock:
+            self.subscribers.add(q)
+
+    def unsubscribe(self, q):
+        with self.subscribers_lock:
+            self.subscribers.discard(q)
+
+    def _broadcast(self, log_entry):
+        with self.subscribers_lock:
+            for q in list(self.subscribers):
+                try:
+                    q.put_nowait(log_entry)
+                except Exception:
+                    pass
+
+    @staticmethod
+    def _host_ip():
+        """Best-effort primary LAN IP of this host (no traffic actually sent)."""
+        import socket as _s
+        for probe in ("10.255.255.255", "192.168.255.255", "8.8.8.8"):
+            try:
+                k = _s.socket(_s.AF_INET, _s.SOCK_DGRAM)
+                k.connect((probe, 1)); ip = k.getsockname()[0]; k.close()
+                if ip and not ip.startswith("127."):
+                    return ip
+            except Exception:
+                pass
+        try:
+            return _s.gethostbyname(_s.gethostname())
+        except Exception:
+            return "127.0.0.1"
+
+    def get_status(self):
+        cur_file = self.get_current_log_filepath()
+        file_size = os.path.getsize(cur_file) if os.path.exists(cur_file) else 0
+        return {
+            "running": self.is_running,
+            "host_ip": self._host_ip(),
+            "port": self.bound_port,
+            "requested_port": self.port,
+            "logfile": os.path.relpath(cur_file, self.repo_root),
+            "filesize": file_size,
+            "packets": self.packets_received,
+            "last_sender": self.last_sender,
+            "last_message": self.last_message,
+            "last_timestamp": self.last_timestamp,
+            "recent_count": len(self.recent_logs)
+        }
+
+syslog_manager = SyslogManager(REPO_ROOT)
+
+
+def _mcu_from_platformio(platform: str, board: str, env: str = "") -> str:
+    """MCU family from platformio.ini `platform =` / `board =` (authoritative)."""
+    b = (board or "").lower().strip()
+    p = (platform or "").lower()
+    e = (env or "").lower()
+    if b.startswith("teensy") or "teensy" in p:
+        return "TEENSY"
+    if b in ("rpipico2w",) or "pico2w" in b:
+        return "PICO2W"
+    if b in ("rpipico2",) or "pico2" in b or "rp2350" in b:
+        return "PICO2"
+    if b in ("rpipicow",) or "picow" in b:
+        return "PICOW"
+    if b in ("rpipico",) or "pico" in b or "rp2040" in b:
+        return "PICO"
+    if "esp32-s3" in b or "esp32s3" in b:
+        return "ESP32S3"
+    if "esp32-s2" in b or "esp32s2" in b:
+        return "ESP32S2"
+    if "espressif32" in p or b in ("nodemcu-32s",) or "esp32" in b:
+        return "GENDRV" if e.startswith("gendrv") else "ESP32"
+    return ""
+
+
+def _parse_platformio_boards(ini_path: str) -> list:
+    """
+    Parse firmware/platformio.ini and return a list of board environment dicts:
+      env, config_file, config_macro, transport, wifi, board, monitor_speed, display_name
+    Only environments with a USE_*_CONFIG define in build_flags are included.
+    """
+    # Macro → relative path from REPO_ROOT
+    MACRO_TO_CONFIG = {
+        "USE_GENDRV_CONFIG":  "config/custom/gendrv_config.h",
+        "USE_ESP32_CONFIG":   "config/custom/esp32_config.h",
+        "USE_ESP32S2_CONFIG": "config/custom/esp32s2_config.h",
+        "USE_ESP32S3_CONFIG": "config/custom/esp32s3_config.h",
+        "USE_PICO_CONFIG":    "config/custom/pico_config.h",
+        "USE_VATTENKAR_CONFIG": "config/custom/vattenkar_config.h",
+        "USE_TEENSY_CONFIG":  "config/lino_base_config.h",
+    }
+    # Friendly display names
+    ENV_DISPLAY = {
+        "teensy41": "Teensy 4.1",
+        "teensy40": "Teensy 4.0",
+        "teensy36": "Teensy 3.6",
+        "teensy35": "Teensy 3.5",
+        "teensy31": "Teensy 3.1 / 3.2",
+        "vattenkar": "Vattenkar (Teensy 4.0)",
+        "gendrv": "Waveshare General Driver (ESP32, Serial)",
+        "gendrv_wifi": "Waveshare General Driver (ESP32, WiFi)",
+        "esp32": "ESP32 DevKit (Serial)",
+        "esp32_wifi": "ESP32 DevKit (WiFi)",
+        "esp32s2": "ESP32-S2 (Serial)",
+        "esp32s2_wifi": "ESP32-S2 (WiFi)",
+        "esp32s3": "ESP32-S3 (Serial)",
+        "esp32s3_wifi": "ESP32-S3 (WiFi)",
+        "pico": "Raspberry Pi Pico (RP2040, Serial)",
+        "picow": "Raspberry Pi Pico W (RP2040, Serial)",
+        "picow_wifi": "Raspberry Pi Pico W (RP2040, WiFi)",
+        "pico2": "Raspberry Pi Pico 2 (RP2350, Serial)",
+        "pico2w": "Raspberry Pi Pico 2W (RP2350, Serial)",
+        "pico2w_wifi": "Raspberry Pi Pico 2W (RP2350, WiFi)",
+    }
+
+    if not os.path.isfile(ini_path):
+        return []
+
+    with open(ini_path, "r", encoding="utf-8") as f:
+        raw = f.read()
+
+    # Split into sections
+    section_re = re.compile(r'^\[env:([^\]]+)\]', re.MULTILINE)
+    positions = [(m.start(), m.group(1)) for m in section_re.finditer(raw)]
+
+    boards = []
+    for idx, (pos, env_name) in enumerate(positions):
+        end = positions[idx + 1][0] if idx + 1 < len(positions) else len(raw)
+        section_text = raw[pos:end]
+
+        # Extract build_flags block (multi-line, continuation lines indented)
+        bf_match = re.search(r'build_flags\s*=\s*((?:.*\n(?:[ \t]+.*\n)*)*)', section_text)
+        build_flags = bf_match.group(1) if bf_match else ""
+
+        # Find USE_*_CONFIG macro
+        macro_match = re.search(r'-D\s+(USE_\w+_CONFIG)', build_flags)
+        if not macro_match:
+            # Teensy boards use generic config (no USE_*_CONFIG)
+            # They inherit from [env] which has no USE_*_CONFIG, but we can
+            # identify them by board type
+            board_val = re.search(r'^board\s*=\s*(\S+)', section_text, re.MULTILINE)
+            bv = board_val.group(1) if board_val else ""
+            if "teensy" in bv or "vattenkar" in env_name.lower():
+                config_macro = "USE_TEENSY_CONFIG"
+                config_file = MACRO_TO_CONFIG.get("USE_TEENSY_CONFIG", "config/lino_base_config.h")
+            else:
+                continue
+        else:
+            config_macro = macro_match.group(1)
+            config_file = MACRO_TO_CONFIG.get(config_macro, "")
+            if not config_file:
+                # Generic: USE_<NAME>_CONFIG -> config/custom/<name>_config.h
+                stem = config_macro[len("USE_"):-len("_CONFIG")].lower() if config_macro.startswith("USE_") and config_macro.endswith("_CONFIG") else ""
+                for cand in (stem, env_name.lower()):
+                    if cand and os.path.isfile(os.path.join(REPO_ROOT, "config", "custom", f"{cand}_config.h")):
+                        config_file = f"config/custom/{cand}_config.h"
+                        break
+
+        # Transport detection
+        wifi = (
+            re.search(r'^board_microros_transport\s*=\s*wifi', section_text, re.MULTILINE) is not None
+            or "-D USE_WIFI" in build_flags
+        )
+        transport = "WIFI_UDP" if wifi else "SERIAL"
+
+        # Board hardware ID + platform
+        board_hw = ""
+        bm = re.search(r'^board\s*=\s*(\S+)', section_text, re.MULTILINE)
+        if bm:
+            board_hw = bm.group(1)
+        platform_hw = ""
+        pm = re.search(r'^platform\s*=\s*(\S+)', section_text, re.MULTILINE)
+        if pm:
+            platform_hw = pm.group(1)
+        # env `[env]` section has no `board` (teensy default lives there) —
+        # fall back to the file-level platform for teensy child envs.
+        if not platform_hw and "teensy" in board_hw:
+            platform_hw = "teensy"
+
+        # Monitor speed
+        monitor_speed = None
+        ms_m = re.search(r'^monitor_speed\s*=\s*(\d+)', section_text, re.MULTILINE)
+        if ms_m:
+            monitor_speed = int(ms_m.group(1))
+
+        # Only include if config file exists on disk
+        config_exists = bool(config_file) and os.path.isfile(os.path.join(REPO_ROOT, config_file))
+
+        boards.append({
+            "env":           env_name,
+            "display_name":  ENV_DISPLAY.get(env_name, env_name),
+            "mcu":           _mcu_from_platformio(platform_hw, board_hw, env_name),
+            "platform":      platform_hw,
+            "config_macro":  config_macro,
+            "config_file":   config_file,
+            "config_exists": config_exists,
+            "transport":     transport,
+            "wifi":          wifi,
+            "board":         board_hw,
+            "monitor_speed": monitor_speed,
+        })
+
+    return boards
+
+
+
+def get_port_usb_details(port_path):
+    port_name = os.path.basename(port_path)
+    info = {
+        "port": port_path,
+        "vid": "",
+        "pid": "",
+        "product": "",
+        "manufacturer": "",
+        "chip": "Generic USB Serial",
+        "accessible": os.access(port_path, os.R_OK | os.W_OK),
+        "read": os.access(port_path, os.R_OK),
+        "write": os.access(port_path, os.W_OK)
+    }
+
+    # Inspect Linux sysfs for USB Vendor & Product ID
+    sys_device_path = f"/sys/class/tty/{port_name}/device"
+    if os.path.exists(sys_device_path):
+        curr = os.path.realpath(sys_device_path)
+        for _ in range(6):
+            vid_path = os.path.join(curr, "idVendor")
+            pid_path = os.path.join(curr, "idProduct")
+            if os.path.exists(vid_path) and os.path.exists(pid_path):
+                try:
+                    with open(vid_path, "r") as f:
+                        info["vid"] = f.read().strip().lower()
+                    with open(pid_path, "r") as f:
+                        info["pid"] = f.read().strip().lower()
+                    prod_path = os.path.join(curr, "product")
+                    mfg_path = os.path.join(curr, "manufacturer")
+                    if os.path.exists(prod_path):
+                        with open(prod_path, "r") as f:
+                            info["product"] = f.read().strip()
+                    if os.path.exists(mfg_path):
+                        with open(mfg_path, "r") as f:
+                            info["manufacturer"] = f.read().strip()
+                except Exception:
+                    pass
+                break
+            curr = os.path.dirname(curr)
+
+    # Hardware MCU / Serial Bridge Identification Matrix
+    vid = info["vid"]
+    pid = info["pid"]
+    if vid == "2e8a":
+        if pid in ["0003", "000a"]:
+            info["chip"] = "Raspberry Pi Pico (RP2040)"
+        elif pid in ["000f", "0005"]:
+            info["chip"] = "Raspberry Pi Pico 2 (RP2350)"
+        else:
+            info["chip"] = "Raspberry Pi (RP2040/RP2350)"
+    elif vid == "303a":
+        if pid in ["1001", "1002"]:
+            info["chip"] = "ESP32-S3 (Native USB CDC)"
+        elif pid == "0002":
+            info["chip"] = "ESP32-S2 (Native USB CDC)"
+        elif pid == "1000":
+            info["chip"] = "ESP32-C3 (Native USB CDC)"
+        else:
+            info["chip"] = "Espressif USB Serial"
+    elif vid == "10c4" and pid == "ea60":
+        # CP2102 and CP2102N share this VID:PID by default — only the USB
+        # product string tells them apart. CP2102N (rated/verified up to
+        # 1.5M+ baud) only gets the fast label when explicitly confirmed;
+        # a plain CP2102 (max ~1 Mbps per datasheet) stays conservative.
+        if "cp2102n" in info["product"].lower():
+            info["chip"] = "CP2102N USB Bridge (ESP32/GenDrv)"
+        else:
+            info["chip"] = "CP2102 USB Bridge (ESP32)"
+    elif vid == "1a86" and pid in ["7523", "5523", "7522"]:
+        info["chip"] = "CH340/CH341 USB Bridge (Arduino/ESP32)"
+    elif vid == "0403" and pid in ["6001", "6010", "6015"]:
+        info["chip"] = "FTDI USB Serial Bridge"
+    elif vid == "16c0" and pid in ["0483", "0487", "0488"]:
+        info["chip"] = "Teensy USB Serial"
+
+    return info
+
+
+def check_container_status():
+    has_docker = shutil.which("docker") is not None
+    has_podman = shutil.which("podman") is not None
+    has_builder = False
+    has_flasher = False
+    is_rootless_docker = False
+
+    if has_docker:
+        try:
+            info_res = subprocess.run(
+                ["docker", "info", "-f", "{{.SecurityOptions}}"],
+                capture_output=True, text=True, timeout=3
+            )
+            if "rootless" in (info_res.stdout or "").lower():
+                is_rootless_docker = True
+            elif "docker.sock" in os.environ.get("DOCKER_HOST", "") and "run/user" in os.environ.get("DOCKER_HOST", ""):
+                is_rootless_docker = True
+            else:
+                res_u = subprocess.run(
+                    ["systemctl", "--user", "is-active", "docker"],
+                    capture_output=True, text=True, timeout=2
+                )
+                if res_u.stdout.strip() == "active":
+                    is_rootless_docker = True
+        except Exception:
+            pass
+
+        try:
+            res_b = subprocess.run(["docker", "images", "-q", "linorobot2-builder:latest"], capture_output=True, text=True, timeout=3)
+            has_builder = bool(res_b.stdout.strip())
+            res_f = subprocess.run(["docker", "images", "-q", "linorobot2-flasher:latest"], capture_output=True, text=True, timeout=3)
+            has_flasher = bool(res_f.stdout.strip())
+        except Exception:
+            pass
+
+    if has_podman and not has_builder:
+        try:
+            res_pb = subprocess.run(["podman", "images", "-q", "linorobot2-builder:latest"], capture_output=True, text=True, timeout=3)
+            has_builder = bool(res_pb.stdout.strip())
+            res_pf = subprocess.run(["podman", "images", "-q", "linorobot2-flasher:latest"], capture_output=True, text=True, timeout=3)
+            has_flasher = bool(res_pf.stdout.strip())
+        except Exception:
+            pass
+
+    return {
+        "status": "ok",
+        "has_docker": has_docker,
+        "is_rootless_docker": is_rootless_docker,
+        "has_podman": has_podman,
+        "has_builder_image": has_builder,
+        "has_flasher_image": has_flasher,
+        "platform_system": platform.system()
+    }
+
+
+def get_rootless_info():
+    c_status = check_container_status()
+    uid = os.getuid() if hasattr(os, "getuid") else 1000
+    user = os.environ.get("USER", "user")
+    xdg_runtime = os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{uid}")
+
+    return {
+        "status": "ok",
+        "is_rootless": c_status["is_rootless_docker"],
+        "has_docker": c_status["has_docker"],
+        "has_podman": c_status["has_podman"],
+        "platform_system": c_status["platform_system"],
+        "user": user,
+        "uid": uid,
+        "xdg_runtime_dir": xdg_runtime,
+        "commands": {
+            "ubuntu_debian": [
+                "sudo apt-get update && sudo apt-get install -y uidmap dbus-user-session slirp4netns",
+                "dockerd-rootless-setuptool.sh install",
+                "systemctl --user enable --now docker.service",
+                f"loginctl enable-linger {user}",
+                f'export DOCKER_HOST="unix://{xdg_runtime}/docker.sock"'
+            ],
+            "fedora": [
+                "sudo dnf install -y shadow-utils-subid docker-ce-rootless-extras slirp4netns fuse-overlayfs",
+                "dockerd-rootless-setuptool.sh install",
+                "systemctl --user enable --now docker.service",
+                f"loginctl enable-linger {user}",
+                f'export DOCKER_HOST="unix://{xdg_runtime}/docker.sock"'
+            ],
+            "podman_alternative": [
+                "sudo apt-get install -y podman  # or: sudo dnf install -y podman",
+                "podman run --version"
+            ]
+        }
+    }
+
+
+
+
+def setup_rootless_docker():
+    logs = []
+    user = os.environ.get("USER", "ubuntu")
+    uid = os.getuid() if hasattr(os, "getuid") else 1000
+    xdg_runtime = os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{uid}")
+
+    if platform.system() != "Linux":
+        return {
+            "status": "ok",
+            "success": True,
+            "message": "Rootless setup is only needed on Linux. Windows and macOS map volume permissions automatically.",
+            "is_rootless": True,
+            "logs": "Non-Linux platform."
+        }
+
+    status = check_container_status()
+    if status["is_rootless_docker"]:
+        return {
+            "status": "ok",
+            "success": True,
+            "message": f"Rootless Docker is already active for user '{user}' (UID {uid}).",
+            "is_rootless": True,
+            "logs": "Rootless daemon is already active."
+        }
+
+    setuptool = shutil.which("dockerd-rootless-setuptool.sh")
+    if not setuptool:
+        for p in ["/usr/bin/dockerd-rootless-setuptool.sh", os.path.expanduser("~/.docker/bin/dockerd-rootless-setuptool.sh")]:
+            if os.path.exists(p):
+                setuptool = p
+                break
+
+    if not setuptool:
+        logs.append("Attempting to install rootless Docker prerequisites...")
+        if shutil.which("apt-get"):
+            subprocess.run(["sudo", "-n", "apt-get", "update"], capture_output=True, text=True)
+            r_inst = subprocess.run(["sudo", "-n", "apt-get", "install", "-y", "uidmap", "dbus-user-session", "slirp4netns", "docker-ce-rootless-extras"], capture_output=True, text=True)
+            logs.append(r_inst.stdout or r_inst.stderr)
+        elif shutil.which("dnf"):
+            r_inst = subprocess.run(["sudo", "-n", "dnf", "install", "-y", "shadow-utils-subid", "docker-ce-rootless-extras", "slirp4netns", "fuse-overlayfs"], capture_output=True, text=True)
+            logs.append(r_inst.stdout or r_inst.stderr)
+        setuptool = shutil.which("dockerd-rootless-setuptool.sh")
+
+    if not setuptool:
+        return {
+            "status": "error",
+            "success": False,
+            "message": "dockerd-rootless-setuptool.sh not found. Install uidmap and docker-ce-rootless-extras.",
+            "is_rootless": False,
+            "logs": "\n".join(logs)
+        }
+
+    logs.append("Running dockerd-rootless-setuptool.sh install -f...")
+    try:
+        r_install = subprocess.run([setuptool, "install", "-f"], capture_output=True, text=True, timeout=30)
+        logs.append(r_install.stdout)
+        if r_install.stderr:
+            logs.append(r_install.stderr)
+    except Exception as e:
+        logs.append(f"Execution error: {e}")
+
+    subprocess.run(["systemctl", "--user", "daemon-reload"], capture_output=True, text=True)
+    subprocess.run(["systemctl", "--user", "enable", "--now", "docker.service"], capture_output=True, text=True)
+    subprocess.run(["loginctl", "enable-linger", user], capture_output=True, text=True)
+
+    docker_sock = f"unix://{xdg_runtime}/docker.sock"
+    os.environ["DOCKER_HOST"] = docker_sock
+
+    bashrc = os.path.expanduser("~/.bashrc")
+    try:
+        if os.path.exists(bashrc):
+            with open(bashrc, "r", encoding="utf-8") as f:
+                b_cnt = f.read()
+            if "DOCKER_HOST" not in b_cnt:
+                with open(bashrc, "a", encoding="utf-8") as f:
+                    f.write(f'\nexport DOCKER_HOST="{docker_sock}"\n')
+                logs.append("Appended DOCKER_HOST to ~/.bashrc")
+    except Exception as e:
+        logs.append(f"Notice: could not update ~/.bashrc: {e}")
+
+    new_status = check_container_status()
+    success = new_status["is_rootless_docker"]
+
+    return {
+        "status": "ok" if success else "warning",
+        "success": success,
+        "is_rootless": success,
+        "message": f"Rootless Docker {'configured and active' if success else 'setup completed with warnings'}.",
+        "logs": "\n".join(logs)
+    }
+
+
+def install_container_engine(engine="docker"):
+    logs = []
+    engine = engine.lower().strip()
+
+    if platform.system() != "Linux":
+        return {
+            "status": "ok",
+            "installed": True,
+            "engine": engine,
+            "message": "On Windows/macOS, please install Docker Desktop or Podman Desktop.",
+            "logs": "Non-Linux platform."
+        }
+
+    has_apt = shutil.which("apt-get") is not None
+    has_dnf = shutil.which("dnf") is not None
+
+    if engine in ("podman", "podman_systemd"):
+        if shutil.which("podman"):
+            return {
+                "status": "ok",
+                "installed": True,
+                "engine": "podman",
+                "message": "Podman is already installed.",
+                "logs": "podman binary present."
+            }
+        logs.append("Installing Podman...")
+        if has_apt:
+            subprocess.run(["sudo", "-n", "apt-get", "update"], capture_output=True, text=True, timeout=60)
+            r = subprocess.run(["sudo", "-n", "apt-get", "install", "-y", "podman"], capture_output=True, text=True, timeout=180)
+            logs.append(r.stdout or r.stderr)
+        elif has_dnf:
+            r = subprocess.run(["sudo", "-n", "dnf", "install", "-y", "podman"], capture_output=True, text=True, timeout=180)
+            logs.append(r.stdout or r.stderr)
+        else:
+            return {
+                "status": "error",
+                "installed": False,
+                "engine": "podman",
+                "message": "No supported package manager found (apt-get or dnf).",
+                "logs": "Unsupported package manager."
+            }
+
+        installed = shutil.which("podman") is not None
+        return {
+            "status": "ok" if installed else "error",
+            "installed": installed,
+            "engine": "podman",
+            "message": "Podman installed successfully." if installed else "Podman installation failed.",
+            "logs": "\n".join(logs)
+        }
+
+    elif engine == "docker":
+        if not shutil.which("docker"):
+            logs.append("Installing Docker packages...")
+            if has_apt:
+                subprocess.run(["sudo", "-n", "apt-get", "update"], capture_output=True, text=True, timeout=60)
+                r = subprocess.run(["sudo", "-n", "apt-get", "install", "-y", "docker.io", "uidmap", "dbus-user-session", "slirp4netns"], capture_output=True, text=True, timeout=180)
+                logs.append(r.stdout or r.stderr)
+            elif has_dnf:
+                r = subprocess.run(["sudo", "-n", "dnf", "install", "-y", "docker-ce", "shadow-utils-subid", "docker-ce-rootless-extras", "slirp4netns", "fuse-overlayfs"], capture_output=True, text=True, timeout=180)
+                logs.append(r.stdout or r.stderr)
+            else:
+                return {
+                    "status": "error",
+                    "installed": False,
+                    "engine": "docker",
+                    "message": "No supported package manager found (apt-get or dnf).",
+                    "logs": "Unsupported package manager."
+                }
+
+        rootless_res = setup_rootless_docker()
+        logs.append(rootless_res.get("logs", ""))
+
+        status = check_container_status()
+        installed = status["has_docker"]
+        return {
+            "status": "ok" if installed else "error",
+            "installed": installed,
+            "is_rootless": status["is_rootless_docker"],
+            "engine": "docker",
+            "message": "Docker (Rootless) installed and configured." if (installed and status["is_rootless_docker"]) else ("Docker installed." if installed else "Docker installation failed."),
+            "logs": "\n".join(logs)
+        }
+
+    return {
+        "status": "error",
+        "installed": False,
+        "engine": engine,
+        "message": f"Unknown container engine '{engine}'.",
+        "logs": "Invalid engine requested."
+    }
+
+
+def get_robot_host_info():
+    info = {
+        "system": platform.system(),
+        "node": platform.node(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "distro_id": "",
+        "distro_name": platform.system(),
+        "has_apt": shutil.which("apt-get") is not None,
+        "has_dnf": shutil.which("dnf") is not None,
+        "has_distrobox": shutil.which("distrobox") is not None,
+        "is_container": os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"),
+        "has_pio": shutil.which("pio") is not None or os.path.exists(os.path.expanduser("~/.platformio/penv/bin/pio")),
+        "installed_ros_distros": [],
+        "serial_ports": []
+    }
+    # Check OS Release
+    if os.path.exists("/etc/os-release"):
+        try:
+            with open("/etc/os-release", "r") as f:
+                for line in f:
+                    if line.startswith("ID="):
+                        info["distro_id"] = line.split("=", 1)[1].strip().strip('"').lower()
+                    elif line.startswith("PRETTY_NAME="):
+                        info["distro_name"] = line.split("=", 1)[1].strip().strip('"')
+        except Exception:
+            pass
+
+    # Check installed ROS 2 distros
+    if os.path.isdir("/opt/ros"):
+        try:
+            info["installed_ros_distros"] = sorted(os.listdir("/opt/ros"))
+        except Exception:
+            pass
+
+    # Scan attached MCU serial ports, inspect USB VID:PID, and verify access rights
+    patterns = ["/dev/ttyACM*", "/dev/ttyUSB*", "/dev/ttyTHS*", "/dev/serial0"]
+    found_ports = []
+    port_details = []
+    seen_syspaths = set()
+    for pat in patterns:
+        for p in glob.glob(pat):
+            found_ports.append(p)
+            det = get_port_usb_details(p)
+            port_details.append(det)
+            if det.get("syspath"):
+                try:
+                    seen_syspaths.add(os.path.realpath(det["syspath"]))
+                except Exception:
+                    pass
+
+    # Scan for connected USB ROM bootloaders / Mass Storage devices lacking tty drivers (e.g. RP2 Boot / BOOTSEL)
+    for dev_dir in sorted(glob.glob("/sys/bus/usb/devices/*")):
+        idv_f = os.path.join(dev_dir, "idVendor")
+        idp_f = os.path.join(dev_dir, "idProduct")
+        if os.path.exists(idv_f) and os.path.exists(idp_f):
+            try:
+                with open(idv_f) as f: vid = f.read().strip().lower()
+                with open(idp_f) as f: pid = f.read().strip().lower()
+                real_sys = os.path.realpath(dev_dir)
+                # If already mapped to a tty port, skip
+                if any(real_sys.startswith(s) or s.startswith(real_sys) for s in seen_syspaths):
+                    continue
+
+                prod = ""
+                mfg = ""
+                if os.path.exists(os.path.join(dev_dir, "product")):
+                    with open(os.path.join(dev_dir, "product")) as f: prod = f.read().strip()
+                if os.path.exists(os.path.join(dev_dir, "manufacturer")):
+                    with open(os.path.join(dev_dir, "manufacturer")) as f: mfg = f.read().strip()
+
+                is_bootsel = False
+                chip_name = ""
+                mcu_hint = ""
+                if vid == "2e8a":
+                    if pid in ["0003", "000a"]:
+                        is_bootsel = True
+                        chip_name = "Raspberry Pi Pico (RP2040) [BOOTSEL Mode]"
+                        mcu_hint = "PICO"
+                    elif pid in ["000f", "0005"]:
+                        is_bootsel = True
+                        chip_name = "Raspberry Pi Pico 2 (RP2350) [BOOTSEL Mode]"
+                        mcu_hint = "PICO2"
+                    else:
+                        chip_name = f"Raspberry Pi RP2 Device [{vid}:{pid}]"
+                        mcu_hint = "PICO"
+                        is_bootsel = True
+                elif vid == "303a" and pid in ["0002", "1001", "1002"]:
+                    chip_name = "ESP32-S2/S3 (ROM Bootloader Mode)"
+                    mcu_hint = "ESP32S3"
+                    is_bootsel = True
+
+                if is_bootsel:
+                    boot_entry = {
+                        "port": "BOOTSEL",
+                        "accessible": True,
+                        "vid": vid,
+                        "pid": pid,
+                        "product": prod or "RP2 Boot",
+                        "manufacturer": mfg or "Raspberry Pi",
+                        "chip": chip_name or f"USB Bootloader [{vid}:{pid}]",
+                        "is_bootsel": True,
+                        "mcu_hint": mcu_hint,
+                        "post_flash_port": "/dev/ttyACM0"
+                    }
+                    found_ports.append("BOOTSEL")
+                    port_details.append(boot_entry)
+            except Exception:
+                pass
+
+    info["serial_ports"] = sorted(list(set(found_ports)))
+    info["port_details"] = port_details
+
+    # Check user dialout/plugdev group permissions
+    has_dialout = False
+    try:
+        import grp
+        user = os.environ.get("USER", "")
+        if user:
+            dialout_group = grp.getgrnam("dialout")
+            has_dialout = user in dialout_group.gr_mem
+    except Exception:
+        pass
+    info["has_dialout"] = has_dialout
+
+    return info
+
+
+
+# =============================================================================
+# Workflow & Board Setup Persistence
+# =============================================================================
+WORKFLOW_SETTINGS_PATH = os.path.join(REPO_ROOT, "config", "custom", ".workflow_settings.json")
+
+DEFAULT_WORKFLOW_SETTINGS = {
+    "ros_distro": "jazzy",
+    "build_engine": "docker",
+    "agent_engine": "docker",
+    "container_registry": "auto",
+    "custom_registry": "",
+    "remote_flash": "",
+    "flash_port": "",
+    "multi_ports": "",
+    "robot_name": "scout_pico2",
+    "branch": "scout_pico2",
+    "preset": "bare",
+    "board_env": "",
+    "spec": {}
+}
+
+def load_workflow_settings():
+    if os.path.exists(WORKFLOW_SETTINGS_PATH):
+        try:
+            with open(WORKFLOW_SETTINGS_PATH, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                res = DEFAULT_WORKFLOW_SETTINGS.copy()
+                res.update(data)
+                return res
+        except Exception:
+            pass
+    return DEFAULT_WORKFLOW_SETTINGS.copy()
+
+def save_workflow_settings(data):
+    os.makedirs(os.path.dirname(WORKFLOW_SETTINGS_PATH), exist_ok=True)
+    curr = load_workflow_settings()
+    curr.update(data)
+    with open(WORKFLOW_SETTINGS_PATH, "w", encoding="utf-8") as f:
+        json.dump(curr, f, indent=2)
+    return curr
+
+
+# =============================================================================
+# Remote Target & SSH Management
+# =============================================================================
+REMOTE_CONFIG_PATH = os.path.join(REPO_ROOT, "config", "custom", ".remote_config.json")
+
+DEFAULT_REMOTE_CONFIG = {
+    "target_mode": "local",  # "local" or "remote"
+    "remote_host": "192.168.1.100",
+    "remote_user": "ubuntu",
+    "remote_port": 22,
+    "remote_key": "",
+    "remote_serial_port": "/dev/ttyUSB0",
+    "remote_baud": 1500000
+}
+
+def load_remote_config():
+    if os.path.exists(REMOTE_CONFIG_PATH):
+        try:
+            with open(REMOTE_CONFIG_PATH, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                res = DEFAULT_REMOTE_CONFIG.copy()
+                res.update(data)
+                return res
+        except Exception:
+            pass
+    return DEFAULT_REMOTE_CONFIG.copy()
+
+def save_remote_config(data):
+    os.makedirs(os.path.dirname(REMOTE_CONFIG_PATH), exist_ok=True)
+    curr = load_remote_config()
+    curr.update(data)
+    with open(REMOTE_CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(curr, f, indent=2)
+    return curr
+
+def build_ssh_args(cfg):
+    user = (cfg.get("remote_user") or "ubuntu").strip()
+    host = (cfg.get("remote_host") or "127.0.0.1").strip()
+    port = str(cfg.get("remote_port") or 22).strip()
+    key = (cfg.get("remote_key") or "").strip()
+    args = [
+        "ssh",
+        "-o", "BatchMode=yes",
+        "-o", "ConnectTimeout=5",
+        "-o", "StrictHostKeyChecking=no",
+        "-p", port
+    ]
+    if key and os.path.exists(os.path.expanduser(key)):
+        args.extend(["-i", os.path.expanduser(key)])
+    args.append(f"{user}@{host}")
+    return args
+
+def test_remote_ssh(cfg):
+    args = build_ssh_args(cfg)
+    check_script = (
+        "echo 'SSH_ALIVE'; "
+        "which esptool.py 2>/dev/null || python3 -m esptool version 2>/dev/null || echo 'NO_ESPTOOL'; "
+        "which picotool 2>/dev/null || echo 'NO_PICOTOOL'; "
+        "which docker 2>/dev/null || echo 'NO_DOCKER'; "
+        "uname -s -r -m; "
+        "cat /etc/os-release 2>/dev/null | grep PRETTY_NAME | head -n 1"
+    )
+    args.append(check_script)
+    try:
+        res = subprocess.run(args, capture_output=True, text=True, timeout=8)
+        if res.returncode != 0 and "SSH_ALIVE" not in res.stdout:
+            err = res.stderr.strip() or f"SSH exited with code {res.returncode}"
+            return {"ok": False, "error": err}
+
+        stdout = res.stdout
+        has_docker = "NO_DOCKER" not in stdout and "docker" in stdout
+        has_esptool = "NO_ESPTOOL" not in stdout and ("esptool" in stdout or "5." in stdout or "4." in stdout)
+        has_picotool = "NO_PICOTOOL" not in stdout and "picotool" in stdout
+
+        # Docker Anywhere: auto-install Docker on Robot PC if missing
+        if not has_docker:
+            try:
+                inst_docker = build_ssh_args(cfg)
+                inst_docker.append("curl -fsSL https://get.docker.com | sudo sh 2>/dev/null && sudo usermod -a -G docker $USER 2>/dev/null || true")
+                subprocess.run(inst_docker, capture_output=True, text=True, timeout=90)
+                chk_d = build_ssh_args(cfg)
+                chk_d.append("which docker 2>/dev/null || echo 'NO_DOCKER'")
+                res_d = subprocess.run(chk_d, capture_output=True, text=True, timeout=5)
+                has_docker = "NO_DOCKER" not in res_d.stdout and "docker" in res_d.stdout
+            except Exception:
+                pass
+
+        # When Docker is present on Robot PC, container flasher covers esptool and picotool
+        if has_docker:
+            has_esptool = True
+            has_picotool = True
+
+        # Automatic tool installation if missing (zero user action needed)
+        auto_installed = False
+        if not has_esptool:
+            try:
+                inst_args = build_ssh_args(cfg)
+                inst_args.append("python3 -m pip install -q --user --break-system-packages esptool 2>/dev/null || python3 -m pip install -q --user esptool 2>/dev/null || sudo apt-get install -y -qq python3-esptool 2>/dev/null || true")
+                subprocess.run(inst_args, capture_output=True, text=True, timeout=15)
+                has_esptool = True
+                auto_installed = True
+            except Exception:
+                pass
+
+        if not has_picotool:
+            try:
+                inst_pico = build_ssh_args(cfg)
+                inst_pico.append("sudo apt-get install -y -qq picotool 2>/dev/null || true; [ -d /etc/udev/rules.d ] && [ ! -f /etc/udev/rules.d/99-pico.rules ] && echo \"ATTRS{idVendor}==\"2e8a\", MODE=\"666\", GROUP=\"dialout\"\" | sudo tee /etc/udev/rules.d/99-pico.rules >/dev/null 2>&1 || true")
+                subprocess.run(inst_pico, capture_output=True, text=True, timeout=10)
+                has_picotool = True
+                auto_installed = True
+            except Exception:
+                pass
+
+        # Ensure dialout permissions automatically
+        try:
+            perm_args = build_ssh_args(cfg)
+            perm_args.append("sudo usermod -a -G dialout ubuntu 2>/dev/null || true; for _d in /dev/ttyUSB* /dev/ttyACM*; do [ -e \"\" ] && sudo chmod a+rw \"\" 2>/dev/null || true; done")
+            subprocess.run(perm_args, capture_output=True, text=True, timeout=5)
+        except Exception:
+            pass
+
+        os_info = ""
+        for line in stdout.split("\n"):
+            if "PRETTY_NAME" in line:
+                os_info = line.split("=", 1)[-1].strip().strip('"')
+                break
+        if not os_info:
+            for line in stdout.split("\n"):
+                if "Linux" in line:
+                    os_info = line.strip()
+                    break
+
+        return {
+            "ok": True,
+            "ssh": True,
+            "has_esptool": has_esptool,
+            "has_picotool": has_picotool,
+            "has_docker": has_docker,
+            "os_info": os_info or "Linux"
+        }
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "SSH connection timed out (5s)"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+def get_remote_serial_ports(cfg):
+    args = build_ssh_args(cfg)
+    probe_script = (
+        "python3 -c '"
+        "import glob, json, os\n"
+        "patterns = [\"/dev/ttyACM*\", \"/dev/ttyUSB*\", \"/dev/ttyTHS*\", \"/dev/serial0\"]\n"
+        "found_ports = []\n"
+        "port_details = []\n"
+        "for pat in patterns:\n"
+        "    for p in glob.glob(pat):\n"
+        "        found_ports.append(p)\n"
+        "        port_name = os.path.basename(p)\n"
+        "        info = {\"port\": p, \"vid\": \"\", \"pid\": \"\", \"product\": \"\", \"manufacturer\": \"\", \"chip\": \"Generic USB Serial\"}\n"
+        "        dev_path = f\"/sys/class/tty/{port_name}/device\"\n"
+        "        if os.path.exists(dev_path):\n"
+        "            curr = os.path.realpath(dev_path)\n"
+        "            for _ in range(6):\n"
+        "                vp = os.path.join(curr, \"idVendor\")\n"
+        "                pp = os.path.join(curr, \"idProduct\")\n"
+        "                if os.path.exists(vp) and os.path.exists(pp):\n"
+        "                    with open(vp) as f: info[\"vid\"] = f.read().strip().lower()\n"
+        "                    with open(pp) as f: info[\"pid\"] = f.read().strip().lower()\n"
+        "                    if os.path.exists(os.path.join(curr, \"product\")):\n"
+        "                        with open(os.path.join(curr, \"product\")) as f: info[\"product\"] = f.read().strip()\n"
+        "                    if os.path.exists(os.path.join(curr, \"manufacturer\")):\n"
+        "                        with open(os.path.join(curr, \"manufacturer\")) as f: info[\"manufacturer\"] = f.read().strip()\n"
+        "                    break\n"
+        "                curr = os.path.dirname(curr)\n"
+        "        vid, pid = info[\"vid\"], info[\"pid\"]\n"
+        "        if vid == \"10c4\" and pid == \"ea60\":\n"
+        "            info[\"chip\"] = \"CP2102N USB Bridge (ESP32/GenDrv)\" if \"cp2102n\" in info[\"product\"].lower() else \"CP2102 USB Bridge (ESP32)\"\n"
+        "        elif vid == \"1a86\" and pid in [\"7523\", \"5523\", \"7522\"]:\n"
+        "            info[\"chip\"] = \"CH340/CH341 USB Bridge\"\n"
+        "        elif vid == \"2e8a\":\n"
+        "            info[\"chip\"] = \"Raspberry Pi Pico (RP2040)\" if pid in [\"0003\", \"000a\"] else \"Raspberry Pi Pico 2 (RP2350)\"\n"
+        "        elif vid == \"303a\":\n"
+        "            info[\"chip\"] = \"ESP32 USB Serial\"\n"
+        "        port_details.append(info)\n"
+        "print(json.dumps({\"status\": \"ok\", \"serial_ports\": sorted(list(set(found_ports))), \"port_details\": port_details}))\n"
+        "'"
+    )
+    args.append(probe_script)
+    try:
+        res = subprocess.run(args, capture_output=True, text=True, timeout=8)
+        if res.returncode == 0 and res.stdout.strip():
+            out = res.stdout.strip()
+            idx = out.find('{"status": "ok"')
+            if idx >= 0:
+                return json.loads(out[idx:])
+        # Fallback to simple ls
+        fallback_args = build_ssh_args(cfg)
+        fallback_args.append("ls -1 /dev/ttyUSB* /dev/ttyACM* 2>/dev/null")
+        fres = subprocess.run(fallback_args, capture_output=True, text=True, timeout=5)
+        ports = [p.strip() for p in fres.stdout.strip().split("\n") if p.strip()]
+        return {"status": "ok", "serial_ports": ports, "port_details": [{"port": p, "chip": "Serial Port"} for p in ports]}
+    except Exception as e:
+        return {"status": "error", "error": str(e), "serial_ports": [], "port_details": []}
+
+def get_remote_chip_id(cfg, port):
+    args = build_ssh_args(cfg)
+    script = (
+        f"python3 -m esptool --port {port} chip_id 2>&1 || "
+        f"~/.platformio/penv/bin/esptool.py --port {port} chip_id 2>&1 || "
+        f"esptool.py --port {port} chip_id 2>&1 || "
+        f"picotool info 2>&1 || echo 'No chip ID tool available'"
+    )
+    args.append(script)
+    try:
+        res = subprocess.run(args, capture_output=True, text=True, timeout=12)
+        return {"status": "ok", "output": res.stdout}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+def _parse_port_check_output(output, port, mode, udp_port, res):
+    fuser_section = ""
+    container_section = ""
+    process_section = ""
+
+    current_sec = None
+    for line in output.splitlines():
+        line_s = line.strip()
+        if line_s == "---FUSER---":
+            current_sec = "fuser"
+            continue
+        elif line_s == "---CONTAINERS---":
+            current_sec = "containers"
+            continue
+        elif line_s == "---PROCESSES---":
+            current_sec = "processes"
+            continue
+
+        if current_sec == "fuser":
+            fuser_section += line + " "
+        elif current_sec == "containers":
+            container_section += line + chr(10)
+        elif current_sec == "processes":
+            process_section += line + chr(10)
+
+    port_basename = os.path.basename(port) if mode != "udp" else str(udp_port)
+    for line in container_section.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split("|")
+        cid = parts[0]
+        cname = parts[1] if len(parts) > 1 else ""
+        cimg = parts[2] if len(parts) > 2 else ""
+        ccmd = parts[3] if len(parts) > 3 else ""
+
+        is_cont_target = False
+        if mode == "udp":
+            if f":{udp_port}" in ccmd or f"--port {udp_port}" in ccmd or f"{udp_port}/udp" in line or (("microros" in cimg or "uros" in cname) and "udp" in ccmd):
+                is_cont_target = True
+        else:
+            if port in ccmd or port_basename in ccmd or "microros" in cimg or "uros_agent" in cname or "microros_agent" in cname or "uros" in cname:
+                is_cont_target = True
+
+        if is_cont_target:
+            res["in_use"] = True
+            res["holder_type"] = "container"
+            res["container_id"] = cid
+            res["container_name"] = cname
+            res["is_microros"] = "microros" in cimg or "uros" in cname or "micro_ros" in ccmd
+            res["details"] = f"Container '{cname}' ({cid[:12]}): {cimg}"
+            res["summary"] = f"Occupied by container '{cname}' ({cid[:8]})"
+            return res
+
+    raw_pids = [p for p in fuser_section.replace(":", " ").split() if p.isdigit()]
+    if raw_pids:
+        res["in_use"] = True
+        res["pids"] = raw_pids
+        res["holder_type"] = "process"
+        if "micro_ros_agent" in process_section:
+            res["is_microros"] = True
+            res["process_names"] = ["micro_ros_agent"]
+            res["summary"] = f"In use by micro_ros_agent (PID {raw_pids[0]})"
+        else:
+            res["summary"] = f"Port in use by PID {raw_pids[0]}"
+        res["details"] = f"PIDs: {raw_pids}"
+        return res
+
+    if mode == "udp" and str(udp_port) in process_section:
+        res["in_use"] = True
+        res["holder_type"] = "socket"
+        res["summary"] = f"UDP socket :{udp_port} in use"
+        return res
+
+    if mode != "udp" and "micro_ros_agent" in process_section and (port in process_section or port_basename in process_section):
+        res["in_use"] = True
+        res["holder_type"] = "process"
+        res["is_microros"] = True
+        res["summary"] = f"micro_ros_agent active on {port}"
+        res["details"] = process_section.strip()
+        return res
+
+    return res
+
+
+def check_agent_port_status(port="/dev/ttyUSB0", mode="serial", udp_port=8888, host=None, user=None):
+    res = {
+        "status": "ok",
+        "in_use": False,
+        "mode": mode,
+        "target": port if mode in ["serial", "multiserial"] else f"UDP:{udp_port}",
+        "holder_type": "none",
+        "pids": [],
+        "process_names": [],
+        "container_id": "",
+        "container_name": "",
+        "is_microros": False,
+        "details": "",
+        "summary": "Port is available"
+    }
+
+    if host:
+        ssh_cmd = [
+            "ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=4",
+            "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+            f"{user}@{host}" if user else host
+        ]
+        if mode in ["serial", "multiserial"]:
+            script = (
+                f"echo '---FUSER---'; fuser '{port}' 2>/dev/null || true; "
+                f"echo '---CONTAINERS---'; "
+                f"docker ps --format '{{{{.ID}}}}|{{{{.Names}}}}|{{{{.Image}}}}|{{{{.Command}}}}' 2>/dev/null || true; "
+                f"podman ps --format '{{{{.ID}}}}|{{{{.Names}}}}|{{{{.Image}}}}|{{{{.Command}}}}' 2>/dev/null || true; "
+                f"echo '---PROCESSES---'; "
+                f"pgrep -fa 'micro_ros_agent' 2>/dev/null || true"
+            )
+        else:
+            script = (
+                f"echo '---FUSER---'; fuser '{udp_port}/udp' 2>/dev/null || true; "
+                f"echo '---CONTAINERS---'; "
+                f"docker ps --format '{{{{.ID}}}}|{{{{.Names}}}}|{{{{.Image}}}}|{{{{.Command}}}}' 2>/dev/null || true; "
+                f"podman ps --format '{{{{.ID}}}}|{{{{.Names}}}}|{{{{.Image}}}}|{{{{.Command}}}}' 2>/dev/null || true; "
+                f"echo '---PROCESSES---'; "
+                f"ss -ulnp 'sport = :{udp_port}' 2>/dev/null || true"
+            )
+        try:
+            r = subprocess.run(ssh_cmd + [script], capture_output=True, text=True, timeout=8)
+            output = r.stdout
+        except Exception as e:
+            res["status"] = "error"
+            res["details"] = f"SSH error: {e}"
+            return res
+        return _parse_port_check_output(output, port, mode, udp_port, res)
+
+    # Local port checks
+    output_parts = []
+    if mode in ["serial", "multiserial"]:
+        output_parts.append("---FUSER---")
+        if os.path.exists(port):
+            try:
+                f = subprocess.run(["fuser", port], capture_output=True, text=True, timeout=2)
+                output_parts.append(f.stdout)
+            except Exception:
+                pass
+        output_parts.append("---CONTAINERS---")
+        try:
+            d = subprocess.run(["docker", "ps", "--format", "{{.ID}}|{{.Names}}|{{.Image}}|{{.Command}}"], capture_output=True, text=True, timeout=2)
+            output_parts.append(d.stdout)
+        except Exception:
+            pass
+        try:
+            p = subprocess.run(["podman", "ps", "--format", "{{.ID}}|{{.Names}}|{{.Image}}|{{.Command}}"], capture_output=True, text=True, timeout=2)
+            output_parts.append(p.stdout)
+        except Exception:
+            pass
+        output_parts.append("---PROCESSES---")
+        try:
+            pr = subprocess.run(["pgrep", "-fa", "micro_ros_agent"], capture_output=True, text=True, timeout=2)
+            output_parts.append(pr.stdout)
+        except Exception:
+            pass
+    else:
+        output_parts.append("---FUSER---")
+        try:
+            f = subprocess.run(["fuser", f"{udp_port}/udp"], capture_output=True, text=True, timeout=2)
+            output_parts.append(f.stdout)
+        except Exception:
+            pass
+        output_parts.append("---CONTAINERS---")
+        try:
+            d = subprocess.run(["docker", "ps", "--format", "{{.ID}}|{{.Names}}|{{.Image}}|{{.Command}}"], capture_output=True, text=True, timeout=2)
+            output_parts.append(d.stdout)
+        except Exception:
+            pass
+        try:
+            p = subprocess.run(["podman", "ps", "--format", "{{.ID}}|{{.Names}}|{{.Image}}|{{.Command}}"], capture_output=True, text=True, timeout=2)
+            output_parts.append(p.stdout)
+        except Exception:
+            pass
+        output_parts.append("---PROCESSES---")
+        try:
+            pr = subprocess.run(["ss", "-ulnp", f"sport = :{udp_port}"], capture_output=True, text=True, timeout=2)
+            output_parts.append(pr.stdout)
+        except Exception:
+            pass
+
+    return _parse_port_check_output("\n".join(output_parts), port, mode, udp_port, res)
+
+
+def release_agent_port(port="/dev/ttyUSB0", mode="serial", udp_port=8888, host=None, user=None):
+    if host:
+        ssh_cmd = [
+            "ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=4",
+            "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+            f"{user}@{host}" if user else host
+        ]
+        if mode == "udp":
+            script = (
+                f"docker stop microros_agent uros_agent_udp 2>/dev/null || true; "
+                f"podman stop microros_agent uros_agent_udp 2>/dev/null || true; "
+                f"fuser -k -TERM {udp_port}/udp 2>/dev/null || true; "
+                f"pkill -f 'micro_ros_agent.*udp' 2>/dev/null || true; "
+                f"sleep 0.5"
+            )
+        else:
+            port_base = os.path.basename(port)
+            script = (
+                f"docker stop microros_agent uros_agent_serial 2>/dev/null || true; "
+                f"podman stop microros_agent uros_agent_serial 2>/dev/null || true; "
+                f"[ -e '{port}' ] && fuser -k -TERM '{port}' 2>/dev/null || true; "
+                f"pkill -f '[m]icro_ros_agent.*{port_base}' 2>/dev/null || true; "
+                f"sleep 0.5"
+            )
+        try:
+            r = subprocess.run(ssh_cmd + [script], capture_output=True, text=True, timeout=10)
+            return {"status": "ok", "released": True, "output": r.stdout}
+        except Exception as e:
+            return {"status": "error", "error": str(e)}
+
+    # Local release
+    if mode == "udp":
+        try:
+            subprocess.run(["docker", "stop", "microros_agent", "uros_agent_udp"], capture_output=True, text=True, timeout=5)
+        except Exception:
+            pass
+        try:
+            subprocess.run(["podman", "stop", "microros_agent", "uros_agent_udp"], capture_output=True, text=True, timeout=5)
+        except Exception:
+            pass
+        try:
+            subprocess.run(["fuser", "-k", "-TERM", f"{udp_port}/udp"], capture_output=True, text=True, timeout=3)
+        except Exception:
+            pass
+        try:
+            subprocess.run(["pkill", "-f", "micro_ros_agent.*udp"], capture_output=True, text=True, timeout=3)
+        except Exception:
+            pass
+    else:
+        port_base = os.path.basename(port)
+        try:
+            subprocess.run(["docker", "stop", "microros_agent", "uros_agent_serial"], capture_output=True, text=True, timeout=5)
+        except Exception:
+            pass
+        try:
+            subprocess.run(["podman", "stop", "microros_agent", "uros_agent_serial"], capture_output=True, text=True, timeout=5)
+        except Exception:
+            pass
+        if os.path.exists(port):
+            try:
+                subprocess.run(["fuser", "-k", "-TERM", port], capture_output=True, text=True, timeout=3)
+            except Exception:
+                pass
+        try:
+            subprocess.run(["pkill", "-f", f"[m]icro_ros_agent.*{port_base}"], capture_output=True, text=True, timeout=3)
+        except Exception:
+            pass
+
+    return {"status": "ok", "released": True}
+
+
+def manage_remote_microros_agent(cfg, action, distro="jazzy", port="/dev/ttyUSB0", baud="1500000"):
+    host = cfg.get("robot_host")
+    user = cfg.get("robot_user", "ubuntu")
+
+    if action == "status":
+        chk = check_agent_port_status(port=port, mode="serial", host=host if host else None, user=user)
+        return {"status": "ok", "running": chk["in_use"], "details": chk["details"] or chk["summary"], "check": chk}
+    elif action == "start":
+        release_agent_port(port=port, mode="serial", host=host if host else None, user=user)
+        args = build_ssh_args(cfg)
+        script = (
+            f"docker run -d --rm --name microros_agent --net=host --privileged "
+            f"-v /dev:/dev microros/micro-ros-agent:{distro} "
+            f"serial --dev {port} -b {baud}"
+        )
+        args.append(script)
+        res = subprocess.run(args, capture_output=True, text=True, timeout=15)
+        return {"status": "ok", "output": res.stdout.strip()}
+    elif action == "stop":
+        rel = release_agent_port(port=port, mode="serial", host=host if host else None, user=user)
+        return {"status": "ok", "stopped": True, "details": rel}
+    return {"status": "error", "error": f"Unknown action: {action}"}
+
+
+class LinorobotEngineHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=WEB_DIR, **kwargs)
+
+    def end_headers(self):
+        self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+        super().end_headers()
+
+    def do_HEAD(self):
+        parsed = urlparse(self.path)
+        if parsed.path in ["/api/status", "/api/configs"]:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            return
+        return super().do_HEAD()
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+
+        if parsed.path == "/api/docker/status":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(check_container_status()).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/workflow/settings":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps({"status": "ok", "settings": load_workflow_settings()}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/docker/rootless_info":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(get_rootless_info()).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/docker/setup_rootless":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(setup_rootless_docker()).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/container/install":
+            qs = parse_qs(parsed.query)
+            eng = qs.get("engine", ["docker"])[0]
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(install_container_engine(eng)).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/remote/config":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            cfg = load_remote_config()
+            self.wfile.write(json.dumps({"status": "ok", "config": cfg}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/remote/serial_ports":
+            cfg = load_remote_config()
+            qs = parse_qs(parsed.query)
+            if "host" in qs: cfg["remote_host"] = qs["host"][0]
+            if "user" in qs: cfg["remote_user"] = qs["user"][0]
+            if "port" in qs:
+                try: cfg["remote_port"] = int(qs["port"][0])
+                except: pass
+            res = get_remote_serial_ports(cfg)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(res).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/remote/chip_id":
+            cfg = load_remote_config()
+            qs = parse_qs(parsed.query)
+            if "host" in qs: cfg["remote_host"] = qs["host"][0]
+            if "user" in qs: cfg["remote_user"] = qs["user"][0]
+            port = qs.get("port", [cfg.get("remote_serial_port", "/dev/ttyUSB0")])[0]
+            res = get_remote_chip_id(cfg, port)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(res).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/agent/port_check":
+            qs = parse_qs(parsed.query)
+            port = qs.get("port", ["/dev/ttyUSB0"])[0]
+            mode = qs.get("mode", ["serial"])[0]
+            udp_port = int(qs.get("udp_port", [8888])[0])
+            host = qs.get("host", [""])[0]
+            user = qs.get("user", ["ubuntu"])[0]
+            res = check_agent_port_status(port, mode, udp_port, host=host if host else None, user=user)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(res).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/remote/microros_agent":
+            cfg = load_remote_config()
+            res = manage_remote_microros_agent(cfg, "status")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(res).encode("utf-8"))
+            return
+        
+        if parsed.path == "/api/syslog/status":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({"status": "ok", **syslog_manager.get_status()}).encode("utf-8"))
+            except Exception:
+                pass
+            return
+
+        if parsed.path == "/api/syslog/logs":
+            # List available log files and optionally read tail lines
+            qs = parse_qs(parsed.query)
+            tail_count = int(qs.get("tail", [50])[0])
+            files = []
+            if os.path.exists(syslog_manager.logs_dir):
+                for f in sorted(os.listdir(syslog_manager.logs_dir), reverse=True):
+                    if f.endswith(".log"):
+                        fp = os.path.join(syslog_manager.logs_dir, f)
+                        files.append({
+                            "name": f,
+                            "path": os.path.relpath(fp, REPO_ROOT),
+                            "size": os.path.getsize(fp),
+                            "mtime": os.path.getmtime(fp)
+                        })
+
+            current_log = syslog_manager.get_current_log_filepath()
+            lines = []
+            if os.path.exists(current_log):
+                try:
+                    with open(current_log, "r", encoding="utf-8", errors="replace") as f:
+                        all_lines = f.readlines()
+                        lines = [l.strip() for l in all_lines[-tail_count:]]
+                except Exception:
+                    pass
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({
+                    "status": "ok",
+                    "files": files,
+                    "current_file": os.path.relpath(current_log, REPO_ROOT),
+                    "lines": lines
+                }).encode("utf-8"))
+            except Exception:
+                pass
+            return
+
+        if parsed.path == "/api/syslog/stream":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+
+            q = queue.Queue(maxsize=100)
+            syslog_manager.subscribe(q)
+
+            # Send initial status
+            try:
+                status_init = f"event: status\ndata: {json.dumps(syslog_manager.get_status())}\n\n"
+                self.wfile.write(status_init.encode("utf-8"))
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                syslog_manager.unsubscribe(q)
+                return
+
+            try:
+                while True:
+                    try:
+                        entry = q.get(timeout=2.0)
+                        msg = f"event: syslog\ndata: {json.dumps(entry)}\n\n"
+                        self.wfile.write(msg.encode("utf-8"))
+                        self.wfile.flush()
+                    except queue.Empty:
+                        self.wfile.write(b": ping\n\n")
+                        self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            finally:
+                syslog_manager.unsubscribe(q)
+            return
+
+        if parsed.path == "/api/ros2/topics":
+            # Discover active ROS 2 topics, message types, and default known rates
+            topics = []
+            try:
+                setup_bash = ""
+                for distro in ["jazzy", "lyrical", "rolling"]:
+                    p = f"/opt/ros/{distro}/setup.bash"
+                    if os.path.exists(p):
+                        setup_bash = p
+                        break
+                
+                cmd = f"source {setup_bash} 2>/dev/null && ros2 topic list -t"
+                res = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True, timeout=3.5)
+                if res.returncode == 0:
+                    for line in res.stdout.strip().split("\n"):
+                        line = line.strip()
+                        if line and " [" in line and line.endswith("]"):
+                            t_name, t_type = line.split(" [", 1)
+                            t_name = t_name.strip()
+                            t_type = t_type[:-1].strip()
+                            
+                            # Estimate nominal rate
+                            hz_str = "--"
+                            status_str = "active"
+                            if "odom" in t_name:
+                                hz_str = "50.0 Hz"
+                            elif "imu" in t_name:
+                                hz_str = "50.0 Hz"
+                            elif "battery" in t_name:
+                                hz_str = "1.0 Hz"
+                            elif "cmd_vel" in t_name:
+                                hz_str = "Subscribed"
+                                status_str = "sub"
+                            elif "sonar" in t_name:
+                                hz_str = "20.0 Hz"
+                            elif "parameter_events" in t_name or "rosout" in t_name:
+                                hz_str = "Event"
+
+                            topics.append({
+                                "topic": t_name,
+                                "type": t_type,
+                                "hz": hz_str,
+                                "status": status_str
+                            })
+            except Exception as e:
+                pass
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({"status": "ok", "topics": topics}).encode("utf-8"))
+            except Exception:
+                pass
+            return
+
+        if parsed.path == "/api/ros2/hz_single":
+            # Single-shot frequency measurement. `secs` (default 6, 3..20) is the
+            # sampling window — a 1 Hz topic needs several seconds to average
+            # meaningfully, so the caller can ask for a longer window on slow
+            # topics. The LAST `average rate:` line (most settled) is reported.
+            qs = parse_qs(parsed.query)
+            topic = qs.get("topic", ["/odom/unfiltered"])[0].strip()
+            try:
+                secs = int(round(float(qs.get("secs", ["6"])[0])))
+            except Exception:
+                secs = 6
+            secs = max(3, min(secs, 20))
+            rate_val = "0.0"
+            try:
+                setup_bash = ""
+                for distro in ["jazzy", "lyrical", "rolling"]:
+                    p = f"/opt/ros/{distro}/setup.bash"
+                    if os.path.exists(p):
+                        setup_bash = p
+                        break
+                cmd = (f"source {setup_bash} 2>/dev/null && "
+                       f"timeout {secs} stdbuf -oL -eL ros2 topic hz --window 10000 {topic}")
+                res = subprocess.run(["bash", "-c", cmd], capture_output=True,
+                                     text=True, timeout=secs + 5)
+                rates = re.findall(r"average rate:\s*([0-9.]+)", res.stdout)
+                if rates:
+                    rate_val = f"{float(rates[-1]):.2f} Hz"
+            except Exception:
+                pass
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({"status": "ok", "topic": topic, "hz": rate_val}).encode("utf-8"))
+            except Exception:
+                pass
+            return
+
+        if parsed.path == "/api/ros2/stream":
+            qs = parse_qs(parsed.query)
+            topic = qs.get("topic", ["/odom/unfiltered"])[0].strip()
+            mode = qs.get("mode", ["echo"])[0].strip()
+
+            setup_bash = ""
+            for distro in ["jazzy", "lyrical", "rolling"]:
+                p = f"/opt/ros/{distro}/setup.bash"
+                if os.path.exists(p):
+                    setup_bash = p
+                    break
+
+            if mode == "hz":
+                cmd = f"source {setup_bash} 2>/dev/null && stdbuf -oL -eL ros2 topic hz {topic}"
+            else:
+                cmd = f"source {setup_bash} 2>/dev/null && stdbuf -oL -eL ros2 topic echo {topic}"
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+
+            init_msg = json.dumps({"type": "start", "topic": topic, "mode": mode, "text": f"--- Streaming ROS 2 topic {topic} ({mode}) ---"})
+            try:
+                self.wfile.write(f"data: {init_msg}\n\n".encode("utf-8"))
+                self.wfile.flush()
+            except Exception:
+                return
+
+            proc = None
+            try:
+                proc = subprocess.Popen(
+                    ["bash", "-c", cmd],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    bufsize=1,
+                    preexec_fn=os.setsid
+                )
+
+                for line in iter(proc.stdout.readline, ""):
+                    if not line:
+                        break
+                    line_data = json.dumps({"type": "line", "text": line.rstrip()})
+                    self.wfile.write(f"data: {line_data}\n\n".encode("utf-8"))
+                    self.wfile.flush()
+            except Exception:
+                pass
+            finally:
+                if proc:
+                    try:
+                        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                    except Exception:
+                        pass
+                    try:
+                        proc.kill()
+                    except Exception:
+                        pass
+            return
+
+        if parsed.path == "/api/gitinfo":
+            # Git provenance for the header version badge: the 7-char commit the
+            # server booted on, plus the live branch / remotes / last 10 commits
+            # shown when the badge is clicked.
+            info = collect_git_info()
+            info["version_at_start"] = GIT_VERSION_AT_START
+            info["moved_since_start"] = (
+                info.get("version") != GIT_VERSION_AT_START
+                and GIT_VERSION_AT_START != "unknown"
+            )
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps(info).encode("utf-8"))
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            return
+
+        if parsed.path == "/api/boards":
+            # Parse firmware/platformio.ini and return all board environments
+            # with their config file path, transport mode, and baud rate.
+            ini_path = os.path.join(REPO_ROOT, "firmware", "platformio.ini")
+            boards = []
+            try:
+                boards = _parse_platformio_boards(ini_path)
+            except Exception as e:
+                pass
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({"status": "ok", "boards": boards}).encode("utf-8"))
+            except Exception:
+                pass
+            return
+
+        if parsed.path == "/api/status":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            host_info = get_robot_host_info()
+            status_data = {
+                "status": "ok",
+                "exec_supported": True,
+                "os": host_info["system"],
+                "node": host_info["node"],
+                "release": host_info["release"],
+                "machine": host_info["machine"],
+                "distro_id": host_info["distro_id"],
+                "distro_name": host_info["distro_name"],
+                "has_apt": host_info["has_apt"],
+                "has_dnf": host_info["has_dnf"],
+                "has_distrobox": host_info["has_distrobox"],
+                "is_container": host_info["is_container"],
+                "has_pio": host_info["has_pio"],
+                "installed_ros_distros": host_info["installed_ros_distros"],
+                "serial_ports": host_info["serial_ports"],
+                "port_details": host_info.get("port_details", []),
+                "has_dialout": host_info.get("has_dialout", False),
+                "host_ip": SyslogManager._host_ip(),
+                "repo_root": REPO_ROOT
+            }
+            try:
+                self.wfile.write(json.dumps(status_data).encode("utf-8"))
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            return
+
+        if parsed.path == "/api/configs":
+            # List available custom configurations in config/custom/
+            custom_dir = os.path.join(REPO_ROOT, "config", "custom")
+            configs = []
+            if os.path.isdir(custom_dir):
+                for f in sorted(os.listdir(custom_dir)):
+                    if f.endswith("_config.h"):
+                        full_path = os.path.join(custom_dir, f)
+                        try:
+                            with open(full_path, "r", encoding="utf-8") as hf:
+                                content = hf.read()
+                                spec = parse_header_to_spec(content)
+                                configs.append({
+                                    "filename": f,
+                                    "path": os.path.relpath(full_path, REPO_ROOT),
+                                    "robot_name": spec.get("robot_name", f[:-9]),
+                                    "kinematics": spec.get("kinematics", "UNKNOWN"),
+                                    "mcu": spec.get("mcu", "UNKNOWN"),
+                                    "imu": spec.get("sensors", {}).get("imu_type", "UNKNOWN"),
+                                    "mag": spec.get("sensors", {}).get("mag_type", "UNKNOWN"),
+                                    "wifi": spec.get("telemetry", {}).get("use_wifi", False),
+                                    "content": content
+                                })
+                        except Exception:
+                            pass
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({"configs": configs}).encode("utf-8"))
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            return
+
+        try:
+            return super().do_GET()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS, HEAD")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def do_POST(self):
+        global active_process
+        parsed = urlparse(self.path)
+
+        if parsed.path == "/api/workflow/settings":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                data = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                data = {}
+            saved = save_workflow_settings(data)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps({"status": "ok", "settings": saved}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/docker/status":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(check_container_status()).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/docker/rootless_info":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(get_rootless_info()).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/docker/setup_rootless":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(setup_rootless_docker()).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/container/install":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                data = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                data = {}
+            eng = data.get("engine", "docker")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(install_container_engine(eng)).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/docker/setup_rootless":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(setup_rootless_docker()).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/container/install":
+            qs = parse_qs(parsed.query)
+            eng = qs.get("engine", ["docker"])[0]
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(install_container_engine(eng)).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/remote/config":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                data = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                data = {}
+            saved = save_remote_config(data)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps({"status": "ok", "config": saved}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/docker/install":
+            cmd = "curl -fsSL https://get.docker.com | sh 2>/dev/null && sudo usermod -a -G docker $USER 2>/dev/null || true"
+            try:
+                res = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=120)
+                ok = shutil.which("docker") is not None
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"ok": ok, "output": res.stdout[-300:]}).encode("utf-8"))
+            except Exception as e:
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"ok": False, "error": str(e)}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/remote/test":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                data = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                data = {}
+            cfg = load_remote_config()
+            cfg.update(data)
+            res = test_remote_ssh(cfg)
+            self.send_response(200 if res.get("ok") else 400)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(res).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/remote/chip_id":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                data = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                data = {}
+            cfg = load_remote_config()
+            cfg.update(data)
+            port = data.get("port", cfg.get("remote_serial_port", "/dev/ttyUSB0"))
+            res = get_remote_chip_id(cfg, port)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(res).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/agent/port_check":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                data = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                data = {}
+            port = data.get("port", "/dev/ttyUSB0")
+            mode = data.get("mode", "serial")
+            udp_port = int(data.get("udp_port", 8888))
+            host = data.get("host", "")
+            user = data.get("user", "ubuntu")
+            res = check_agent_port_status(port, mode, udp_port, host=host if host else None, user=user)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(res).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/agent/port_release":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                data = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                data = {}
+            port = data.get("port", "/dev/ttyUSB0")
+            mode = data.get("mode", "serial")
+            udp_port = int(data.get("udp_port", 8888))
+            host = data.get("host", "")
+            user = data.get("user", "ubuntu")
+            res = release_agent_port(port, mode, udp_port, host=host if host else None, user=user)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(res).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/remote/microros_agent":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                data = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                data = {}
+            cfg = load_remote_config()
+            action = data.get("action", "status")
+            distro = data.get("distro", "jazzy")
+            port = data.get("port", cfg.get("remote_serial_port", "/dev/ttyUSB0"))
+            baud = data.get("baud", str(cfg.get("remote_baud", 1500000)))
+            res = manage_remote_microros_agent(cfg, action, distro, port, baud)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(res).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/syslog/start":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                data = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                data = {}
+            req_port = data.get("port", 514)
+            try:
+                res = syslog_manager.start(req_port)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps(res).encode("utf-8"))
+            except Exception as e:
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(e)}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/syslog/stop":
+            res = syslog_manager.stop()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(res).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/load_board_config":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                data = json.loads(body.decode("utf-8")) if body else {}
+            except Exception:
+                data = {}
+            env_name = data.get("env", "")
+            try:
+                ini_path = os.path.join(REPO_ROOT, "firmware", "platformio.ini")
+                boards = _parse_platformio_boards(ini_path)
+                board_info = next((b for b in boards if b["env"] == env_name), None)
+                if not board_info:
+                    raise ValueError(f"Board environment '{env_name}' not found in platformio.ini")
+                config_rel = board_info.get("config_file", "")
+                if not config_rel:
+                    raise ValueError(f"No config file mapped for environment '{env_name}'")
+                config_path = os.path.join(REPO_ROOT, config_rel)
+                if not os.path.isfile(config_path):
+                    raise FileNotFoundError(f"Config file not found: {config_path}")
+                with open(config_path, "r", encoding="utf-8") as hf:
+                    header_content = hf.read()
+                spec = parse_header_to_spec(header_content)
+                # The board header pulls WiFi creds from the git-ignored
+                # config/custom/wifi_config.h via __has_include — read them so
+                # the form shows the real SSID / password / host IPs.
+                merge_wifi_config(spec, _wifi_config_content())
+                # Override transport/wifi from platformio.ini flags (authoritative)
+                if board_info.get("wifi"):
+                    spec["telemetry"]["use_wifi"] = True
+                    spec["telemetry"]["transport"] = "WIFI_UDP"
+                else:
+                    spec["telemetry"]["use_wifi"] = False
+                    spec["telemetry"]["transport"] = "SERIAL"
+                if board_info.get("monitor_speed"):
+                    spec["telemetry"]["baudrate"] = board_info["monitor_speed"]
+                # MCU family from platformio.ini platform=/board= (authoritative);
+                # env-name map is only a fallback for odd/legacy envs.
+                pio_mcu = _mcu_from_platformio(board_info.get("platform", ""),
+                                               board_info.get("board", ""), env_name)
+                env_to_mcu = {
+                    "gendrv": "GENDRV", "gendrv_wifi": "GENDRV",
+                    "esp32": "ESP32", "esp32_wifi": "ESP32",
+                    "esp32s2": "ESP32S2", "esp32s2_wifi": "ESP32S2",
+                    "esp32s3": "ESP32S3", "esp32s3_wifi": "ESP32S3",
+                    "pico": "PICO", "picow": "PICOW", "picow_wifi": "PICOW",
+                    "pico2": "PICO2", "pico2w": "PICO2W", "pico2w_wifi": "PICO2W",
+                    "teensy41": "TEENSY", "teensy40": "TEENSY",
+                    "teensy36": "TEENSY", "teensy35": "TEENSY", "teensy31": "TEENSY",
+                    "vattenkar": "TEENSY",
+                }
+                if pio_mcu:
+                    spec["mcu"] = pio_mcu
+                elif env_name in env_to_mcu:
+                    spec["mcu"] = env_to_mcu[env_name]
+                # Attach board metadata
+                spec["_board_env"] = env_name
+                spec["_board_info"] = board_info
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"status": "ok", "spec": spec, "board": board_info}).encode("utf-8"))
+            except Exception as e:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(e)}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/parse":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+            try:
+                data = json.loads(body.decode("utf-8"))
+                content = data.get("content", "")
+                if data.get("is_json", False):
+                    spec = json.loads(content)
+                else:
+                    spec = parse_header_to_spec(content)
+                    if '__has_include("wifi_config.h")' in content or "WIFI_AP_LIST" in content:
+                        merge_wifi_config(spec, _wifi_config_content())
+
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"status": "ok", "spec": spec}).encode("utf-8"))
+            except Exception as e:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": f"Parse error: {e}"}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/merge":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+            try:
+                data = json.loads(body.decode("utf-8"))
+                base_spec = data.get("base_spec", {})
+                override_spec = data.get("override_spec", {})
+                if not base_spec and "base_content" in data:
+                    base_spec = parse_header_to_spec(data["base_content"])
+
+                merged_spec, changes = merge_configurations(base_spec, override_spec)
+                generated_header = generate_config_header(merged_spec)
+
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    "status": "ok",
+                    "merged_spec": merged_spec,
+                    "changes": changes,
+                    "header": generated_header
+                }).encode("utf-8"))
+            except Exception as e:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": f"Merge error: {e}"}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/save":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+            try:
+                data = json.loads(body.decode("utf-8"))
+                filename = data.get("filename", "")
+                header_content = data.get("header", "")
+                if not filename:
+                    robot_name = data.get("spec", {}).get("robot_name", "custom")
+                    filename = f"{robot_name}_config.h"
+
+                save_path = os.path.join(REPO_ROOT, "config", "custom", filename)
+                os.makedirs(os.path.dirname(save_path), exist_ok=True)
+                with open(save_path, "w", encoding="utf-8") as sf:
+                    sf.write(header_content)
+
+                # WiFi credentials (if any) go to the git-ignored wifi_config.h,
+                # never into the tracked robot header. Don't clobber an existing one.
+                wifi_config = data.get("wifi_config", "") or ""
+                wifi_written = False
+                wifi_path = os.path.join(REPO_ROOT, "config", "custom", "wifi_config.h")
+                if wifi_config.strip() and not os.path.exists(wifi_path):
+                    with open(wifi_path, "w", encoding="utf-8") as wf:
+                        wf.write(wifi_config)
+                    wifi_written = True
+
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    "status": "saved",
+                    "path": os.path.relpath(save_path, REPO_ROOT),
+                    "filename": filename,
+                    "wifi_config_written": wifi_written
+                }).encode("utf-8"))
+            except Exception as e:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": f"Save error: {e}"}).encode("utf-8"))
+            return
+
+        if parsed.path == "/api/kill":
+            with active_process_lock:
+                if active_process and active_process.poll() is None:
+                    try:
+                        active_process.terminate()
+                        time.sleep(0.2)
+                        if active_process.poll() is None:
+                            active_process.kill()
+                    except Exception:
+                        pass
+                    active_process = None
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            try:
+                self.wfile.write(json.dumps({"status": "killed"}).encode("utf-8"))
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            return
+
+        if parsed.path == "/api/exec":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+            try:
+                data = json.loads(body.decode("utf-8"))
+            except Exception as e:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": f"Invalid JSON: {e}"}).encode("utf-8"))
+                return
+
+            command = data.get("command", "").strip()
+            cwd = data.get("cwd", REPO_ROOT)
+            if not os.path.isabs(cwd):
+                cwd = os.path.join(REPO_ROOT, cwd)
+
+            if not command:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "Empty command"}).encode("utf-8"))
+                return
+
+            # Single-flight: one build/deploy at a time. Without this a tab that
+            # crashed mid-deploy and was reopened could start a second parallel
+            # `pio` compile -- ~4 heavy cc1plus jobs on a 4 GB SBC, i.e. OOM.
+            with active_process_lock:
+                busy = active_process is not None and active_process.poll() is None
+            if busy:
+                self.send_response(409)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    "error": "A command is already running. Stop it (Cancel) before starting another."
+                }).encode("utf-8"))
+                return
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+
+            env = os.environ.copy()
+            env["PYTHONUNBUFFERED"] = "1"
+            penv_path = os.path.expanduser("~/.platformio/penv/bin")
+            local_bin = os.path.expanduser("~/.local/bin")
+            env["PATH"] = f"{penv_path}:{local_bin}:{env.get('PATH', '')}"
+            ros_distro = (data.get("ros_distro") or "").strip()
+            if not ros_distro:
+                ros_distro = env.get("ROS_DISTRO") or "jazzy"
+            env["ROS_DISTRO"] = ros_distro
+
+            client_gone = False
+
+            def send_event(event_type, payload):
+                nonlocal client_gone
+                msg = f"event: {event_type}\ndata: {json.dumps(payload)}\n\n"
+                try:
+                    self.wfile.write(msg.encode("utf-8"))
+                    self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    client_gone = True
+
+            # Adaptive execution: on a bare host that lacks /opt/ros, route ROS commands into
+            # the distrobox named after the requested distro. Never do this when we are already
+            # inside a container -- nested `distrobox enter` is unsupported and would hang or fail.
+            has_distrobox = shutil.which("distrobox") is not None
+            has_host_ros = os.path.exists("/opt/ros")
+            is_deploy = ("EOF_DEPLOY_SCRIPT_WRAPPER" in command) or ("deploy_" in command)
+            needs_ros = ("ros2" in command or "source /opt/ros" in command) and not is_deploy
+            if IN_CONTAINER:
+                if needs_ros and not has_host_ros:
+                    send_event("output", {
+                        "line": f"[INFO] Running inside container '{os.environ.get('CONTAINER_ID', 'container')}'; "
+                                f"executing directly (no nested distrobox).\n"
+                    })
+            elif (not has_host_ros) and has_distrobox and needs_ros:
+                try:
+                    res = subprocess.run(["distrobox", "list"], capture_output=True, text=True, timeout=2.0)
+                    box_exists = ros_distro in res.stdout
+                except Exception:
+                    box_exists = False
+                if box_exists:
+                    escaped_cmd = command.replace("\\", "\\\\").replace('"', '\\"')
+                    command = (
+                        f'distrobox enter {ros_distro} -- bash -c '
+                        f'"source /opt/ros/{ros_distro}/setup.bash 2>/dev/null; '
+                        f'[ -f $HOME/uros_ws/install/setup.bash ] && source $HOME/uros_ws/install/setup.bash; '
+                        f'{escaped_cmd}"'
+                    )
+
+            send_event("start", {"command": command, "cwd": cwd})
+
+                        # Proactively stop serial-transport micro-ROS agent and free USB port if flashing (WiFi agent kept running)
+            if any(k in command for k in ["-t upload", "picotool", "flash", "deploy"]):
+                try:
+                    subprocess.run(["pkill", "-f", "micro_ros_agent.*serial"], capture_output=True, timeout=2.0)
+                    subprocess.run(["pkill", "-f", "micro_ros_agent.*multiserial"], capture_output=True, timeout=2.0)
+                    subprocess.run(["pkill", "-f", "miniterm"], capture_output=True, timeout=2.0)
+                except Exception:
+                    pass
+
+            try:
+                with active_process_lock:
+                    active_process = subprocess.Popen(
+                        command,
+                        cwd=cwd,
+                        shell=True,
+                        executable="/bin/bash",
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        bufsize=1,
+                        env=env,
+                        preexec_fn=os.setsid if hasattr(os, "setsid") else None
+                    )
+
+                if active_process and active_process.stdout:
+                    for line in iter(active_process.stdout.readline, ""):
+                        if not line:
+                            break
+                        send_event("output", {"line": line, "text": line})
+                        if client_gone:
+                            # Browser closed/crashed: kill the whole process
+                            # group so a long build doesn't run unwatched.
+                            try:
+                                os.killpg(os.getpgid(active_process.pid), signal.SIGTERM)
+                                active_process.wait(timeout=5)
+                            except subprocess.TimeoutExpired:
+                                try:
+                                    os.killpg(os.getpgid(active_process.pid), signal.SIGKILL)
+                                except Exception:
+                                    pass
+                            except Exception:
+                                pass
+                            break
+
+                active_process.wait()
+                exit_code = active_process.returncode
+                send_event("done", {"code": exit_code, "exit_code": exit_code})
+            except Exception as e:
+                send_event("error", {"error": str(e)})
+            finally:
+                with active_process_lock:
+                    active_process = None
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+
+if __name__ == "__main__":
+    print(f"============================================================")
+    print(f" Linorobot2 Robot Configuration Engine & Web Studio")
+    print(f" Live HTTP Server listening on port {PORT}")
+    print(f" Web UI: http://localhost:{PORT}")
+    print(f" Repository Root: {REPO_ROOT}")
+    print(f" Press Ctrl+C to terminate.")
+    print(f"============================================================")
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), LinorobotEngineHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down server...")
+        server.server_close()

--- a/tools/robot_config_engine/web/style.css
+++ b/tools/robot_config_engine/web/style.css
@@ -52,8 +52,10 @@ body {
   color: var(--text-main);
   min-height: 100vh;
   line-height: 1.5;
-  overflow-x: hidden;
   position: relative;
+  /* No overflow-x:hidden — it silently clipped anything wider than the
+     viewport (common when the browser is zoomed in) with no way to scroll
+     to it. Wide inner content instead scrolls inside its own container. */
 }
 
 /* Background Glowing Orbs */
@@ -93,8 +95,10 @@ body {
   top: 0;
   z-index: 50;
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
+  gap: 0.75rem 1.5rem;
   padding: 1rem 2rem;
   background: rgba(9, 13, 22, 0.85);
   backdrop-filter: blur(16px);
@@ -106,6 +110,148 @@ body {
   display: flex;
   align-items: center;
   gap: 1rem;
+}
+
+/* Header stack: robot name, branch, git version, reference build */
+.reference-build-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 360px;
+}
+.git-version-row {
+  position: relative;
+  display: flex;
+}
+
+/* Compact labelled field pills in the header stack */
+.hdr-field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-card-elevated);
+  padding: 0.3rem 0.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+}
+.hdr-field > label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.hdr-input.form-input {
+  flex: 1;
+  min-width: 120px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: #a5b4fc;
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+.hdr-btn {
+  flex-shrink: 0;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: var(--transition-fast);
+}
+.hdr-btn:hover {
+  color: var(--text-main);
+  border-color: var(--border-glow);
+}
+
+/* Git Version Badge + Popover */
+.git-version-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.6rem;
+  background: var(--bg-card-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9999px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+.git-version-badge:hover,
+.git-version-badge[aria-expanded="true"] {
+  border-color: var(--border-glow);
+  color: var(--text-main);
+  box-shadow: var(--shadow-glow);
+}
+.git-version-badge.is-dirty {
+  color: #fbbf24;
+  border-color: rgba(251, 191, 36, 0.4);
+}
+.git-version-badge svg { opacity: 0.7; flex-shrink: 0; }
+
+.git-version-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 60;
+  width: 440px;
+  max-width: min(90vw, 480px);
+  max-height: 72vh;
+  overflow-y: auto;
+  padding: 1rem 1.1rem;
+  background: rgba(9, 13, 22, 0.98);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.55);
+  font-size: 0.8rem;
+  color: var(--text-main);
+}
+.git-version-popover[hidden] { display: none; }
+.git-version-popover h4 {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin: 0.9rem 0 0.35rem;
+}
+.git-version-popover h4:first-child { margin-top: 0; }
+.git-version-popover .gv-line {
+  display: flex;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  padding: 0.12rem 0;
+}
+.git-version-popover .gv-key { color: var(--text-muted); min-width: 88px; flex-shrink: 0; }
+.git-version-popover .gv-val { color: var(--text-main); word-break: break-all; }
+.git-version-popover .gv-remote-name { color: #a5b4fc; }
+.git-version-popover ol.gv-commits { list-style: none; margin: 0; padding: 0; }
+.git-version-popover ol.gv-commits li {
+  padding: 0.35rem 0;
+  border-top: 1px solid var(--border-subtle);
+}
+.git-version-popover ol.gv-commits li:first-child { border-top: none; }
+.git-version-popover .gv-hash { font-family: var(--font-mono); color: #06b6d4; }
+.git-version-popover .gv-subject { color: var(--text-main); }
+.git-version-popover .gv-meta { color: var(--text-muted); font-size: 0.7rem; }
+.git-version-popover .gv-note {
+  color: #fbbf24;
+  font-size: 0.72rem;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border-subtle);
 }
 
 .brand-logo {
@@ -148,6 +294,7 @@ body {
 
 .header-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.85rem;
 }
@@ -276,11 +423,13 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  min-width: 0; /* let the 1.15fr / 1fr grid columns shrink instead of forcing page-wide overflow */
 }
 
 /* Nav Tabs */
 .nav-tabs {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
   background: var(--bg-card);
   backdrop-filter: blur(12px);
@@ -291,7 +440,8 @@ body {
 }
 
 .nav-tab {
-  flex: 1;
+  flex: 1 1 110px;
+  min-width: 0;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/tools/robot_config_engine/web/style.css
+++ b/tools/robot_config_engine/web/style.css
@@ -1,0 +1,2302 @@
+/* ==========================================================================
+   Linorobot2 Robot Configuration Engine - Modern Dark Glassmorphism CSS
+   ========================================================================== */
+
+:root {
+  --bg-main: #090d16;
+  --bg-card: rgba(17, 24, 39, 0.75);
+  --bg-card-elevated: rgba(30, 41, 59, 0.7);
+  --bg-input: rgba(15, 23, 42, 0.85);
+  --bg-code: #070a11;
+
+  --border-subtle: rgba(255, 255, 255, 0.08);
+  --border-focus: #6366f1;
+  --border-glow: rgba(99, 102, 241, 0.35);
+
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --text-dim: #64748b;
+
+  --accent-primary: #6366f1;
+  --accent-primary-hover: #4f46e5;
+  --accent-cyan: #06b6d4;
+  --accent-emerald: #10b981;
+  --accent-purple: #a855f7;
+  --accent-amber: #f59e0b;
+  --accent-rose: #f43f5e;
+
+  --font-sans: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
+
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+  --radius-xl: 20px;
+
+  --shadow-card: 0 10px 25px -5px rgba(0, 0, 0, 0.4), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
+  --shadow-glow: 0 0 20px rgba(99, 102, 241, 0.25);
+  --transition-fast: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-smooth: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Reset & Box Sizing */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--bg-main);
+  color: var(--text-main);
+  min-height: 100vh;
+  line-height: 1.5;
+  overflow-x: hidden;
+  position: relative;
+}
+
+/* Background Glowing Orbs */
+.bg-glow {
+  position: fixed;
+  border-radius: 50%;
+  filter: blur(120px);
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.35;
+}
+.glow-1 {
+  width: 500px;
+  height: 500px;
+  background: radial-gradient(circle, #6366f1, transparent);
+  top: -150px;
+  left: -150px;
+}
+.glow-2 {
+  width: 600px;
+  height: 600px;
+  background: radial-gradient(circle, #06b6d4, transparent);
+  bottom: -200px;
+  right: -200px;
+}
+.glow-3 {
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(circle, #a855f7, transparent);
+  top: 40%;
+  left: 45%;
+}
+
+/* App Header */
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: rgba(9, 13, 22, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.header-brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand-logo {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, #6366f1, #06b6d4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  box-shadow: 0 0 15px rgba(99, 102, 241, 0.4);
+}
+
+.brand-title {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.badge-accent {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  background: rgba(99, 102, 241, 0.2);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  border-radius: 999px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.brand-subtitle {
+  font-size: 0.825rem;
+  color: var(--text-muted);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.preset-selector-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-card-elevated);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+}
+
+.preset-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.preset-select {
+  background: transparent;
+  border: none;
+  color: #a5b4fc;
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  font-weight: 600;
+  outline: none;
+  cursor: pointer;
+}
+
+.preset-select option {
+  background: #111827;
+  color: var(--text-main);
+}
+
+/* Button System */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1.1rem;
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-decoration: none;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent-primary), #4f46e5);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
+}
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(99, 102, 241, 0.45);
+}
+
+.btn-secondary {
+  background: var(--bg-card-elevated);
+  color: var(--text-main);
+  border-color: var(--border-subtle);
+}
+.btn-secondary:hover {
+  background: rgba(45, 55, 72, 0.8);
+  border-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.btn-accent {
+  background: linear-gradient(135deg, var(--accent-cyan), #0891b2);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(6, 182, 212, 0.3);
+}
+.btn-accent:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(6, 182, 212, 0.45);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-muted);
+  border-color: var(--border-subtle);
+}
+.btn-ghost:hover {
+  color: var(--text-main);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.btn-sm {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+.github-link {
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  padding: 0.5rem;
+  border-radius: var(--radius-md);
+  transition: color var(--transition-fast);
+}
+.github-link:hover {
+  color: var(--text-main);
+}
+
+/* App Main Container Grid */
+.app-container {
+  position: relative;
+  z-index: 1;
+  max-width: 1680px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 1.5rem;
+}
+
+/* Panels */
+.config-panel, .dashboard-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* Nav Tabs */
+.nav-tabs {
+  display: flex;
+  gap: 0.5rem;
+  background: var(--bg-card);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  padding: 0.4rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-subtle);
+}
+
+.nav-tab {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.5rem;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.nav-tab:hover {
+  color: var(--text-main);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.nav-tab.active {
+  color: #fff;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.35), rgba(6, 182, 212, 0.25));
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+/* Tab Content */
+.tab-content-wrapper {
+  background: var(--bg-card);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-subtle);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-card);
+}
+
+.tab-pane {
+  display: none;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+.tab-pane.active {
+  display: flex;
+  animation: fadeIn 0.2s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Form Styles */
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-main);
+  letter-spacing: -0.01em;
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: 0.6rem;
+}
+
+.section-header-flex {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: 0.6rem;
+}
+.section-header-flex .section-title {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.sub-title {
+  font-size: 0.925rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-label {
+  font-size: 0.825rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.form-input, .form-select {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-main);
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  outline: none;
+  transition: all var(--transition-fast);
+}
+
+.form-input:focus, .form-select:focus {
+  border-color: var(--border-focus);
+  box-shadow: 0 0 0 3px var(--border-glow);
+}
+
+.form-select option {
+  background: #111827;
+  color: var(--text-main);
+}
+
+.input-hint {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+
+.sub-panel {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.checkbox-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.checkbox-label input[type="checkbox"] {
+  accent-color: var(--accent-primary);
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+/* Pinout Tables */
+.pin-table-wrapper {
+  overflow-x: auto;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+}
+
+.pin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  text-align: left;
+}
+
+.pin-table th {
+  background: rgba(15, 23, 42, 0.9);
+  padding: 0.65rem 0.85rem;
+  color: var(--text-muted);
+  font-weight: 600;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.pin-table td {
+  padding: 0.5rem 0.85rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.pin-table tr:last-child td {
+  border-bottom: none;
+}
+
+.pin-input {
+  max-width: 90px;
+  padding: 0.4rem 0.6rem;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  text-align: center;
+}
+
+/* Right Dashboard Column */
+
+/* HUD Card */
+.hud-card {
+  background: var(--bg-card);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-subtle);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-card);
+}
+
+.hud-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.hud-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.hud-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(6, 182, 212, 0.15);
+  color: var(--accent-cyan);
+  border: 1px solid rgba(6, 182, 212, 0.35);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.85rem;
+}
+
+.metric-card {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.metric-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.metric-val-wrap {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.metric-val {
+  font-family: var(--font-mono);
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(135deg, #fff, #a5b4fc);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.metric-unit {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.metric-sub {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* Safety Inspector Card */
+.safety-card {
+  background: var(--bg-card);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-subtle);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-card);
+  transition: all var(--transition-smooth);
+}
+
+.safety-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.safety-indicator-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.status-ok {
+  background: var(--accent-emerald);
+  box-shadow: 0 0 10px var(--accent-emerald);
+}
+.status-err {
+  background: var(--accent-rose);
+  box-shadow: 0 0 10px var(--accent-rose);
+  animation: pulse 1.5s infinite;
+}
+.status-warn {
+  background: var(--accent-amber);
+  box-shadow: 0 0 10px var(--accent-amber);
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.6; transform: scale(1.15); }
+}
+
+.safety-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.safety-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+}
+.badge-ok {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--accent-emerald);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+.badge-err {
+  background: rgba(244, 63, 94, 0.15);
+  color: var(--accent-rose);
+  border: 1px solid rgba(244, 63, 94, 0.4);
+}
+.badge-warn {
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--accent-amber);
+  border: 1px solid rgba(245, 158, 11, 0.4);
+}
+
+.safety-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.safety-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: var(--radius-md);
+  font-size: 0.825rem;
+}
+.item-ok {
+  background: rgba(16, 185, 129, 0.08);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  color: #a7f3d0;
+}
+.item-err {
+  background: rgba(244, 63, 94, 0.1);
+  border: 1px solid rgba(244, 63, 94, 0.35);
+  color: #fecdd3;
+}
+.item-warn {
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  color: #fde68a;
+}
+
+/* Artifacts Code Card */
+.artifacts-card {
+  background: var(--bg-card);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+}
+
+.artifacts-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 1rem;
+  background: rgba(15, 23, 42, 0.9);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.artifact-tabs {
+  display: flex;
+  gap: 0.35rem;
+  overflow-x: auto;
+}
+
+.artifact-tab {
+  padding: 0.4rem 0.75rem;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  font-weight: 600;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+}
+.artifact-tab:hover {
+  color: var(--text-main);
+  background: rgba(255, 255, 255, 0.05);
+}
+.artifact-tab.active {
+  color: #a5b4fc;
+  background: rgba(99, 102, 241, 0.2);
+  border-color: rgba(99, 102, 241, 0.4);
+}
+
+.artifact-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.code-viewer-wrap {
+  position: relative;
+  background: var(--bg-code);
+  min-height: 200px;
+  height: 440px;
+  max-height: 90vh;
+  /* user-resizable: drag the bottom-right grip */
+  resize: vertical;
+  overflow: auto;
+  padding: 1.25rem;
+}
+
+.code-viewer {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: #e2e8f0;
+  tab-size: 2;
+  white-space: pre;
+}
+
+/* Toast Notification */
+.toast {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: rgba(16, 185, 129, 0.95);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: var(--radius-lg);
+  font-weight: 600;
+  font-size: 0.875rem;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
+  transform: translateY(100px);
+  opacity: 0;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 100;
+}
+.toast.show {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+/* Utility Helpers */
+.mt-4 { margin-top: 1rem; }
+.mb-3 { margin-bottom: 0.75rem; }
+
+/* Responsive Media Queries */
+@media (max-width: 1200px) {
+  .app-container {
+    grid-template-columns: 1fr;
+  }
+  .metrics-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1rem;
+  }
+  .header-actions {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+  .metrics-grid {
+    grid-template-columns: 1fr;
+  }
+  .nav-tabs {
+    flex-wrap: wrap;
+  }
+  .nav-tab {
+    flex: 1 1 45%;
+  }
+}
+
+
+/* ==========================================================================
+   Automation Hub, OS Detection, Deploy Scripts & Web Serial Console
+   ========================================================================== */
+
+/* Header OS Badge & Accent Button */
+.os-quick-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.85rem;
+  background: var(--bg-card-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9999px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-main);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  transition: var(--transition-fast);
+}
+.os-quick-badge:hover {
+  border-color: var(--border-glow);
+  box-shadow: var(--shadow-glow);
+}
+.os-badge-icon {
+  font-size: 1.1rem;
+}
+
+.btn-accent {
+  background: linear-gradient(135deg, #06b6d4, #6366f1);
+  color: #ffffff;
+  box-shadow: 0 4px 14px rgba(6, 182, 212, 0.35);
+  border: none;
+}
+.btn-accent:hover {
+  background: linear-gradient(135deg, #0891b2, #4f46e5);
+  box-shadow: 0 6px 20px rgba(6, 182, 212, 0.5);
+  transform: translateY(-1px);
+}
+
+/* OS Detection Banner */
+.os-detect-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.5rem;
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.95));
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 8px 24px -6px rgba(0, 0, 0, 0.5), 0 0 15px rgba(99, 102, 241, 0.15);
+  margin-top: 1rem;
+  position: relative;
+  overflow: hidden;
+}
+.os-detect-banner::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, #6366f1, #06b6d4, #10b981);
+}
+
+.os-detect-info {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+.os-icon-large {
+  font-size: 2.25rem;
+  filter: drop-shadow(0 0 12px rgba(6, 182, 212, 0.4));
+}
+.os-banner-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-main);
+}
+.os-banner-sub {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-top: 0.2rem;
+}
+
+/* Badge Pills */
+.badge-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.65rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.badge-pill.badge-ok {
+  background: rgba(16, 185, 129, 0.15);
+  color: #34d399;
+  border: 1px solid rgba(16, 185, 129, 0.35);
+}
+.badge-pill.badge-warn {
+  background: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+}
+.badge-pill.badge-err {
+  background: rgba(244, 63, 94, 0.15);
+  color: #fb7185;
+  border: 1px solid rgba(244, 63, 94, 0.35);
+}
+.badge-pill.badge-accent {
+  background: rgba(99, 102, 241, 0.15);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+}
+
+/* Pulse Dot Animation */
+.pulse-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: currentColor;
+  position: relative;
+}
+.pulse-dot::after {
+  content: "";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  animation: pulse-ring 1.8s cubic-bezier(0.215, 0.61, 0.355, 1) infinite;
+}
+@keyframes pulse-ring {
+  0% { transform: scale(0.8); opacity: 0.9; }
+  80%, 100% { transform: scale(2.2); opacity: 0; }
+}
+
+/* Automation Options Grid */
+.automation-options-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+.automation-options-grid .checkbox-label {
+  padding: 0.85rem 1rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  font-size: 0.88rem;
+  line-height: 1.4;
+  color: var(--text-main);
+  transition: var(--transition-fast);
+}
+.automation-options-grid .checkbox-label:hover {
+  background: var(--bg-card-elevated);
+  border-color: var(--border-glow);
+}
+
+/* Quick Command Preview Boxes */
+.quick-cmd-box {
+  margin-top: 0.85rem;
+  background: var(--bg-code);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.quick-cmd-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: rgba(15, 23, 42, 0.95);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.quick-cmd-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--accent-cyan);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.quick-cmd-code {
+  padding: 0.85rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: #cbd5e1;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  line-height: 1.5;
+}
+
+/* Button Group Row */
+.btn-group-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.flex-1 {
+  flex: 1;
+  min-width: 180px;
+}
+
+/* Web Serial Live Diagnostics Console */
+.web-serial-console-card {
+  margin-top: 1rem;
+  background: #030712;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  border-radius: var(--radius-lg);
+  /* not 'hidden' — would clip the resizable terminal's grip / overflow */
+  overflow: visible;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.6);
+}
+.console-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.25rem;
+  background: rgba(15, 23, 42, 0.9);
+  border-bottom: 1px solid var(--border-subtle);
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+.console-controls-left,
+.console-controls-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.serial-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.serial-status-pill.pill-connected {
+  background: rgba(16, 185, 129, 0.15);
+  color: #10b981;
+  border: 1px solid rgba(16, 185, 129, 0.4);
+  box-shadow: 0 0 10px rgba(16, 185, 129, 0.2);
+}
+.serial-status-pill.pill-disconnected {
+  background: rgba(100, 116, 139, 0.15);
+  color: #94a3b8;
+  border: 1px solid rgba(100, 116, 139, 0.3);
+}
+
+.form-select-sm {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.82rem;
+  min-width: 150px;
+}
+.btn-xs {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+}
+.checkbox-label-sm {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.terminal-screen {
+  height: 260px;
+  /* user-resizable: drag the bottom-right grip to enlarge for long
+     ROS 2 topic messages / build logs */
+  resize: both;
+  min-height: 120px;
+  max-height: 90vh;
+  min-width: 320px;
+  max-width: 100%;
+  overflow: auto;
+  padding: 1rem 1.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  line-height: 1.6;
+  color: #e2e8f0;
+  background: radial-gradient(circle at top left, rgba(15, 23, 42, 0.6), transparent 70%), #040711;
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.8);
+}
+.terminal-line {
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+.terminal-dim {
+  color: #64748b;
+  font-style: italic;
+}
+.terminal-in {
+  color: #38bdf8;
+  font-weight: 500;
+}
+.terminal-out {
+  color: #a7f3d0;
+}
+.terminal-err {
+  color: #f43f5e;
+  font-weight: 600;
+}
+
+.terminal-input-bar {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  background: rgba(15, 23, 42, 0.95);
+  border-top: 1px solid var(--border-subtle);
+}
+.terminal-input {
+  flex: 1;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0.45rem 0.85rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: #f8fafc;
+  outline: none;
+  transition: var(--transition-fast);
+}
+.terminal-input:focus {
+  border-color: var(--border-focus);
+  box-shadow: 0 0 8px var(--border-glow);
+}
+
+
+/* Quick Command Actions Row */
+.quick-cmd-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.btn-danger {
+  background: rgba(244, 63, 94, 0.2);
+  color: #fb7185;
+  border: 1px solid rgba(244, 63, 94, 0.4);
+}
+.btn-danger:hover {
+  background: rgba(244, 63, 94, 0.35);
+  border-color: #f43f5e;
+}
+
+/* Local Runner Status Pill */
+.runner-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.runner-status-pill.pill-online {
+  background: rgba(16, 185, 129, 0.15);
+  color: #34d399;
+  border: 1px solid rgba(16, 185, 129, 0.4);
+  box-shadow: 0 0 10px rgba(16, 185, 129, 0.2);
+}
+.runner-status-pill.pill-offline {
+  background: rgba(148, 163, 184, 0.12);
+  color: #94a3b8;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+.runner-status-pill.pill-checking {
+  background: rgba(99, 102, 241, 0.15);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+}
+
+/* Direct 1-Click Upload Buttons Grid */
+.direct-upload-section {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 14px;
+}
+.direct-upload-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+.btn-direct-upload {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+.btn-direct-upload:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  border-color: var(--accent-primary);
+}
+.btn-direct-upload:active {
+  transform: translateY(0);
+}
+.direct-upload-icon {
+  font-size: 1.6rem;
+  line-height: 1;
+}
+.direct-upload-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+.direct-upload-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.direct-upload-title code {
+  color: var(--accent-secondary);
+  font-size: 0.9em;
+}
+.direct-upload-desc {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.direct-upload-badge {
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 4px 8px;
+  border-radius: 9999px;
+  background: rgba(14, 165, 233, 0.15);
+  color: #38bdf8;
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.btn-upload-sensors:hover .direct-upload-badge {
+  background: rgba(16, 185, 129, 0.2);
+  color: #34d399;
+  border-color: rgba(52, 211, 153, 0.4);
+}
+.btn-upload-motors:hover .direct-upload-badge {
+  background: rgba(245, 158, 11, 0.2);
+  color: #fbbf24;
+  border-color: rgba(251, 191, 36, 0.4);
+}
+.btn-upload-acc:hover .direct-upload-badge {
+  background: rgba(168, 85, 247, 0.2);
+  color: #c084fc;
+  border-color: rgba(192, 132, 252, 0.4);
+}
+.btn-upload-firmware:hover .direct-upload-badge {
+  background: rgba(14, 165, 233, 0.25);
+  color: #38bdf8;
+  border-color: rgba(56, 189, 248, 0.5);
+}
+
+/* Port Chips & Multi-Serial Styling */
+.port-chips-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 24px;
+}
+
+.chips-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-dim);
+}
+
+.chips-empty {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  font-style: italic;
+}
+
+/* USB VID:PID Port Chip Enhancements */
+.port-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 3px 9px;
+  background: rgba(99, 102, 241, 0.15);
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  border-radius: var(--radius-sm);
+  color: #a5b4fc;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.port-chip:hover {
+  background: rgba(99, 102, 241, 0.28);
+  border-color: #818cf8;
+  color: #ffffff;
+}
+
+.port-chip.port-chip-warn {
+  background: rgba(245, 158, 11, 0.15);
+  border-color: rgba(245, 158, 11, 0.45);
+  color: #fbbf24;
+}
+
+.port-chip.port-chip-warn:hover {
+  background: rgba(245, 158, 11, 0.28);
+  border-color: #fbbf24;
+  color: #fef08a;
+}
+
+.chip-vidpid {
+  font-size: 0.7rem;
+  color: #38bdf8;
+  background: rgba(56, 189, 248, 0.15);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.chip-desc {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.chip-lock {
+  font-size: 0.7rem;
+  color: #f87171;
+  font-weight: 600;
+}
+
+/* Base Port Chip */
+.old-port-chip {
+  padding: 2px 8px;
+  background: rgba(99, 102, 241, 0.15);
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  border-radius: var(--radius-sm);
+  color: #a5b4fc;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.port-chip:hover {
+  background: rgba(99, 102, 241, 0.3);
+  border-color: rgba(99, 102, 241, 0.6);
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.agent-config-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.form-label-xs {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.form-input-sm, .form-select-sm {
+  padding: 0.35rem 0.5rem;
+  font-size: 0.8rem;
+}
+
+/* ==========================================================================
+   ADC Calibration Studio & LUT Visualizer
+   ========================================================================== */
+.adc-studio-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-card);
+  margin-top: 1rem;
+}
+
+.adc-studio-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.adc-studio-title-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.adc-studio-icon {
+  font-size: 1.8rem;
+}
+
+.adc-studio-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.adc-studio-subtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.adc-studio-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.adc-setup-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: var(--radius-md);
+  padding: 0.6rem 0.9rem;
+  margin-bottom: 1.2rem;
+  font-size: 0.82rem;
+}
+
+.adc-setup-badge {
+  background: #f59e0b;
+  color: #000000;
+  font-weight: 700;
+  font-size: 0.72rem;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.adc-setup-text {
+  color: #fde68a;
+}
+
+.adc-studio-grid {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 1.25rem;
+}
+
+@media (max-width: 900px) {
+  .adc-studio-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.adc-chart-pane {
+  display: flex;
+  flex-direction: column;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 0.9rem;
+}
+
+.adc-chart-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.adc-chart-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.adc-chart-legend {
+  display: flex;
+  gap: 0.85rem;
+  font-size: 0.72rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--text-muted);
+}
+
+.legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.adc-canvas-container {
+  position: relative;
+  width: 100%;
+  height: 260px;
+  background: #090d16;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  overflow: hidden;
+}
+
+#adc-chart-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.adc-chart-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid #6366f1;
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.6rem;
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+  color: #ffffff;
+  box-shadow: var(--shadow-md);
+  z-index: 10;
+  white-space: nowrap;
+}
+
+.adc-metrics-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.adc-metric-box {
+  background: rgba(30, 41, 59, 0.5);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.metric-label {
+  font-size: 0.68rem;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.metric-val {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  margin-top: 2px;
+}
+
+.text-accent {
+  color: #a5b4fc !important;
+}
+
+.adc-lut-pane {
+  display: flex;
+  flex-direction: column;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 0.9rem;
+}
+
+.adc-lut-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.adc-lut-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.adc-lut-code-wrap {
+  flex: 1;
+  min-height: 220px;
+  max-height: 260px;
+  overflow-y: auto;
+  background: #090d16;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 0.6rem 0.75rem;
+}
+
+.adc-lut-code {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: #94a3b8;
+  line-height: 1.4;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.adc-status-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 0.75rem;
+  padding: 0.35rem 0.5rem;
+  background: rgba(30, 41, 59, 0.4);
+  border-radius: var(--radius-sm);
+}
+
+.btn-upload-adc:hover .direct-upload-badge {
+  background: rgba(234, 179, 8, 0.2);
+  color: #facc15;
+  border-color: rgba(250, 204, 21, 0.4);
+}
+
+/* ==========================================================================
+   ADC 3.0V Safety Banner & CAD Circuit Schematic
+   ========================================================================== */
+.adc-safety-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.85rem 1.15rem;
+  border-radius: var(--radius-md);
+  margin-top: 0.85rem;
+  transition: all var(--transition-normal);
+}
+
+.adc-safety-banner.safe {
+  background: rgba(16, 185, 129, 0.12);
+  border: 1px solid rgba(16, 185, 129, 0.35);
+  color: #a7f3d0;
+}
+.adc-safety-banner.safe .safety-banner-title {
+  color: #34d399;
+  font-weight: 700;
+  font-size: 0.92rem;
+}
+.adc-safety-banner.safe .safety-banner-desc {
+  color: #d1fae5;
+  font-size: 0.82rem;
+  margin-top: 0.15rem;
+}
+.adc-safety-banner.safe code {
+  color: #6ee7b7;
+  background: rgba(6, 78, 59, 0.5);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.adc-safety-banner.warning {
+  background: rgba(244, 63, 94, 0.18);
+  border: 1.5px solid rgba(244, 63, 94, 0.6);
+  box-shadow: 0 0 15px rgba(244, 63, 94, 0.25);
+  animation: pulse-warn 2s infinite;
+}
+.adc-safety-banner.warning .safety-banner-title {
+  color: #fb7185;
+  font-weight: 800;
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.adc-safety-banner.warning .safety-banner-desc {
+  color: #fecdd3;
+  font-size: 0.84rem;
+  margin-top: 0.2rem;
+  font-weight: 500;
+}
+.adc-safety-banner.warning code {
+  color: #ffffff;
+  background: rgba(159, 18, 57, 0.8);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 700;
+}
+
+@keyframes pulse-warn {
+  0%, 100% { box-shadow: 0 0 15px rgba(244, 63, 94, 0.25); }
+  50% { box-shadow: 0 0 25px rgba(244, 63, 94, 0.5); }
+}
+
+.safety-banner-icon {
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+/* CAD Circuit Schematic Card */
+.adc-cad-schematic-card {
+  background: #060913;
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: var(--radius-lg);
+  padding: 1.15rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+
+.schematic-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.85rem;
+}
+
+.schematic-title-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.schematic-icon {
+  font-size: 1.5rem;
+}
+
+.schematic-title {
+  font-size: 0.98rem;
+  font-weight: 700;
+  color: #e0f2fe;
+  margin: 0;
+}
+
+.schematic-subtitle {
+  font-size: 0.78rem;
+  color: #94a3b8;
+  margin: 0;
+}
+
+.schematic-badges {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.schematic-badge {
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid var(--border-subtle);
+  color: #94a3b8;
+}
+
+.schematic-badge.badge-safe {
+  background: rgba(16, 185, 129, 0.15);
+  border-color: rgba(16, 185, 129, 0.4);
+  color: #34d399;
+  font-weight: 600;
+}
+
+.schematic-badge.badge-warning {
+  background: rgba(244, 63, 94, 0.2);
+  border-color: rgba(244, 63, 94, 0.6);
+  color: #fb7185;
+  font-weight: 700;
+}
+
+.schematic-svg-container {
+  width: 100%;
+  overflow-x: auto;
+  background: #020617;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  padding: 0.75rem;
+}
+
+.schematic-svg {
+  width: 100%;
+  min-width: 680px;
+  height: auto;
+  display: block;
+}
+
+
+.port-chip-bootsel {
+  background: rgba(168, 85, 247, 0.18) !important;
+  border-color: rgba(168, 85, 247, 0.6) !important;
+  color: #c084fc !important;
+  animation: pulse-glow 2s infinite ease-in-out;
+}
+.port-chip-bootsel:hover {
+  background: rgba(168, 85, 247, 0.35) !important;
+  border-color: #a855f7 !important;
+  box-shadow: 0 0 12px rgba(168, 85, 247, 0.5);
+}
+
+/* Hero Deploy Card (Top of Tab 5) */
+.deploy-hero-card {
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.95), rgba(15, 23, 42, 0.98));
+  border: 2px solid rgba(59, 130, 246, 0.4);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35), 0 0 20px rgba(59, 130, 246, 0.15);
+  margin-bottom: 1.5rem;
+}
+.deploy-hero-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 0.75rem;
+}
+.deploy-hero-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #60a5fa;
+  margin: 0;
+}
+.deploy-hero-desc {
+  font-size: 0.85rem;
+  color: var(--text-muted, #94a3b8);
+  margin: 0.25rem 0 0 0;
+}
+.deploy-hero-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(34, 197, 94, 0.15);
+  border: 1px solid rgba(34, 197, 94, 0.4);
+  color: #4ade80;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: 20px;
+}
+.btn-hero-deploy {
+  font-size: 1rem !important;
+  padding: 0.75rem 1.5rem !important;
+  background: linear-gradient(135deg, #2563eb, #7c3aed) !important;
+  border: none !important;
+  box-shadow: 0 4px 14px rgba(37, 99, 235, 0.4) !important;
+  transition: all 0.2s ease-in-out !important;
+}
+.btn-hero-deploy:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(124, 58, 237, 0.6) !important;
+}
+.pulse-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 8px #22c55e;
+  animation: pulse-dot-anim 1.5s infinite;
+}
+@keyframes pulse-dot-anim {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.4); opacity: 0.6; }
+}
+
+/* ROS 2 Live Topic Inspector & Stream Controls */
+.ros2-stream-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.ros2-inspector-card {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.9));
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  border-radius: 12px;
+  padding: 1.25rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+.ros2-inspector-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 0.75rem;
+}
+.ros2-inspector-title-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.ros2-inspector-icon {
+  font-size: 1.5rem;
+}
+.ros2-inspector-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #38bdf8;
+  margin: 0;
+}
+.ros2-inspector-subtitle {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  margin: 0.2rem 0 0 0;
+}
+.ros2-topics-badge-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+}
+.ros2-topic-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 0.6rem 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+.ros2-topic-badge:hover {
+  border-color: #38bdf8;
+  background: rgba(56, 189, 248, 0.1);
+  transform: translateY(-2px);
+}
+.ros2-topic-badge.active {
+  border-color: #38bdf8;
+  background: rgba(56, 189, 248, 0.15);
+  box-shadow: 0 0 12px rgba(56, 189, 248, 0.3);
+}
+.topic-icon {
+  font-size: 1.25rem;
+}
+.topic-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+}
+.topic-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #f8fafc;
+  font-family: monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.topic-type {
+  font-size: 0.7rem;
+  color: #94a3b8;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.topic-hz-badge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #4ade80;
+  background: rgba(34, 197, 94, 0.15);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  padding: 0.2rem 0.5rem;
+  border-radius: 12px;
+}
+.ros2-live-hud-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.75rem;
+}
+.hud-metric-mini {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+}
+.hud-mini-label {
+  font-size: 0.7rem;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.hud-mini-val {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin-top: 0.2rem;
+}
+.text-cyan { color: #38bdf8 !important; }
+.text-green { color: #4ade80 !important; }
+.text-purple { color: #c084fc !important; }
+
+/* ROS 2 Topic Hz Table */
+.ros2-table-wrapper {
+  overflow-x: auto;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(10, 15, 29, 0.6);
+}
+.ros2-topic-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+.ros2-topic-table th {
+  background: rgba(30, 41, 59, 0.7);
+  padding: 0.65rem 0.85rem;
+  font-weight: 600;
+  color: #94a3b8;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  text-align: left;
+}
+.ros2-topic-table td {
+  padding: 0.6rem 0.85rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  vertical-align: middle;
+}
+.ros2-topic-table tbody tr {
+  transition: background 0.15s ease-in-out;
+  cursor: pointer;
+}
+.ros2-topic-table tbody tr:hover {
+  background: rgba(56, 189, 248, 0.08);
+}
+.ros2-topic-table tbody tr.active {
+  background: rgba(56, 189, 248, 0.15);
+  border-left: 3px solid #38bdf8;
+}
+.topic-table-name {
+  font-weight: 600;
+  color: #f8fafc;
+}
+.topic-table-type {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+.topic-hz-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #4ade80;
+  background: rgba(34, 197, 94, 0.15);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  padding: 0.2rem 0.55rem;
+  border-radius: 12px;
+  font-family: monospace;
+}
+.topic-hz-badge.hz-low {
+  color: #fbbf24;
+  background: rgba(245, 158, 11, 0.15);
+  border-color: rgba(245, 158, 11, 0.35);
+}
+.topic-hz-badge.hz-sub {
+  color: #c084fc;
+  background: rgba(192, 132, 252, 0.15);
+  border-color: rgba(192, 132, 252, 0.35);
+}
+
+/* Slower PC / Low-Spec SBC Build Time Hint */
+.deploy-time-hint {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: #94a3b8;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+}
+.deploy-time-hint .hint-icon {
+  font-size: 1rem;
+}
+.deploy-hero-badge.deploying {
+  background: rgba(245, 158, 11, 0.15);
+  border-color: rgba(245, 158, 11, 0.4);
+  color: #fbbf24;
+}
+.deploy-hero-badge.succeeded {
+  background: rgba(16, 185, 129, 0.15);
+  border-color: rgba(16, 185, 129, 0.4);
+  color: #34d399;
+}
+/* ==========================================================================
+   📡 UDP Syslog Server, Streamer & Real-Time Logger Aesthetics
+   ========================================================================== */
+
+.syslog-card {
+  background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.08), transparent 70%),
+              linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(8, 14, 26, 0.98));
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: var(--radius-md, 8px);
+  padding: 1.25rem;
+  margin-top: 1rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4), 0 0 15px rgba(56, 189, 248, 0.08);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.syslog-card:hover {
+  border-color: rgba(56, 189, 248, 0.4);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.5), 0 0 20px rgba(56, 189, 248, 0.15);
+}
+
+.syslog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.syslog-title-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.syslog-icon {
+  font-size: 1.5rem;
+  filter: drop-shadow(0 0 8px rgba(56, 189, 248, 0.5));
+}
+
+.syslog-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #f8fafc;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.syslog-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: rgba(100, 116, 139, 0.15);
+  border: 1px solid rgba(100, 116, 139, 0.3);
+  color: #94a3b8;
+  font-family: var(--font-mono, monospace);
+  transition: all 0.3s ease;
+}
+
+.syslog-status-badge.running {
+  background: rgba(16, 185, 129, 0.15);
+  border-color: rgba(16, 185, 129, 0.4);
+  color: #34d399;
+  box-shadow: 0 0 10px rgba(16, 185, 129, 0.2);
+}
+
+.syslog-status-badge.stopped {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: #f87171;
+}
+
+.syslog-controls-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  align-items: flex-end;
+  margin-bottom: 1rem;
+}
+
+.syslog-stats-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-sm, 6px);
+  font-size: 0.82rem;
+}
+
+.syslog-stat-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #cbd5e1;
+}
+
+.syslog-stat-label {
+  color: #64748b;
+  font-weight: 500;
+}
+
+.syslog-stat-val {
+  font-family: var(--font-mono, monospace);
+  color: #38bdf8;
+  font-weight: 600;
+}
+
+/* Terminal Syslog Stream Lines */
+.terminal-syslog {
+  color: #e2e8f0;
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  padding: 0.15rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  animation: fadeInFast 0.2s ease-out;
+}
+
+.badge-syslog {
+  background: rgba(56, 189, 248, 0.2);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  color: #38bdf8;
+  padding: 0.08rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-family: var(--font-mono, monospace);
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+.syslog-time {
+  color: #64748b;
+  font-size: 0.76rem;
+  font-family: var(--font-mono, monospace);
+  flex-shrink: 0;
+}
+
+.syslog-sender {
+  color: #a78bfa;
+  font-weight: 600;
+  font-size: 0.8rem;
+  font-family: var(--font-mono, monospace);
+  flex-shrink: 0;
+}
+
+.syslog-msg {
+  color: #f1f5f9;
+  word-break: break-all;
+  flex: 1;
+}
+
+@keyframes fadeInFast {
+  from { opacity: 0; transform: translateY(-2px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/tools/robot_config_engine/web/style.css
+++ b/tools/robot_config_engine/web/style.css
@@ -402,6 +402,25 @@ body {
   font-size: 0.8rem;
 }
 
+/* Disabled buttons / inputs — the custom .btn gradients hide the native
+   :disabled look, so grey them explicitly (e.g. the terminal Send button
+   before Connect, or on a browser without Web Serial). */
+.btn:disabled,
+.btn.is-disabled,
+.form-input:disabled,
+.form-select:disabled,
+.terminal-input:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  filter: grayscale(0.7);
+  box-shadow: none;
+}
+.btn:disabled:hover,
+.btn.is-disabled:hover {
+  transform: none;
+  filter: grayscale(0.7);
+}
+
 .github-link {
   color: var(--text-muted);
   display: flex;

--- a/tools/robot_config_engine/web/style.css
+++ b/tools/robot_config_engine/web/style.css
@@ -170,6 +170,14 @@ body {
   border-color: var(--border-glow);
 }
 
+/* Header "Run Full Deploy" — the first-run one-click action, always in reach */
+.hdr-deploy-btn {
+  width: 100%;
+  justify-content: center;
+  padding: 0.55rem 1rem;
+  font-size: 0.9rem;
+}
+
 /* Git Version Badge + Popover */
 .git-version-badge {
   display: inline-flex;

--- a/tools/robot_config_engine/web/style.css
+++ b/tools/robot_config_engine/web/style.css
@@ -1,0 +1,2767 @@
+/* ==========================================================================
+   Linorobot2 Robot Configuration Engine - Modern Dark Glassmorphism CSS
+   ========================================================================== */
+
+:root {
+  --bg-main: #090d16;
+  --bg-card: rgba(17, 24, 39, 0.75);
+  --bg-card-elevated: rgba(30, 41, 59, 0.7);
+  --bg-input: rgba(15, 23, 42, 0.85);
+  --bg-code: #070a11;
+
+  --border-subtle: rgba(255, 255, 255, 0.08);
+  --border-focus: #6366f1;
+  --border-glow: rgba(99, 102, 241, 0.35);
+
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --text-dim: #64748b;
+
+  --accent-primary: #6366f1;
+  --accent-primary-hover: #4f46e5;
+  --accent-cyan: #06b6d4;
+  --accent-emerald: #10b981;
+  --accent-purple: #a855f7;
+  --accent-amber: #f59e0b;
+  --accent-rose: #f43f5e;
+
+  --font-sans: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
+
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+  --radius-xl: 20px;
+
+  --shadow-card: 0 10px 25px -5px rgba(0, 0, 0, 0.4), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
+  --shadow-glow: 0 0 20px rgba(99, 102, 241, 0.25);
+  --transition-fast: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-smooth: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Reset & Box Sizing */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--bg-main);
+  color: var(--text-main);
+  min-height: 100vh;
+  line-height: 1.5;
+  position: relative;
+  /* No overflow-x:hidden — it silently clipped anything wider than the
+     viewport (common when the browser is zoomed in) with no way to scroll
+     to it. Wide inner content instead scrolls inside its own container. */
+}
+
+/* Background Glowing Orbs */
+.bg-glow {
+  position: fixed;
+  border-radius: 50%;
+  filter: blur(120px);
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.35;
+}
+.glow-1 {
+  width: 500px;
+  height: 500px;
+  background: radial-gradient(circle, #6366f1, transparent);
+  top: -150px;
+  left: -150px;
+}
+.glow-2 {
+  width: 600px;
+  height: 600px;
+  background: radial-gradient(circle, #06b6d4, transparent);
+  bottom: -200px;
+  right: -200px;
+}
+.glow-3 {
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(circle, #a855f7, transparent);
+  top: 40%;
+  left: 45%;
+}
+
+/* App Header */
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem 1.5rem;
+  padding: 1rem 2rem;
+  background: rgba(9, 13, 22, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.header-brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+/* Header stack: robot name, branch, git version, reference build */
+.reference-build-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 360px;
+}
+.git-version-row {
+  position: relative;
+  display: flex;
+}
+
+/* Compact labelled field pills in the header stack */
+.hdr-field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-card-elevated);
+  padding: 0.3rem 0.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+  position: relative;
+}
+
+/* Branch picker: caret button + drop-down list */
+.hdr-caret {
+  flex-shrink: 0;
+  padding: 0.1rem 0.35rem;
+  font-size: 0.7rem;
+  line-height: 1;
+  color: var(--text-muted);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+.hdr-caret:hover,
+.hdr-caret[aria-expanded="true"] {
+  color: var(--text-main);
+  border-color: var(--border-glow);
+}
+.branch-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 60;
+  min-width: 220px;
+  max-width: min(90vw, 360px);
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 0.3rem;
+  background: rgba(9, 13, 22, 0.98);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.55);
+}
+.branch-menu[hidden] { display: none; }
+.branch-menu .branch-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.35rem 0.55rem;
+  font-size: 0.8rem;
+  font-family: var(--font-mono);
+  color: var(--text-main);
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+}
+.branch-menu .branch-item:hover,
+.branch-menu .branch-item.is-active {
+  background: rgba(129, 140, 248, 0.16);
+  color: #c7d2fe;
+}
+.branch-menu .branch-item .branch-cur-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #34d399;
+  flex-shrink: 0;
+  visibility: hidden;
+}
+.branch-menu .branch-item.is-current .branch-cur-dot { visibility: visible; }
+.branch-menu .branch-empty {
+  padding: 0.4rem 0.55rem;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+}
+.hdr-field > label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.hdr-input.form-input {
+  flex: 1;
+  min-width: 120px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: #a5b4fc;
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+.hdr-btn {
+  flex-shrink: 0;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: var(--transition-fast);
+}
+.hdr-btn:hover {
+  color: var(--text-main);
+  border-color: var(--border-glow);
+}
+
+/* Header Workflow Settings Stack */
+.workflow-settings-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 440px;
+}
+.hdr-wf-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.hdr-wf-field {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--bg-card-elevated);
+  padding: 0.28rem 0.65rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+  position: relative;
+}
+.hdr-wf-field label {
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.hdr-select {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: #38bdf8;
+  font-size: 0.8rem;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+  min-width: 110px;
+}
+.hdr-select option {
+  background: #0f172a;
+  color: #f8fafc;
+}
+.hdr-info-btn {
+  flex-shrink: 0;
+  padding: 0.12rem 0.45rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #38bdf8;
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: var(--transition-fast);
+}
+.hdr-info-btn:hover {
+  background: rgba(56, 189, 248, 0.25);
+  color: #fff;
+  box-shadow: 0 0 10px rgba(56, 189, 248, 0.3);
+}
+
+/* Header "Run Full Deploy" — the first-run one-click action, always in reach */
+.hdr-deploy-btn {
+  width: 100%;
+  justify-content: center;
+  padding: 0.55rem 1rem;
+  font-size: 0.9rem;
+}
+
+/* Git Version Badge + Popover */
+.git-version-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.6rem;
+  background: var(--bg-card-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9999px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+.git-version-badge:hover,
+.git-version-badge[aria-expanded="true"] {
+  border-color: var(--border-glow);
+  color: var(--text-main);
+  box-shadow: var(--shadow-glow);
+}
+.git-version-badge.is-dirty {
+  color: #fbbf24;
+  border-color: rgba(251, 191, 36, 0.4);
+}
+.git-version-badge svg { opacity: 0.7; flex-shrink: 0; }
+
+.git-version-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 60;
+  width: 440px;
+  max-width: min(90vw, 480px);
+  max-height: 72vh;
+  overflow-y: auto;
+  padding: 1rem 1.1rem;
+  background: rgba(9, 13, 22, 0.98);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.55);
+  font-size: 0.8rem;
+  color: var(--text-main);
+}
+.git-version-popover[hidden] { display: none; }
+.git-version-popover h4 {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin: 0.9rem 0 0.35rem;
+}
+.git-version-popover h4:first-child { margin-top: 0; }
+.git-version-popover .gv-line {
+  display: flex;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  padding: 0.12rem 0;
+}
+.git-version-popover .gv-key { color: var(--text-muted); min-width: 88px; flex-shrink: 0; }
+.git-version-popover .gv-val { color: var(--text-main); word-break: break-all; }
+.git-version-popover .gv-remote-name { color: #a5b4fc; }
+.git-version-popover ol.gv-commits { list-style: none; margin: 0; padding: 0; }
+.git-version-popover ol.gv-commits li {
+  padding: 0.35rem 0;
+  border-top: 1px solid var(--border-subtle);
+}
+.git-version-popover ol.gv-commits li:first-child { border-top: none; }
+.git-version-popover .gv-hash { font-family: var(--font-mono); color: #06b6d4; }
+.git-version-popover .gv-subject { color: var(--text-main); }
+.git-version-popover .gv-meta { color: var(--text-muted); font-size: 0.7rem; }
+.git-version-popover .gv-note {
+  color: #fbbf24;
+  font-size: 0.72rem;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.brand-logo {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, #6366f1, #06b6d4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  box-shadow: 0 0 15px rgba(99, 102, 241, 0.4);
+}
+
+.brand-title {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.badge-accent {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  background: rgba(99, 102, 241, 0.2);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  border-radius: 999px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.brand-subtitle {
+  font-size: 0.825rem;
+  color: var(--text-muted);
+}
+
+.header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.preset-selector-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-card-elevated);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+}
+
+.preset-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.preset-select {
+  background: transparent;
+  border: none;
+  color: #a5b4fc;
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  font-weight: 600;
+  outline: none;
+  cursor: pointer;
+}
+
+.preset-select option {
+  background: #111827;
+  color: var(--text-main);
+}
+
+/* Button System */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1.1rem;
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-decoration: none;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent-primary), #4f46e5);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
+}
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(99, 102, 241, 0.45);
+}
+
+.btn-secondary {
+  background: var(--bg-card-elevated);
+  color: var(--text-main);
+  border-color: var(--border-subtle);
+}
+.btn-secondary:hover {
+  background: rgba(45, 55, 72, 0.8);
+  border-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.btn-accent {
+  background: linear-gradient(135deg, var(--accent-cyan), #0891b2);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(6, 182, 212, 0.3);
+}
+.btn-accent:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(6, 182, 212, 0.45);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-muted);
+  border-color: var(--border-subtle);
+}
+.btn-ghost:hover {
+  color: var(--text-main);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.btn-sm {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+/* Disabled buttons / inputs — the custom .btn gradients hide the native
+   :disabled look, so grey them explicitly (e.g. the terminal Send button
+   before Connect, or on a browser without Web Serial). */
+.btn:disabled,
+.btn.is-disabled,
+.form-input:disabled,
+.form-select:disabled,
+.terminal-input:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  filter: grayscale(0.7);
+  box-shadow: none;
+}
+.btn:disabled:hover,
+.btn.is-disabled:hover {
+  transform: none;
+  filter: grayscale(0.7);
+}
+
+.github-link {
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  padding: 0.5rem;
+  border-radius: var(--radius-md);
+  transition: color var(--transition-fast);
+}
+.github-link:hover {
+  color: var(--text-main);
+}
+
+/* App Main Container Grid */
+.app-container {
+  position: relative;
+  z-index: 1;
+  max-width: 1680px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 1.5rem;
+}
+
+/* Panels */
+.config-panel, .dashboard-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-width: 0; /* let the 1.15fr / 1fr grid columns shrink instead of forcing page-wide overflow */
+}
+
+/* Nav Tabs */
+.nav-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  background: var(--bg-card);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  padding: 0.4rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-subtle);
+}
+
+.nav-tab {
+  flex: 1 1 110px;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.5rem;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.nav-tab:hover {
+  color: var(--text-main);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.nav-tab.active {
+  color: #fff;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.35), rgba(6, 182, 212, 0.25));
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+/* Tab Content */
+.tab-content-wrapper {
+  background: var(--bg-card);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-subtle);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-card);
+}
+
+.tab-pane {
+  display: none;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+.tab-pane.active {
+  display: flex;
+  animation: fadeIn 0.2s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Form Styles */
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-main);
+  letter-spacing: -0.01em;
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: 0.6rem;
+}
+
+.section-header-flex {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: 0.6rem;
+}
+.section-header-flex .section-title {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.sub-title {
+  font-size: 0.925rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-label {
+  font-size: 0.825rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.form-input, .form-select {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-main);
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  outline: none;
+  transition: all var(--transition-fast);
+}
+
+.form-input:focus, .form-select:focus {
+  border-color: var(--border-focus);
+  box-shadow: 0 0 0 3px var(--border-glow);
+}
+
+.form-select option {
+  background: #111827;
+  color: var(--text-main);
+}
+
+.input-hint {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+
+.sub-panel {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.checkbox-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.checkbox-label input[type="checkbox"] {
+  accent-color: var(--accent-primary);
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+/* Pinout Tables */
+.pin-table-wrapper {
+  overflow-x: auto;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+}
+
+.pin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  text-align: left;
+}
+
+.pin-table th {
+  background: rgba(15, 23, 42, 0.9);
+  padding: 0.65rem 0.85rem;
+  color: var(--text-muted);
+  font-weight: 600;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.pin-table td {
+  padding: 0.5rem 0.85rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.pin-table tr:last-child td {
+  border-bottom: none;
+}
+
+.pin-input {
+  max-width: 90px;
+  padding: 0.4rem 0.6rem;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  text-align: center;
+}
+
+/* Right Dashboard Column */
+
+/* HUD Card */
+.hud-card {
+  background: var(--bg-card);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-subtle);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-card);
+}
+
+.hud-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.hud-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.hud-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(6, 182, 212, 0.15);
+  color: var(--accent-cyan);
+  border: 1px solid rgba(6, 182, 212, 0.35);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.85rem;
+}
+
+.metric-card {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.metric-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.metric-val-wrap {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.metric-val {
+  font-family: var(--font-mono);
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(135deg, #fff, #a5b4fc);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.metric-unit {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.metric-sub {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* Safety Inspector Card */
+.safety-card {
+  background: var(--bg-card);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-subtle);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-card);
+  transition: all var(--transition-smooth);
+}
+
+.safety-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.safety-indicator-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.status-ok {
+  background: var(--accent-emerald);
+  box-shadow: 0 0 10px var(--accent-emerald);
+}
+.status-err {
+  background: var(--accent-rose);
+  box-shadow: 0 0 10px var(--accent-rose);
+  animation: pulse 1.5s infinite;
+}
+.status-warn {
+  background: var(--accent-amber);
+  box-shadow: 0 0 10px var(--accent-amber);
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.6; transform: scale(1.15); }
+}
+
+.safety-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.safety-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+}
+.badge-ok {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--accent-emerald);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+.badge-err {
+  background: rgba(244, 63, 94, 0.15);
+  color: var(--accent-rose);
+  border: 1px solid rgba(244, 63, 94, 0.4);
+}
+.badge-warn {
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--accent-amber);
+  border: 1px solid rgba(245, 158, 11, 0.4);
+}
+
+.safety-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.safety-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: var(--radius-md);
+  font-size: 0.825rem;
+}
+.item-ok {
+  background: rgba(16, 185, 129, 0.08);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  color: #a7f3d0;
+}
+.item-err {
+  background: rgba(244, 63, 94, 0.1);
+  border: 1px solid rgba(244, 63, 94, 0.35);
+  color: #fecdd3;
+}
+.item-warn {
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  color: #fde68a;
+}
+
+/* Artifacts Code Card */
+.artifacts-card {
+  background: var(--bg-card);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+}
+
+.artifacts-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 1rem;
+  background: rgba(15, 23, 42, 0.9);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.artifact-tabs {
+  display: flex;
+  gap: 0.35rem;
+  overflow-x: auto;
+}
+
+.artifact-tab {
+  padding: 0.4rem 0.75rem;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  font-weight: 600;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+}
+.artifact-tab:hover {
+  color: var(--text-main);
+  background: rgba(255, 255, 255, 0.05);
+}
+.artifact-tab.active {
+  color: #a5b4fc;
+  background: rgba(99, 102, 241, 0.2);
+  border-color: rgba(99, 102, 241, 0.4);
+}
+
+.artifact-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.code-viewer-wrap {
+  position: relative;
+  background: var(--bg-code);
+  min-height: 200px;
+  height: 440px;
+  max-height: 90vh;
+  /* user-resizable: drag the bottom-right grip */
+  resize: vertical;
+  overflow: auto;
+  padding: 1.25rem;
+}
+
+.code-viewer {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: #e2e8f0;
+  tab-size: 2;
+  white-space: pre;
+}
+
+/* Toast Notification */
+.toast {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: rgba(16, 185, 129, 0.95);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: var(--radius-lg);
+  font-weight: 600;
+  font-size: 0.875rem;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
+  transform: translateY(100px);
+  opacity: 0;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 100;
+}
+.toast.show {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+/* Utility Helpers */
+.mt-4 { margin-top: 1rem; }
+.mb-3 { margin-bottom: 0.75rem; }
+
+/* Responsive Media Queries */
+@media (max-width: 1200px) {
+  .app-container {
+    grid-template-columns: 1fr;
+  }
+  .metrics-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1rem;
+  }
+  .header-actions {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+  .metrics-grid {
+    grid-template-columns: 1fr;
+  }
+  .nav-tabs {
+    flex-wrap: wrap;
+  }
+  .nav-tab {
+    flex: 1 1 45%;
+  }
+}
+
+
+/* ==========================================================================
+   Automation Hub, OS Detection, Deploy Scripts & Web Serial Console
+   ========================================================================== */
+
+/* Header OS Badge & Accent Button */
+.os-quick-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.85rem;
+  background: var(--bg-card-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9999px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-main);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  transition: var(--transition-fast);
+}
+.os-quick-badge:hover {
+  border-color: var(--border-glow);
+  box-shadow: var(--shadow-glow);
+}
+.os-badge-icon {
+  font-size: 1.1rem;
+}
+
+.btn-accent {
+  background: linear-gradient(135deg, #06b6d4, #6366f1);
+  color: #ffffff;
+  box-shadow: 0 4px 14px rgba(6, 182, 212, 0.35);
+  border: none;
+}
+.btn-accent:hover {
+  background: linear-gradient(135deg, #0891b2, #4f46e5);
+  box-shadow: 0 6px 20px rgba(6, 182, 212, 0.5);
+  transform: translateY(-1px);
+}
+
+/* OS Detection Banner */
+.os-detect-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.5rem;
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.95));
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 8px 24px -6px rgba(0, 0, 0, 0.5), 0 0 15px rgba(99, 102, 241, 0.15);
+  margin-top: 1rem;
+  position: relative;
+  overflow: hidden;
+}
+.os-detect-banner::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, #6366f1, #06b6d4, #10b981);
+}
+
+.os-detect-info {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+.os-icon-large {
+  font-size: 2.25rem;
+  filter: drop-shadow(0 0 12px rgba(6, 182, 212, 0.4));
+}
+.os-banner-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-main);
+}
+.os-banner-sub {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-top: 0.2rem;
+}
+
+/* Badge Pills */
+.badge-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.65rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.badge-pill.badge-ok {
+  background: rgba(16, 185, 129, 0.15);
+  color: #34d399;
+  border: 1px solid rgba(16, 185, 129, 0.35);
+}
+.badge-pill.badge-warn {
+  background: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+}
+.badge-pill.badge-err {
+  background: rgba(244, 63, 94, 0.15);
+  color: #fb7185;
+  border: 1px solid rgba(244, 63, 94, 0.35);
+}
+.badge-pill.badge-accent {
+  background: rgba(99, 102, 241, 0.15);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+}
+
+/* Pulse Dot Animation */
+.pulse-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: currentColor;
+  position: relative;
+}
+.pulse-dot::after {
+  content: "";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  animation: pulse-ring 1.8s cubic-bezier(0.215, 0.61, 0.355, 1) infinite;
+}
+@keyframes pulse-ring {
+  0% { transform: scale(0.8); opacity: 0.9; }
+  80%, 100% { transform: scale(2.2); opacity: 0; }
+}
+
+/* Automation Options Grid */
+.automation-options-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+.automation-options-grid .checkbox-label {
+  padding: 0.85rem 1rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  font-size: 0.88rem;
+  line-height: 1.4;
+  color: var(--text-main);
+  transition: var(--transition-fast);
+}
+.automation-options-grid .checkbox-label:hover {
+  background: var(--bg-card-elevated);
+  border-color: var(--border-glow);
+}
+
+/* Quick Command Preview Boxes */
+.quick-cmd-box {
+  margin-top: 0.85rem;
+  background: var(--bg-code);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.quick-cmd-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: rgba(15, 23, 42, 0.95);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.quick-cmd-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--accent-cyan);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.quick-cmd-code {
+  padding: 0.85rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: #cbd5e1;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  line-height: 1.5;
+}
+
+/* Button Group Row */
+.btn-group-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.flex-1 {
+  flex: 1;
+  min-width: 180px;
+}
+
+/* Web Serial Live Diagnostics Console */
+.web-serial-console-card {
+  margin-top: 1rem;
+  background: #030712;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  border-radius: var(--radius-lg);
+  /* not 'hidden' — would clip the resizable terminal's grip / overflow */
+  overflow: visible;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.6);
+}
+.console-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.25rem;
+  background: rgba(15, 23, 42, 0.9);
+  border-bottom: 1px solid var(--border-subtle);
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+.console-controls-left,
+.console-controls-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.serial-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.serial-status-pill.pill-connected {
+  background: rgba(16, 185, 129, 0.15);
+  color: #10b981;
+  border: 1px solid rgba(16, 185, 129, 0.4);
+  box-shadow: 0 0 10px rgba(16, 185, 129, 0.2);
+}
+.serial-status-pill.pill-disconnected {
+  background: rgba(100, 116, 139, 0.15);
+  color: #94a3b8;
+  border: 1px solid rgba(100, 116, 139, 0.3);
+}
+
+.form-select-sm {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.82rem;
+  min-width: 150px;
+}
+.btn-xs {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+}
+.checkbox-label-sm {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.terminal-screen {
+  height: 260px;
+  /* user-resizable: drag the bottom-right grip to enlarge for long
+     ROS 2 topic messages / build logs */
+  resize: both;
+  min-height: 120px;
+  max-height: 90vh;
+  min-width: 320px;
+  max-width: 100%;
+  overflow: auto;
+  padding: 1rem 1.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  line-height: 1.6;
+  color: #e2e8f0;
+  background: radial-gradient(circle at top left, rgba(15, 23, 42, 0.6), transparent 70%), #040711;
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.8);
+}
+.terminal-line {
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+.terminal-dim {
+  color: #64748b;
+  font-style: italic;
+}
+.terminal-in {
+  color: #38bdf8;
+  font-weight: 500;
+}
+.terminal-out {
+  color: #a7f3d0;
+}
+.terminal-err {
+  color: #f43f5e;
+  font-weight: 600;
+}
+
+.terminal-input-bar {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  background: rgba(15, 23, 42, 0.95);
+  border-top: 1px solid var(--border-subtle);
+}
+.terminal-input {
+  flex: 1;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0.45rem 0.85rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: #f8fafc;
+  outline: none;
+  transition: var(--transition-fast);
+}
+.terminal-input:focus {
+  border-color: var(--border-focus);
+  box-shadow: 0 0 8px var(--border-glow);
+}
+
+
+/* Quick Command Actions Row */
+.quick-cmd-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.btn-danger {
+  background: rgba(244, 63, 94, 0.2);
+  color: #fb7185;
+  border: 1px solid rgba(244, 63, 94, 0.4);
+}
+.btn-danger:hover {
+  background: rgba(244, 63, 94, 0.35);
+  border-color: #f43f5e;
+}
+
+/* Local Runner Status Pill */
+.runner-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.runner-status-pill.pill-online {
+  background: rgba(16, 185, 129, 0.15);
+  color: #34d399;
+  border: 1px solid rgba(16, 185, 129, 0.4);
+  box-shadow: 0 0 10px rgba(16, 185, 129, 0.2);
+}
+.runner-status-pill.pill-offline {
+  background: rgba(148, 163, 184, 0.12);
+  color: #94a3b8;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+.runner-status-pill.pill-checking {
+  background: rgba(99, 102, 241, 0.15);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+}
+
+/* Direct 1-Click Upload Buttons Grid */
+.direct-upload-section {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 14px;
+}
+.direct-upload-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+.btn-direct-upload {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+.btn-direct-upload:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  border-color: var(--accent-primary);
+}
+.btn-direct-upload:active {
+  transform: translateY(0);
+}
+.direct-upload-icon {
+  font-size: 1.6rem;
+  line-height: 1;
+}
+.direct-upload-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+.direct-upload-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.direct-upload-title code {
+  color: var(--accent-secondary);
+  font-size: 0.9em;
+}
+.direct-upload-desc {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.direct-upload-badge {
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 4px 8px;
+  border-radius: 9999px;
+  background: rgba(14, 165, 233, 0.15);
+  color: #38bdf8;
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.btn-upload-sensors:hover .direct-upload-badge {
+  background: rgba(16, 185, 129, 0.2);
+  color: #34d399;
+  border-color: rgba(52, 211, 153, 0.4);
+}
+.btn-upload-motors:hover .direct-upload-badge {
+  background: rgba(245, 158, 11, 0.2);
+  color: #fbbf24;
+  border-color: rgba(251, 191, 36, 0.4);
+}
+.btn-upload-acc:hover .direct-upload-badge {
+  background: rgba(168, 85, 247, 0.2);
+  color: #c084fc;
+  border-color: rgba(192, 132, 252, 0.4);
+}
+.btn-upload-firmware:hover .direct-upload-badge {
+  background: rgba(14, 165, 233, 0.25);
+  color: #38bdf8;
+  border-color: rgba(56, 189, 248, 0.5);
+}
+
+/* Port Chips & Multi-Serial Styling */
+.port-chips-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 24px;
+}
+
+.chips-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-dim);
+}
+
+.chips-empty {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  font-style: italic;
+}
+
+/* USB VID:PID Port Chip Enhancements */
+.port-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 3px 9px;
+  background: rgba(99, 102, 241, 0.15);
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  border-radius: var(--radius-sm);
+  color: #a5b4fc;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.port-chip:hover {
+  background: rgba(99, 102, 241, 0.28);
+  border-color: #818cf8;
+  color: #ffffff;
+}
+
+.port-chip.port-chip-warn {
+  background: rgba(245, 158, 11, 0.15);
+  border-color: rgba(245, 158, 11, 0.45);
+  color: #fbbf24;
+}
+
+.port-chip.port-chip-warn:hover {
+  background: rgba(245, 158, 11, 0.28);
+  border-color: #fbbf24;
+  color: #fef08a;
+}
+
+.chip-vidpid {
+  font-size: 0.7rem;
+  color: #38bdf8;
+  background: rgba(56, 189, 248, 0.15);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.chip-desc {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.chip-lock {
+  font-size: 0.7rem;
+  color: #f87171;
+  font-weight: 600;
+}
+
+/* Base Port Chip */
+.old-port-chip {
+  padding: 2px 8px;
+  background: rgba(99, 102, 241, 0.15);
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  border-radius: var(--radius-sm);
+  color: #a5b4fc;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.port-chip:hover {
+  background: rgba(99, 102, 241, 0.3);
+  border-color: rgba(99, 102, 241, 0.6);
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.agent-config-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.form-label-xs {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.form-input-sm, .form-select-sm {
+  padding: 0.35rem 0.5rem;
+  font-size: 0.8rem;
+}
+
+/* ==========================================================================
+   ADC Calibration Studio & LUT Visualizer
+   ========================================================================== */
+.adc-studio-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-card);
+  margin-top: 1rem;
+}
+
+.adc-studio-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.adc-studio-title-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.adc-studio-icon {
+  font-size: 1.8rem;
+}
+
+.adc-studio-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.adc-studio-subtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.adc-studio-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.adc-dacpin-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.9rem;
+  margin-bottom: 0.9rem;
+}
+.adc-dacpin-row select {
+  max-width: 220px;
+}
+
+.adc-nodac-note {
+  background: rgba(244, 63, 94, 0.1);
+  border: 1px solid rgba(244, 63, 94, 0.35);
+  border-radius: var(--radius-md);
+  padding: 0.6rem 0.9rem;
+  margin-bottom: 1rem;
+  font-size: 0.82rem;
+  color: var(--text-primary);
+}
+
+/* MCU without a hardware DAC: grey the whole ADC studio out */
+.adc-studio-card.is-disabled {
+  opacity: 0.55;
+  filter: grayscale(0.6);
+  pointer-events: none;
+}
+.adc-studio-card.is-disabled #adc-nodac-note {
+  pointer-events: auto;
+}
+
+.adc-setup-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: var(--radius-md);
+  padding: 0.6rem 0.9rem;
+  margin-bottom: 1.2rem;
+  font-size: 0.82rem;
+}
+
+.adc-setup-badge {
+  background: #f59e0b;
+  color: #000000;
+  font-weight: 700;
+  font-size: 0.72rem;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.adc-setup-text {
+  color: #fde68a;
+}
+
+.adc-studio-grid {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 1.25rem;
+}
+
+@media (max-width: 900px) {
+  .adc-studio-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.adc-chart-pane {
+  display: flex;
+  flex-direction: column;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 0.9rem;
+}
+
+.adc-chart-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.adc-chart-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.adc-chart-legend {
+  display: flex;
+  gap: 0.85rem;
+  font-size: 0.72rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--text-muted);
+}
+
+.legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.adc-canvas-container {
+  position: relative;
+  width: 100%;
+  height: 260px;
+  background: #090d16;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  overflow: hidden;
+}
+
+#adc-chart-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.adc-chart-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid #6366f1;
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.6rem;
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+  color: #ffffff;
+  box-shadow: var(--shadow-md);
+  z-index: 10;
+  white-space: nowrap;
+}
+
+.adc-metrics-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.adc-metric-box {
+  background: rgba(30, 41, 59, 0.5);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.metric-label {
+  font-size: 0.68rem;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.metric-val {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  margin-top: 2px;
+}
+
+.text-accent {
+  color: #a5b4fc !important;
+}
+
+.adc-lut-pane {
+  display: flex;
+  flex-direction: column;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 0.9rem;
+}
+
+.adc-lut-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.adc-lut-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.adc-lut-code-wrap {
+  flex: 1;
+  min-height: 220px;
+  max-height: 260px;
+  overflow-y: auto;
+  background: #090d16;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 0.6rem 0.75rem;
+}
+
+.adc-lut-code {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: #94a3b8;
+  line-height: 1.4;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.adc-status-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 0.75rem;
+  padding: 0.35rem 0.5rem;
+  background: rgba(30, 41, 59, 0.4);
+  border-radius: var(--radius-sm);
+}
+
+.btn-upload-adc:hover .direct-upload-badge {
+  background: rgba(234, 179, 8, 0.2);
+  color: #facc15;
+  border-color: rgba(250, 204, 21, 0.4);
+}
+
+/* ==========================================================================
+   ADC 3.0V Safety Banner & CAD Circuit Schematic
+   ========================================================================== */
+.adc-safety-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.85rem 1.15rem;
+  border-radius: var(--radius-md);
+  margin-top: 0.85rem;
+  transition: all var(--transition-normal);
+}
+
+.adc-safety-banner.safe {
+  background: rgba(16, 185, 129, 0.12);
+  border: 1px solid rgba(16, 185, 129, 0.35);
+  color: #a7f3d0;
+}
+.adc-safety-banner.safe .safety-banner-title {
+  color: #34d399;
+  font-weight: 700;
+  font-size: 0.92rem;
+}
+.adc-safety-banner.safe .safety-banner-desc {
+  color: #d1fae5;
+  font-size: 0.82rem;
+  margin-top: 0.15rem;
+}
+.adc-safety-banner.safe code {
+  color: #6ee7b7;
+  background: rgba(6, 78, 59, 0.5);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.adc-safety-banner.warning {
+  background: rgba(244, 63, 94, 0.18);
+  border: 1.5px solid rgba(244, 63, 94, 0.6);
+  box-shadow: 0 0 15px rgba(244, 63, 94, 0.25);
+  animation: pulse-warn 2s infinite;
+}
+.adc-safety-banner.warning .safety-banner-title {
+  color: #fb7185;
+  font-weight: 800;
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.adc-safety-banner.warning .safety-banner-desc {
+  color: #fecdd3;
+  font-size: 0.84rem;
+  margin-top: 0.2rem;
+  font-weight: 500;
+}
+.adc-safety-banner.warning code {
+  color: #ffffff;
+  background: rgba(159, 18, 57, 0.8);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 700;
+}
+
+@keyframes pulse-warn {
+  0%, 100% { box-shadow: 0 0 15px rgba(244, 63, 94, 0.25); }
+  50% { box-shadow: 0 0 25px rgba(244, 63, 94, 0.5); }
+}
+
+.safety-banner-icon {
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+/* CAD Circuit Schematic Card */
+.adc-cad-schematic-card {
+  background: #060913;
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: var(--radius-lg);
+  padding: 1.15rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+
+.schematic-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.85rem;
+}
+
+.schematic-title-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.schematic-icon {
+  font-size: 1.5rem;
+}
+
+.schematic-title {
+  font-size: 0.98rem;
+  font-weight: 700;
+  color: #e0f2fe;
+  margin: 0;
+}
+
+.schematic-subtitle {
+  font-size: 0.78rem;
+  color: #94a3b8;
+  margin: 0;
+}
+
+.schematic-badges {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.schematic-badge {
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid var(--border-subtle);
+  color: #94a3b8;
+}
+
+.schematic-badge.badge-safe {
+  background: rgba(16, 185, 129, 0.15);
+  border-color: rgba(16, 185, 129, 0.4);
+  color: #34d399;
+  font-weight: 600;
+}
+
+.schematic-badge.badge-warning {
+  background: rgba(244, 63, 94, 0.2);
+  border-color: rgba(244, 63, 94, 0.6);
+  color: #fb7185;
+  font-weight: 700;
+}
+
+.schematic-svg-container {
+  width: 100%;
+  overflow-x: auto;
+  background: #020617;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  padding: 0.75rem;
+}
+
+.schematic-svg {
+  width: 100%;
+  min-width: 680px;
+  height: auto;
+  display: block;
+}
+
+
+.port-chip-bootsel {
+  background: rgba(168, 85, 247, 0.18) !important;
+  border-color: rgba(168, 85, 247, 0.6) !important;
+  color: #c084fc !important;
+  animation: pulse-glow 2s infinite ease-in-out;
+}
+.port-chip-bootsel:hover {
+  background: rgba(168, 85, 247, 0.35) !important;
+  border-color: #a855f7 !important;
+  box-shadow: 0 0 12px rgba(168, 85, 247, 0.5);
+}
+
+/* Hero Deploy Card (Top of Tab 5) */
+.deploy-hero-card {
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.95), rgba(15, 23, 42, 0.98));
+  border: 2px solid rgba(59, 130, 246, 0.4);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35), 0 0 20px rgba(59, 130, 246, 0.15);
+  margin-bottom: 1.5rem;
+}
+.deploy-hero-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 0.75rem;
+}
+.deploy-hero-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #60a5fa;
+  margin: 0;
+}
+.deploy-hero-desc {
+  font-size: 0.85rem;
+  color: var(--text-muted, #94a3b8);
+  margin: 0.25rem 0 0 0;
+}
+.deploy-hero-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(34, 197, 94, 0.15);
+  border: 1px solid rgba(34, 197, 94, 0.4);
+  color: #4ade80;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: 20px;
+}
+.btn-hero-deploy {
+  font-size: 1rem !important;
+  padding: 0.75rem 1.5rem !important;
+  background: linear-gradient(135deg, #2563eb, #7c3aed) !important;
+  border: none !important;
+  box-shadow: 0 4px 14px rgba(37, 99, 235, 0.4) !important;
+  transition: all 0.2s ease-in-out !important;
+}
+.btn-hero-deploy:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(124, 58, 237, 0.6) !important;
+}
+.pulse-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 8px #22c55e;
+  animation: pulse-dot-anim 1.5s infinite;
+}
+@keyframes pulse-dot-anim {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.4); opacity: 0.6; }
+}
+
+/* ROS 2 Live Topic Inspector & Stream Controls */
+.ros2-stream-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.ros2-inspector-card {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.9));
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  border-radius: 12px;
+  padding: 1.25rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+.ros2-inspector-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 0.75rem;
+}
+.ros2-inspector-title-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.ros2-inspector-icon {
+  font-size: 1.5rem;
+}
+.ros2-inspector-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #38bdf8;
+  margin: 0;
+}
+.ros2-inspector-subtitle {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  margin: 0.2rem 0 0 0;
+}
+.ros2-topics-badge-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+}
+.ros2-topic-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 0.6rem 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+.ros2-topic-badge:hover {
+  border-color: #38bdf8;
+  background: rgba(56, 189, 248, 0.1);
+  transform: translateY(-2px);
+}
+.ros2-topic-badge.active {
+  border-color: #38bdf8;
+  background: rgba(56, 189, 248, 0.15);
+  box-shadow: 0 0 12px rgba(56, 189, 248, 0.3);
+}
+.topic-icon {
+  font-size: 1.25rem;
+}
+.topic-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+}
+.topic-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #f8fafc;
+  font-family: monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.topic-type {
+  font-size: 0.7rem;
+  color: #94a3b8;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.topic-hz-badge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #4ade80;
+  background: rgba(34, 197, 94, 0.15);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  padding: 0.2rem 0.5rem;
+  border-radius: 12px;
+}
+.ros2-live-hud-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.75rem;
+}
+.hud-metric-mini {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+}
+.hud-mini-label {
+  font-size: 0.7rem;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.hud-mini-val {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin-top: 0.2rem;
+}
+.text-cyan { color: #38bdf8 !important; }
+.text-green { color: #4ade80 !important; }
+.text-purple { color: #c084fc !important; }
+
+/* ROS 2 Topic Hz Table */
+.ros2-table-wrapper {
+  overflow-x: auto;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(10, 15, 29, 0.6);
+}
+.ros2-topic-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+.ros2-topic-table th {
+  background: rgba(30, 41, 59, 0.7);
+  padding: 0.65rem 0.85rem;
+  font-weight: 600;
+  color: #94a3b8;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  text-align: left;
+}
+.ros2-topic-table td {
+  padding: 0.6rem 0.85rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  vertical-align: middle;
+}
+.ros2-topic-table tbody tr {
+  transition: background 0.15s ease-in-out;
+  cursor: pointer;
+}
+.ros2-topic-table tbody tr:hover {
+  background: rgba(56, 189, 248, 0.08);
+}
+.ros2-topic-table tbody tr.active {
+  background: rgba(56, 189, 248, 0.15);
+  border-left: 3px solid #38bdf8;
+}
+.topic-table-name {
+  font-weight: 600;
+  color: #f8fafc;
+}
+.topic-table-type {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+.topic-hz-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #4ade80;
+  background: rgba(34, 197, 94, 0.15);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  padding: 0.2rem 0.55rem;
+  border-radius: 12px;
+  font-family: monospace;
+}
+.topic-hz-badge.hz-low {
+  color: #fbbf24;
+  background: rgba(245, 158, 11, 0.15);
+  border-color: rgba(245, 158, 11, 0.35);
+}
+.topic-hz-badge.hz-sub {
+  color: #c084fc;
+  background: rgba(192, 132, 252, 0.15);
+  border-color: rgba(192, 132, 252, 0.35);
+}
+
+/* Slower PC / Low-Spec SBC Build Time Hint */
+.deploy-time-hint {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: #94a3b8;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+}
+.deploy-time-hint .hint-icon {
+  font-size: 1rem;
+}
+.deploy-hero-badge.deploying {
+  background: rgba(245, 158, 11, 0.15);
+  border-color: rgba(245, 158, 11, 0.4);
+  color: #fbbf24;
+}
+.deploy-hero-badge.succeeded {
+  background: rgba(16, 185, 129, 0.15);
+  border-color: rgba(16, 185, 129, 0.4);
+  color: #34d399;
+}
+/* ==========================================================================
+   📡 UDP Syslog Server, Streamer & Real-Time Logger Aesthetics
+   ========================================================================== */
+
+.syslog-card {
+  background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.08), transparent 70%),
+              linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(8, 14, 26, 0.98));
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: var(--radius-md, 8px);
+  padding: 1.25rem;
+  margin-top: 1rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4), 0 0 15px rgba(56, 189, 248, 0.08);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.syslog-card:hover {
+  border-color: rgba(56, 189, 248, 0.4);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.5), 0 0 20px rgba(56, 189, 248, 0.15);
+}
+
+.syslog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.syslog-title-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.syslog-icon {
+  font-size: 1.5rem;
+  filter: drop-shadow(0 0 8px rgba(56, 189, 248, 0.5));
+}
+
+.syslog-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #f8fafc;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.syslog-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: rgba(100, 116, 139, 0.15);
+  border: 1px solid rgba(100, 116, 139, 0.3);
+  color: #94a3b8;
+  font-family: var(--font-mono, monospace);
+  transition: all 0.3s ease;
+}
+
+.syslog-status-badge.running {
+  background: rgba(16, 185, 129, 0.15);
+  border-color: rgba(16, 185, 129, 0.4);
+  color: #34d399;
+  box-shadow: 0 0 10px rgba(16, 185, 129, 0.2);
+}
+
+.syslog-status-badge.stopped {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: #f87171;
+}
+
+.syslog-controls-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  align-items: flex-end;
+  margin-bottom: 1rem;
+}
+
+.syslog-stats-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-sm, 6px);
+  font-size: 0.82rem;
+}
+
+.syslog-stat-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #cbd5e1;
+}
+
+.syslog-stat-label {
+  color: #64748b;
+  font-weight: 500;
+}
+
+.syslog-stat-val {
+  font-family: var(--font-mono, monospace);
+  color: #38bdf8;
+  font-weight: 600;
+}
+
+/* Terminal Syslog Stream Lines */
+.terminal-syslog {
+  color: #e2e8f0;
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  padding: 0.15rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  animation: fadeInFast 0.2s ease-out;
+}
+
+.badge-syslog {
+  background: rgba(56, 189, 248, 0.2);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  color: #38bdf8;
+  padding: 0.08rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-family: var(--font-mono, monospace);
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+.syslog-time {
+  color: #64748b;
+  font-size: 0.76rem;
+  font-family: var(--font-mono, monospace);
+  flex-shrink: 0;
+}
+
+.syslog-sender {
+  color: #a78bfa;
+  font-weight: 600;
+  font-size: 0.8rem;
+  font-family: var(--font-mono, monospace);
+  flex-shrink: 0;
+}
+
+.syslog-msg {
+  color: #f1f5f9;
+  word-break: break-all;
+  flex: 1;
+}
+
+@keyframes fadeInFast {
+  from { opacity: 0; transform: translateY(-2px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+
+/* =============================================================================
+   🎯 Target Execution Mode & Remote SSH Panel
+   ============================================================================= */
+.target-mode-card {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.9));
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: 12px;
+  padding: 1.25rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+.target-mode-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.target-mode-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #38bdf8;
+  margin: 0;
+}
+.target-mode-desc {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  margin: 0.25rem 0 0 0;
+}
+.mode-toggle-group {
+  display: flex;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 3px;
+  gap: 4px;
+}
+.btn-mode-toggle {
+  background: transparent;
+  border: none;
+  color: #94a3b8;
+  padding: 0.4rem 0.9rem;
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+.btn-mode-toggle:hover {
+  color: #f8fafc;
+  background: rgba(255, 255, 255, 0.05);
+}
+.btn-mode-toggle.active {
+  background: linear-gradient(135deg, #0284c7, #0ea5e9);
+  color: #ffffff;
+  box-shadow: 0 2px 8px rgba(14, 165, 233, 0.4);
+}
+.remote-ssh-panel {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px dashed rgba(56, 189, 248, 0.2);
+  border-radius: 8px;
+  padding: 1rem;
+}
+.remote-actions-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+.remote-badges {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.remote-btns {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.remote-chip-callout {
+  background: #0f172a;
+  border: 1px solid #38bdf8;
+  border-radius: 6px;
+  padding: 0.75rem;
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: #e2e8f0;
+  white-space: pre-wrap;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+/* ---------- simulation-mode banner ---------- */
+#sim-mode-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  margin: 0 1rem 0.75rem;
+  padding: 0.7rem 1rem;
+  border-radius: 8px;
+  background: rgba(234, 88, 12, 0.14);
+  border: 1px solid rgba(234, 88, 12, 0.55);
+  border-left: 5px solid #ea580c;
+  color: var(--text, #e5e7eb);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+#sim-mode-banner .sim-banner-icon { font-size: 1.4rem; flex: 0 0 auto; }
+#sim-mode-banner .sim-banner-text { flex: 1 1 auto; }
+#sim-mode-banner strong { color: #fb923c; }
+#sim-mode-banner b { color: #fdba74; }
+#sim-mode-banner code {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+}
+#btn-sim-banner-off { flex: 0 0 auto; white-space: nowrap; }


### PR DESCRIPTION
## What it adds

**`tools/robot_config_engine/`** — a browser-based configuration studio plus a
Python engine that generates a `linorobot2_hardware` setup from a guided form:

- `web/` — a **zero-dependency** studio (`index.html` + `app.js` + `style.css`)
  served by `web/server.py` (stdlib `http.server`, ~30-40 MB RAM). Detects the
  board from its USB VID:PID — including telling a plain CP2102 apart from a
  CP2102N and FTDI bridges, so it only suggests the 1.5M baud rate (and hides
  the option entirely otherwise) when the actual chip supports it — walks you
  through kinematics / driver / sensors / pins / telemetry, shows the
  generated code live, and offers 1-click build / flash / micro-ROS-agent,
  ADC-calibration LUT capture, and a UDP syslog viewer. Every config write
  goes through a search-and-merge so hand edits to an existing header survive
  re-generation instead of being overwritten.
- `generate_config.py` — CLI: validate a `spec.json` and emit (or merge) the
  `config/custom/<robot>_config.h`, the `[env:<robot>]` section, and the URDF
  xacro.
- `validator.py` / `generator.py` / `parser.py` — hardware rules + codegen +
  lossless round-trip of an imported header. `schema.json` documents the spec.
- `examples/*.json` — sample specs (Pico 2, Pico 2 W, ESP32, ESP32-S3).
- `test_config_engine.py` — unit tests (stdlib `unittest`, no hardware),
  18 tests, all green.

**`tools/i2c_detect/`** — a tiny PlatformIO sketch (`pico2` / `pico` / `esp32` /
`esp32s3` / `gendrv`) that scans the I2C bus and prints found addresses over
serial, for bringing up a bare board before any sensor config exists.

**`.github/workflows/config-engine-ci.yml`** — standalone CI, deliberately
**independent of the firmware build matrix**: engine unit tests + a generator
smoke test over the example specs, byte-compile, `node --check app.js`, and a
PlatformIO build of `tools/i2c_detect`. Path-filtered to `tools/`.

**Build speed**: when the studio launches a diagnostic-tool build
(`test_sensors`/`test_motors`/`test_acc`), it now sets `PLATFORMIO_LIBDEPS_DIR`
to `firmware/`'s libdeps dir so the tool reuses the already-built micro-ROS
static lib instead of rebuilding it, cutting each tool's build from ~75s to ~5s.

The generated `config/custom/<robot>_config.h` stays the single source of
truth. WiFi credentials are written only to the **git-ignored**
`config/custom/wifi_config.h`, never the tracked header.

## Commit order (2 commits)

1. **`firmware: allow LED_PIN -1 to mean no addressable status LED`** — must come
   first. The configuration engine's *bare module* default emits
   `#define LED_PIN -1`; without this firmware guard the bare-module build fails
   the moment the firmware writes to the LED. Board configs that keep
   `LED_PIN LED_BUILTIN` are unaffected (a non-macro identifier folds to `0` in
   the `#if`, so the LED stays enabled and resolves at link time).
2. **`tools: add Robot Configuration Engine + i2c_detect`** — everything above,
   squashed into one commit, scoped strictly to `tools/`, `.github/workflows/`,
   and this `README.md`. (A related `adc_calibrate` firmware tweak — a
   selectable DAC calibration pin — is out of scope here and will come as its
   own standalone PR.)

Rebased onto current `jazzy` — no conflicts, both commits apply cleanly on
top of the recent Humble-removal and shared-micro-ROS-build changes already
merged upstream.

## Tried on real hardware

Bare one-click deploy verified on RP2040 (Pico), RP2350 (Pico 2), and ESP32;
WiFi-UDP transport + OTA + syslog on ESP32; ADC-calibrate → LUT merge →
`/battery` and HC-SR04 → `/sonar` on a bare ESP32; the full onboard sensor
suite (QMI8658 IMU, AK09918 magnetometer, INA219 current sensor, BMP280
barometer) publishing on a real Waveshare GenDrv board at both 921600 and
1.5M baud; and the USB-bridge-chip-aware baud auto-detect against two real
boards side by side — a GenDrv's genuine CP2102N (auto-selects 1.5M) and a
bare ESP32's plain CP2102 (correctly stays at 921600 and hides the 1.5M
option). Not yet exercised: real closed-loop motors/encoders (`test_motors`),
a full magnetometer-calibration walkthrough, and the LiDAR-UDP path.

This has had substantial real-hardware exercise across several sessions and
I think it's ready to merge — removing the preview label. Happy to adjust
scope, split further, or address anything review turns up.
