### PR TITLE
fix(platformio): share firmware/'s micro-ROS build across test/calibration tools

### DIFF
--- a/adc_calibrate/platformio.ini
+++ b/adc_calibrate/platformio.ini
@@ -1,6 +1,15 @@
 [platformio]
 extra_configs =
     ../firmware/platformio.ini
+; Share firmware/'s lib_deps download+build output instead of each tool
+; redoing it from scratch in its own directory -- skips re-downloading
+; every lib_dep inherited from firmware/platformio.ini's [env] (this tool
+; doesn't itself link micro_ros_platformio, but other tools that inherit
+; the same [env] do, and its slow one-time build -- extra_script.py
+; compiles a full micro-ROS static library and caches the result *inside*
+; the libdeps tree -- is what benefits most from all of them sharing one
+; libdeps_dir with firmware/).
+libdeps_dir = ../firmware/.pio/libdeps
 
 [env]
 lib_extra_dirs =

--- a/bno085_cal/platformio.ini
+++ b/bno085_cal/platformio.ini
@@ -1,6 +1,15 @@
 [platformio]
 extra_configs =
     ../firmware/platformio.ini
+; Share firmware/'s lib_deps download+build output instead of each tool
+; redoing it from scratch in its own directory. Matters most for
+; micro_ros_platformio (which this tool links transitively, via
+; firmware/lib/imu's message-typed interface): its extra_script.py runs a
+; slow one-time build (compiles a full micro-ROS static library) and
+; caches the result *inside* the libdeps tree, so pointing every tool at
+; firmware/'s libdeps_dir lets them all reuse that build instead of paying
+; for it again. Also skips re-downloading every other lib_dep.
+libdeps_dir = ../firmware/.pio/libdeps
 
 [env]
 lib_extra_dirs =

--- a/test_acc/platformio.ini
+++ b/test_acc/platformio.ini
@@ -1,6 +1,15 @@
 [platformio]
 extra_configs =
     ../firmware/platformio.ini
+; Share firmware/'s lib_deps download+build output instead of each tool
+; redoing it from scratch in its own directory. Matters most for
+; micro_ros_platformio (which this tool links transitively, via
+; firmware/lib/imu's message-typed interface): its extra_script.py runs a
+; slow one-time build (compiles a full micro-ROS static library) and
+; caches the result *inside* the libdeps tree, so pointing every tool at
+; firmware/'s libdeps_dir lets them all reuse that build instead of paying
+; for it again. Also skips re-downloading every other lib_dep.
+libdeps_dir = ../firmware/.pio/libdeps
 
 [env]
 lib_extra_dirs =

--- a/test_motors/platformio.ini
+++ b/test_motors/platformio.ini
@@ -1,6 +1,15 @@
 [platformio]
 extra_configs =
     ../firmware/platformio.ini
+; Share firmware/'s lib_deps download+build output instead of each tool
+; redoing it from scratch in its own directory. Matters most for
+; micro_ros_platformio (which this tool links transitively, via
+; firmware/lib/imu's message-typed interface): its extra_script.py runs a
+; slow one-time build (compiles a full micro-ROS static library) and
+; caches the result *inside* the libdeps tree, so pointing every tool at
+; firmware/'s libdeps_dir lets them all reuse that build instead of paying
+; for it again. Also skips re-downloading every other lib_dep.
+libdeps_dir = ../firmware/.pio/libdeps
 
 [env]
 lib_extra_dirs =

--- a/test_sensors/platformio.ini
+++ b/test_sensors/platformio.ini
@@ -1,6 +1,15 @@
 [platformio]
 extra_configs =
     ../firmware/platformio.ini
+; Share firmware/'s lib_deps download+build output instead of each tool
+; redoing it from scratch in its own directory. Matters most for
+; micro_ros_platformio (which this tool links transitively, via
+; firmware/lib/imu's message-typed interface): its extra_script.py runs a
+; slow one-time build (compiles a full micro-ROS static library) and
+; caches the result *inside* the libdeps tree, so pointing every tool at
+; firmware/'s libdeps_dir lets them all reuse that build instead of paying
+; for it again. Also skips re-downloading every other lib_dep.
+libdeps_dir = ../firmware/.pio/libdeps
 
 [env]
 lib_extra_dirs =


### PR DESCRIPTION
## Problem

`test_sensors/`, `test_motors/`, `test_acc/`, `adc_calibrate/`, and
`bno085_cal/` each carry their own `platformio.ini` with
`extra_configs = ../firmware/platformio.ini`, inheriting firmware's
`[env:<board>]` sections and `lib_deps` — but as their own separate
PlatformIO project directories, each one downloads and builds every
`lib_dep` independently, even though it's identical to what `firmware/`
already built for the same board/env.

`micro_ros_platformio` is by far the most expensive of these: its
`extra_script.py` build hook compiles a full micro-ROS static library
from scratch on first use (measured ~70-90s of a build, vs a few seconds
for everything else combined) and stores the result inside its own
install directory under `libdeps_dir`.

`test_sensors`/`test_motors`/`test_acc` genuinely need this dependency —
it's not unused weight. `firmware/lib/imu`'s message-typed interface
(`imu_interface.h`/`mag_interface.h`, pulled in via `imu.h`/`mag.h`)
calls `micro_ros_string_utilities_set()` for the `frame_id` field and
uses micro-ROS-generated message structs throughout, so it can't simply
be dropped from their `lib_deps`. Only `adc_calibrate` doesn't link it at
all, but it still redundantly re-downloads every other `lib_dep` on its
own.

## Fix

Point each tool's `[platformio] libdeps_dir` at `firmware/`'s own
(default, otherwise-untouched) libdeps location. PlatformIO then treats
every `lib_dep`, including `micro_ros_platformio`'s build output, as
already installed there and reuses it instead of redoing the work.

This is PlatformIO's own documented project-config option (equivalent to
the `PLATFORMIO_LIBDEPS_DIR` env var, but baked into the `.ini` itself),
so it applies uniformly whether building through a script, CI, or a
plain `pio run` typed by hand — no env var needs to be set at invocation
time, and `firmware/platformio.ini` itself needs no change.

## Verification

Built on a clean cache, ESP32 target, on the real PlatformIO toolchain:

| Step | Before | After |
|---|---|---|
| `firmware` (cold, includes the real micro-ROS compile) | ~76-98s | unchanged |
| `test_sensors` / `test_motors` / `test_acc` (same env, after firmware) | re-does the full micro-ROS build again | ~5-6s, prints `"micro-ROS already built"`, zero re-downloaded libs |
| `adc_calibrate` / `bno085_cal` | re-downloads every `lib_dep` | ~4-6s, zero re-downloaded libs |

Confirmed via the build logs that no `Installing`/`Downloading` lines
appear for any `lib_dep` (i2cdetect, I2Cdevlib-*, ESP32Servo,
ESP32Encoder, etc.) once shared — only the object-file compilation of
those (cheap, a few seconds) still happens per project directory, which
is expected and not the bottleneck being addressed here.

No functional/runtime changes — this only affects where PlatformIO
stores/reuses build-time dependencies.