### PR TITLE
ci: prevent duplicate workflow triggers on PR branch pushes and add concurrency

### DIFF
--- a/.github/workflows/jazzy-firmware-build.yml
+++ b/.github/workflows/jazzy-firmware-build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     # Run on PRs to jazzy, main, devel, and upstream-pr branches
     branches:
-      - jazzy*
+      - jazzy
       - main
       - devel
       - 'upstream-pr/**'
@@ -18,7 +18,7 @@ on:
   push:
     # Run on pushes to jazzy, main, devel, and upstream-pr branches
     branches:
-      - jazzy*
+      - jazzy
       - main
       - devel
       - 'upstream-pr/**'
@@ -36,6 +36,10 @@ on:
   # Allow manual triggering
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   firmware:

--- a/.github/workflows/rolling-firmware-build.yml
+++ b/.github/workflows/rolling-firmware-build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     # Run on PRs to rolling, main, devel, and upstream-pr branches
     branches:
-      - rolling*
+      - rolling
       - main
       - devel
       - 'upstream-pr/**'
@@ -18,7 +18,7 @@ on:
   push:
     # Run on pushes to rolling, main, devel, and upstream-pr branches
     branches:
-      - rolling*
+      - rolling
       - main
       - devel
       - 'upstream-pr/**'
@@ -36,6 +36,10 @@ on:
   # Allow manual triggering
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   firmware:


### PR DESCRIPTION
### Summary
Resolves #164.

When pushing to a branch named with a  or  prefix (e.g. ) on the repository while an open PR targets :
1. The  trigger fired because the branch name matched the wildcard pattern .
2. The  trigger also fired because the PR's target base branch is .

This resulted in duplicate concurrent CI matrix runs (32 jobs instead of 16) on the exact same commit.

### Changes
- Changed wildcard branch patterns (, ) to exact branch names (, ) under both  and  in:
  - 
  - 
- Added workflow concurrency cancellation to automatically terminate superseded in-flight builds on rapid pushes:
  
