### PR TITLE
ci: pass GITHUB_TOKEN to setup-ros to fix intermittent build failures

### DIFF
--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -50,6 +50,13 @@ jobs:
 
       - name: Setup ROS
         uses: ros-tooling/setup-ros@v0.7
+        env:
+          # setup-ros looks up the latest ros-apt-source release via an
+          # unauthenticated GitHub API call (60 req/hr, shared across every
+          # public runner). Passing a token here raises that to 5000/hr and
+          # avoids the intermittent "curl: (22) The requested URL returned
+          # error: 404" failure this step otherwise hits at random.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           required-ros-distributions: ${{ inputs.ros_distro }}
 
@@ -190,6 +197,13 @@ jobs:
 
       - name: Setup ROS
         uses: ros-tooling/setup-ros@v0.7
+        env:
+          # setup-ros looks up the latest ros-apt-source release via an
+          # unauthenticated GitHub API call (60 req/hr, shared across every
+          # public runner). Passing a token here raises that to 5000/hr and
+          # avoids the intermittent "curl: (22) The requested URL returned
+          # error: 404" failure this step otherwise hits at random.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           required-ros-distributions: ${{ inputs.ros_distro }}
 


### PR DESCRIPTION
This CI workflow (`reusable-platformio-ci.yml`, shared by the jazzy/rolling
firmware build workflows) has been hitting intermittent failures on random
firmware targets, not caused by any actual code change -- seen most recently
on PR #163 across two different pushes: `esp32s2_wifi` failed once, then on
a re-trigger `esp32`, `pico2`, and `picow_wifi` failed instead.

## Root cause

The `Setup ROS` step (`ros-tooling/setup-ros@v0.7`) resolves the latest
`ros-apt-source` release via an **unauthenticated** call to
`api.github.com` (60 requests/hour, shared across every public GitHub
Actions runner on the planet). When that budget is exhausted the lookup
silently returns nothing, `ROS_APT_SOURCE_VERSION` ends up empty, and the
subsequent download 404s:

```
curl: (22) The requested URL returned error: 404
##[error]The process '/usr/bin/bash' failed with exit code 22
```

## Fix

Pass `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` as an env var to the
`Setup ROS` step (both occurrences in this file). This authenticates the
internal lookup, raising the rate limit to 5000/hour. `secrets.GITHUB_TOKEN`
is the workflow's own ambient token -- no new secret to configure, no
permission changes needed.

No functional change to what gets built; this only fixes the flaky
dependency-resolution step.
