### PR TITLE
feat(firmware): add fake wheel and fake LD19 LiDAR simulation modes for bare module robots

### DIFF
--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -156,6 +156,10 @@ jobs:
           PLATFORMIO_BUILD_FLAGS="-D USE_MPU9250_IMU -D USE_AK8963_MAG -D LINO_BASE=MECANUM -D USE_GENERIC_2_IN_MOTOR_DRIVER" pio run -e esp32s3
           echo "== Matrix 6: ESP32 WiFi with LiDAR UDP Forwarding =="
           PLATFORMIO_BUILD_FLAGS="-D USE_LIDAR_UDP" pio run -e esp32_wifi
+          echo "== Matrix 7: Pico 2 Bare Module Simulation (Fake Wheel + Fake LD19) =="
+          PLATFORMIO_BUILD_FLAGS="-D USE_FAKE_WHEEL -D USE_FAKE_LD19 -D FAKE_WALL_OBSTACLE=1" pio run -e pico2
+          echo "== Matrix 8: GenDrv Bare Module Simulation (Fake Wheel + Fake LD19) =="
+          PLATFORMIO_BUILD_FLAGS="-D USE_FAKE_WHEEL -D USE_FAKE_LD19 -D FAKE_WALL_OBSTACLE=1 -D BAUDRATE=1500000" pio run -e gendrv
 
 
 

--- a/README.md
+++ b/README.md
@@ -417,6 +417,100 @@ Constants' Meaning:
 
 - **PWM_FREQUENCY** - Frequency of the PWM signals used to control the motor drivers. You can use the default value if you're unsure what to put here. More info [here](https://www.pjrc.com/teensy/td_pulse.html).
 
+### FAKE WHEEL MODE (SIMULATED DRIVETRAIN)
+
+- **USE_FAKE_WHEEL** - Simulate the drivetrain on the board itself, so a bare module with no
+motors, drivers or encoders attached behaves like a robot. `cmd_vel` drives simulated wheels
+whose encoders report back to the PID, so `/odom/unfiltered` and `/imu/data` move as they would
+on real hardware and you can run teleop, SLAM or navigation against the board alone. Undefined by
+default; the motor drivers still receive their PWM, and the kinematics, PID and odometry are all
+still exercised.
+
+Each wheel is modelled as a DC motor driving a share of the robot's mass: driving torque falls
+off as back-EMF rises, acceleration is limited, friction opposes motion, and a stall band keeps a
+weak duty from creeping. So the wheels accelerate from rest, tail off near top speed, and coast
+down when power is cut, more slowly on a heavier robot. The reported RPM carries noise, which
+gives the PID real error to correct and makes the odometry drift as it does on hardware. The
+simulated IMU is derived from the same motion, so the accelerometer and gyroscope agree with the
+wheel encoders.
+
+        #define USE_FAKE_WHEEL
+
+Optional tuning, all with defaults:
+
+- **FAKE_ROBOT_MASS** - Simulated mass in kg. Defaults to `ROBOT_WEIGHT` when defined, so a
+heavier robot accelerates more slowly.
+- **FAKE_WHEEL_TAU_MS** - Spin-up time constant in milliseconds at the reference mass.
+- **FAKE_WHEEL_MAX_ACCEL_RPM** - Traction and current limit, in RPM per second.
+- **FAKE_WHEEL_FRICTION** - Viscous drag, as a fraction of the current RPM per second.
+- **FAKE_WHEEL_NOISE_RPM** - Peak encoder noise in RPM.
+- **FAKE_IMU_ACCEL_NOISE** / **FAKE_IMU_GYRO_NOISE** - Peak simulated IMU noise.
+
+Encoder pins still select which wheels exist: a motor whose encoder pins are unset stays at zero
+RPM, so a 2WD configuration simulates two wheels and not four.
+
+### FAKE LD19 LIDAR MODE (SIMULATED LASER)
+
+- **USE_FAKE_LD19** - Embeds a real-time, 2D geometric raycasting LiDAR emulator in the
+firmware. Raycasts against a configurable rectangular room and optional interior obstacle
+wall, outputting authentic 47-byte LDROBOT LD19 binary packets (`0x54 0x2C` header, 12 distance
+points, start/end angles, CRC8 checksum) at 10 Hz / 230,400 baud over `LIDAR_RXD` (or over Wi-Fi
+UDP port 8889 if `USE_LIDAR_UDP` is defined).
+
+When combined with `USE_FAKE_WHEEL`, the laser scan updates dynamically as the robot navigates
+in response to `cmd_vel`, allowing complete SLAM mapping, map saving, and Nav2 navigation on a
+bare module without physical motors, drivers or LiDAR.
+
+        #define USE_FAKE_LD19
+
+Optional room and obstacle parameters, all with defaults:
+
+- **FAKE_MAP_WIDTH** / **FAKE_MAP_HEIGHT** - Dimensions of the simulated boundary room in meters
+  (defaults: 6.0m x 4.0m, centered at origin).
+- **FAKE_WALL_OBSTACLE** - Set to 1 to enable the interior obstacle wall, 0 to disable (default: 1).
+- **FAKE_WALL_X1**, **FAKE_WALL_Y1**, **FAKE_WALL_X2**, **FAKE_WALL_Y2** - Coordinates of the obstacle
+  wall in meters (defaults: from (1.0, -0.8) to (1.0, 0.8), a 1.6m barrier positioned 1.0m ahead).
+- **LIDAR_RXD** - Microcontroller pin used to emit the packet stream (defaults to board LiDAR RXD pin).
+- **LIDAR_BAUDRATE** - Serial baud rate (default: 230400).
+
+#### Application: Waveshare GenDrv as a Self-Contained Fake Robot
+
+The Waveshare General Driver Board (`gendrv` ESP32) is ideal for fake robot bench testing because
+it includes two onboard USB serial bridges:
+- **Port 1 (`/dev/ttyUSB0`)**: micro-ROS high-speed serial transport @ 1.5M baud (`-D BAUDRATE=1500000`).
+- **Port 2 (`/dev/ttyUSB1`)**: LD19 LiDAR serial stream @ 230,400 baud (`LIDAR_BAUDRATE 230400`).
+
+With the same physical wiring as LiDAR UDP forwarding (GPIO 4 connected to the onboard second USB
+bridge RX, or streamed over Wi-Fi UDP), a bare GenDrv board acts as a complete simulated robot:
+
+1. **Dual-Channel Serial Mode (1.5M Baud)**:
+   - micro-ROS agent runs over USB serial at 1.5M baud:
+     ```bash
+     ros2 run micro_ros_agent micro_ros_agent serial --dev /dev/ttyUSB0 -b 1500000
+     ```
+   - Standard `ldlidar_stl_ros2` node connects to `/dev/ttyUSB1` @ 230,400 baud:
+     ```bash
+     ros2 run ldlidar_stl_ros2 ldlidar_stl_ros2_node --ros-args \
+       -p product_name:=LDLiDAR_LD19 -p port_name:=/dev/ttyUSB1 -p port_baudrate:=230400 \
+       -p frame_id:=laser -p topic_name:=scan
+     ```
+
+2. **Wireless Wi-Fi UDP Transport Mode**:
+   - micro-ROS bridges over Wi-Fi UDP to port 8888:
+     ```bash
+     ros2 run micro_ros_agent micro_ros_agent udp4 --port 8888
+     ```
+   - Fake LD19 streams batched UDP packets (141 bytes = 3 packets/frame) to port 8889:
+     ```bash
+     ros2 run ldlidar_stl_ros2 ldlidar_stl_ros2_node --ros-args \
+       -p product_name:=LDLiDAR_LD19 -p comm_mode:=udp_server \
+       -p server_ip:=0.0.0.0 -p server_port:=8889 \
+       -p frame_id:=laser -p topic_name:=scan
+     ```
+
+3. **Autonomous Navigation**:
+   Launch `slam_toolbox` or Nav2 directly on your workstation or robot SBC. Driving the fake robot via `/cmd_vel` advances odometry and updates the simulated laser scan against the room walls and barrier obstacle in real time.
+
 ### 2. Hardware Pin Assignments
 Only modify the pin assignments under the motor driver constant that you are using ie. `#ifdef USE_GENERIC_2_IN_MOTOR_DRIVER`. You can check out PJRC's [pinout page](https://www.pjrc.com/teensy/pinout.html) for each board's pin layout.
 

--- a/firmware/lib/encoder/fake_wheel.h
+++ b/firmware/lib/encoder/fake_wheel.h
@@ -1,0 +1,403 @@
+// Copyright (c) 2021 Juan Miguel Jimeno
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FAKE_WHEEL_H
+#define FAKE_WHEEL_H
+
+#include <Arduino.h>
+
+// Simulated drivetrain for a bare module with no motors or encoders attached.
+//
+// Each wheel is modelled as a DC motor driving a share of the robot's mass:
+//
+//   duty      = pwm / PWM_MAX                 commanded power
+//   no_load   = duty * MOTOR_MAX_RPM          speed the motor would settle at
+//   torque   ~= no_load - rpm                 back-EMF: torque falls as it spins up
+//   d(rpm)/dt = torque / tau_eff              tau_eff scales with robot mass
+//
+// so the wheel accelerates hard when the error is large, tails off as it
+// approaches speed, coasts down against friction when power is cut, and takes
+// longer to do all of it on a heavier robot. Acceleration is clamped to a
+// traction/current limit, and a stall band keeps a weak duty from creeping.
+// The reported RPM carries white noise, so the PID has something real to
+// correct against and the odometry drifts the way it does on real hardware.
+
+// The robot's total weight is optional robot data from the config engine, which
+// emits it as ROBOT_WEIGHT. Use it when it is there, so the simulated robot has
+// the inertia of the one that was configured.
+#ifndef FAKE_ROBOT_MASS
+    #ifdef ROBOT_WEIGHT
+        #define FAKE_ROBOT_MASS ROBOT_WEIGHT
+    #else
+        #define FAKE_ROBOT_MASS 3.5     // simulated robot mass (kg)
+    #endif
+#endif
+
+#ifndef FAKE_WHEEL_TAU_MS
+#define FAKE_WHEEL_TAU_MS 150       // spin-up time constant (ms) at FAKE_WHEEL_REF_MASS
+#endif
+
+#ifndef FAKE_WHEEL_REF_MASS
+#define FAKE_WHEEL_REF_MASS 3.5     // mass FAKE_WHEEL_TAU_MS was measured at (kg)
+#endif
+
+#ifndef FAKE_WHEEL_MAX_ACCEL_RPM
+#define FAKE_WHEEL_MAX_ACCEL_RPM 900.0  // traction/current limit (RPM per second)
+#endif
+
+#ifndef FAKE_WHEEL_FRICTION
+#define FAKE_WHEEL_FRICTION 0.06    // viscous drag, fraction of current RPM per second
+#endif
+
+#ifndef FAKE_WHEEL_STALL_DUTY
+#define FAKE_WHEEL_STALL_DUTY 0.04  // duty below which the motor cannot break static friction
+#endif
+
+#ifndef FAKE_WHEEL_NOISE_RPM
+#define FAKE_WHEEL_NOISE_RPM 1.0    // +/- peak white noise on the reported RPM
+#endif
+
+// +/- peak white noise, scaled by amplitude
+static inline float fakeWheelNoise(float amplitude)
+{
+    return ((float)random(-1000, 1001) / 1000.0) * amplitude;
+}
+
+class FakeEncoder
+{
+private:
+    int counts_per_rev_ = -1;
+    bool invert_ = false;
+    float duty_ = 0.0;              // commanded duty cycle, -1.0 .. 1.0
+    float wheel_rpm_ = 0.0;         // simulated wheel speed
+    double ticks_ = 0.0;            // simulated tick accumulator
+    unsigned long prev_update_time_ = 0;
+
+    // advance the wheel model to now
+    void integrate()
+    {
+        unsigned long current_time = micros();
+        unsigned long dt = current_time - prev_update_time_;
+        prev_update_time_ = current_time;
+        // first call, or a micros() rollover: seed the clock, don't step the model
+        if (dt == 0 || dt > 1000000UL) return;
+        float dts = (float)dt / 1000000.0;
+
+        // heavier robot, more inertia per wheel, slower response
+        float tau = (FAKE_WHEEL_TAU_MS / 1000.0) *
+                    ((float)FAKE_ROBOT_MASS / (float)FAKE_WHEEL_REF_MASS);
+        if (tau < 0.001) tau = 0.001;
+
+        float no_load_rpm = duty_ * (float)MOTOR_MAX_RPM;
+        // below the stall band the motor cannot hold the wheel against friction
+        if (fabsf(duty_) < (float)FAKE_WHEEL_STALL_DUTY) no_load_rpm = 0.0;
+
+        // back-EMF: driving torque is proportional to the remaining speed error
+        float accel = (no_load_rpm - wheel_rpm_) / tau;
+        // viscous friction always opposes motion
+        accel -= wheel_rpm_ * (float)FAKE_WHEEL_FRICTION;
+        // traction and current limit the achievable acceleration
+        if (accel > (float)FAKE_WHEEL_MAX_ACCEL_RPM) accel = (float)FAKE_WHEEL_MAX_ACCEL_RPM;
+        if (accel < -(float)FAKE_WHEEL_MAX_ACCEL_RPM) accel = -(float)FAKE_WHEEL_MAX_ACCEL_RPM;
+
+        wheel_rpm_ += accel * dts;
+        // an unpowered wheel settles rather than creeping forever
+        if (no_load_rpm == 0.0 && fabsf(wheel_rpm_) < 0.5) wheel_rpm_ = 0.0;
+
+        // accumulate ticks so read() stays consistent with getRPM()
+        ticks_ += (double)wheel_rpm_ / 60.0 * counts_per_rev_ * dts;
+    }
+
+public:
+    FakeEncoder(int pin1, int pin2, int counts_per_rev, bool invert = false)
+    {
+        // The pins are deliberately ignored. Fake wheel mode exists for boards
+        // with nothing wired, where the encoder pins are normally left unset
+        // (-1); keying off them would leave every simulated wheel at 0 RPM,
+        // which is the one case this class is for. Nothing here touches GPIO.
+        // Which wheels actually count is the kinematics' decision, not the pin
+        // map: Kinematics::getVelocities() zeroes motors 3 and 4 on a
+        // differential base regardless of what the encoders report.
+        (void)pin1;
+        (void)pin2;
+        counts_per_rev_ = (counts_per_rev > 0) ? counts_per_rev : 1;
+        invert_ = invert;
+    }
+
+    // called by the control loop with the PWM just handed to the motor driver
+    void feed(int pwm)
+    {
+        if (counts_per_rev_ < 0) return;
+        integrate();
+        if (invert_) pwm *= -1;
+        // PWM_MAX expands to an unparenthesized expression (`pow(2, PWM_BITS) - 1`),
+        // so it has to be wrapped before dividing or the `- 1` escapes the cast and
+        // lands outside the division, turning a small duty into nearly full reverse.
+        float duty = (float)pwm / (float)(PWM_MAX);
+        if (duty > 1.0) duty = 1.0;
+        if (duty < -1.0) duty = -1.0;
+        duty_ = duty;
+    }
+
+    float getRPM()
+    {
+        if (counts_per_rev_ < 0) return 0.0;
+        integrate();
+        return wheel_rpm_ + fakeWheelNoise((float)FAKE_WHEEL_NOISE_RPM);
+    }
+
+    inline int32_t read()
+    {
+        if (counts_per_rev_ < 0) return 0;
+        integrate();
+        return (int32_t)ticks_;
+    }
+
+    inline void write(int32_t p)
+    {
+        if (counts_per_rev_ < 0) return;
+        ticks_ = (double)p;
+    }
+};
+
+#ifndef FAKE_IMU_GRAVITY
+#define FAKE_IMU_GRAVITY 9.81       // specific force reported on Z when level
+#endif
+
+#ifndef FAKE_IMU_ACCEL_TAU_MS
+#define FAKE_IMU_ACCEL_TAU_MS 60    // accelerometer band limit (ms)
+#endif
+
+#ifndef FAKE_IMU_ACCEL_NOISE
+#define FAKE_IMU_ACCEL_NOISE 0.05   // +/- peak accelerometer noise (m/s^2)
+#endif
+
+// A real MEMS IMU is not a clean derivative of the truth: it has a fixed bias,
+// a bias that wanders slowly with temperature, a scale-factor error, and white
+// noise on top. Fusion (madgwick, the EKF) exists to fight exactly that, so a
+// perfect simulated IMU would make the whole estimation stack look better than
+// it is on hardware.
+#ifndef FAKE_IMU_GYRO_BIAS
+#define FAKE_IMU_GYRO_BIAS 0.004f       // fixed gyro bias (rad/s)
+#endif
+
+#ifndef FAKE_IMU_GYRO_DRIFT
+#define FAKE_IMU_GYRO_DRIFT 0.0015f     // gyro bias random walk (rad/s per sqrt(s))
+#endif
+
+#ifndef FAKE_IMU_ACCEL_BIAS
+#define FAKE_IMU_ACCEL_BIAS 0.03f       // fixed accelerometer bias (m/s^2)
+#endif
+
+#ifndef FAKE_IMU_ACCEL_DRIFT
+#define FAKE_IMU_ACCEL_DRIFT 0.01f      // accelerometer bias random walk (m/s^2 per sqrt(s))
+#endif
+
+#ifndef FAKE_IMU_SCALE_ERROR
+#define FAKE_IMU_SCALE_ERROR 0.01f      // scale-factor error, fraction of reading
+#endif
+
+#ifndef FAKE_MAG_FIELD_T
+#define FAKE_MAG_FIELD_T 50e-6f     // Simulated field strength (Tesla, ~Earth)
+#endif
+
+#ifndef FAKE_MAG_ROOM_HEADING
+#define FAKE_MAG_ROOM_HEADING 0.0f  // Heading (rad) of the room's +X axis vs the field
+#endif
+
+#ifndef FAKE_MAG_NOISE_T
+#define FAKE_MAG_NOISE_T 0.5e-6f    // +/- peak magnetometer noise (Tesla)
+#endif
+
+// Hard-iron offset. A magnetometer mounted on a robot always sits next to
+// motors, batteries and steel, which add a fixed vector to every reading and
+// pull the heading round with the robot. Simulating it means the magnetometer
+// calibration routine has a real offset to discover and remove, instead of
+// converging on zero and proving nothing.
+#ifndef FAKE_MAG_BIAS_X
+#define FAKE_MAG_BIAS_X 6.0e-6f
+#endif
+#ifndef FAKE_MAG_BIAS_Y
+#define FAKE_MAG_BIAS_Y -4.0e-6f
+#endif
+#ifndef FAKE_MAG_BIAS_Z
+#define FAKE_MAG_BIAS_Z 2.5e-6f
+#endif
+
+#ifndef FAKE_IMU_GYRO_NOISE
+#define FAKE_IMU_GYRO_NOISE 0.005   // +/- peak gyroscope noise (rad/s)
+#endif
+
+// Derives IMU readings from the simulated body motion, so the accelerometer
+// and gyroscope agree with the wheel encoders instead of reading zero.
+// Hold a wandering bias inside a plausible envelope.
+static inline float clampBias(float v, float limit)
+{
+    if (limit < 0.0f) limit = -limit;
+    if (v >  limit) return  limit;
+    if (v < -limit) return -limit;
+    return v;
+}
+
+class FakeIMUFromWheels
+{
+private:
+    float linear_x_ = 0.0;          // latest body velocities
+    float linear_y_ = 0.0;
+    float angular_z_ = 0.0;
+    float accel_x_ = 0.0;           // smoothed body accelerations
+    float accel_y_ = 0.0;
+    float heading_ = 0.0;           // simulated yaw, for the magnetometer
+    // slowly wandering sensor biases, seeded to a fixed offset and then walked
+    // Start calibrated. A real IMU has its static bias measured and subtracted
+    // at startup -- IMUInterface::init() calls calibrateGyro(), which averages
+    // 40 samples and stores the offset. Fake wheel mode never calls that (there
+    // is no chip to talk to), so seeding these with the full bias simulated an
+    // IMU that had skipped its own calibration: the gyro read a steady offset
+    // forever, the EKF integrated it, and yaw walked away from the wheels.
+    float gyro_bias_z_ = 0.0f;
+    float accel_bias_x_ = 0.0f;
+    float accel_bias_y_ = 0.0f;
+
+public:
+    // With no real IMU on the bus, imu.getData() / mag.getData() are never
+    // called, and the two messages never get the frame and covariances those
+    // calls would have filled in. Set them once here instead: without a
+    // frame_id the messages are dropped by tf, and with zero covariance the
+    // EKF treats the simulated sensor as exact.
+    void initMsgs(sensor_msgs__msg__Imu &imu_msg,
+                  sensor_msgs__msg__MagneticField &mag_msg)
+    {
+        const float accel_cov[3] = ACCEL_COV;
+        const float gyro_cov[3] = GYRO_COV;
+        const float ori_cov[3] = ORI_COV;
+        const float mag_cov[3] = MAG_COV;
+
+        imu_msg.header.frame_id =
+            micro_ros_string_utilities_set(imu_msg.header.frame_id, "imu_link");
+        mag_msg.header.frame_id =
+            micro_ros_string_utilities_set(mag_msg.header.frame_id, "imu_link");
+
+        for (int i = 0; i < 3; i++)
+        {
+            const int d = i * 4;    // 0, 4, 8: the diagonal of a 3x3 row-major
+            imu_msg.linear_acceleration_covariance[d] = accel_cov[i];
+            imu_msg.angular_velocity_covariance[d] = gyro_cov[i];
+            imu_msg.orientation_covariance[d] = ori_cov[i];
+            mag_msg.magnetic_field_covariance[d] = mag_cov[i];
+        }
+    }
+
+    // fed from the body velocities the kinematics derived from the wheels
+    void update(float linear_x, float linear_y, float angular_z, float dt)
+    {
+        if (dt > 0.0)
+        {
+            // differencing velocity at the loop rate is spiky; a real
+            // accelerometer is band limited, so ease into the new value
+            float raw_x = (linear_x - linear_x_) / dt;
+            float raw_y = (linear_y - linear_y_) / dt;
+            float alpha = 1.0 - expf(-dt / (FAKE_IMU_ACCEL_TAU_MS / 1000.0));
+            accel_x_ += (raw_x - accel_x_) * alpha;
+            accel_y_ += (raw_y - accel_y_) * alpha;
+
+            // Random walk: the step scales with sqrt(dt), so the drift rate is
+            // independent of how often this happens to be called.
+            //
+            // Bounded, because a free random walk has no bound and this one had
+            // none: the longer the board ran, the further the bias wandered,
+            // and it does not come back. Measured after a long session the
+            // stationary gyro read 0.01813 rad/s -- 4.5x the nominal bias --
+            // and the EKF turned that into 0.87 deg/s of yaw drift, 52 deg in a
+            // minute while the robot stood still. Real parts do not do that:
+            // bias instability wanders within an envelope. Clamping to the
+            // nominal bias keeps the drift a filter has to cope with, without
+            // letting uptime decide whether SLAM works.
+            const float rw = sqrtf(dt);
+            gyro_bias_z_  += fakeWheelNoise((float)FAKE_IMU_GYRO_DRIFT) * rw;
+            accel_bias_x_ += fakeWheelNoise((float)FAKE_IMU_ACCEL_DRIFT) * rw;
+            accel_bias_y_ += fakeWheelNoise((float)FAKE_IMU_ACCEL_DRIFT) * rw;
+            gyro_bias_z_  = clampBias(gyro_bias_z_,  (float)FAKE_IMU_GYRO_BIAS);
+            accel_bias_x_ = clampBias(accel_bias_x_, (float)FAKE_IMU_ACCEL_BIAS);
+            accel_bias_y_ = clampBias(accel_bias_y_, (float)FAKE_IMU_ACCEL_BIAS);
+        }
+        linear_x_ = linear_x;
+        linear_y_ = linear_y;
+        angular_z_ = angular_z;
+    }
+
+    // The simulated robot turns, so a magnetometer stuck at a constant vector
+    // would disagree with the yaw the wheels report and drag any heading fusion
+    // (madgwick, EKF) away from the truth. Rotate a fixed world field into the
+    // body frame instead, so the mag agrees with the simulated room: the field
+    // points along the room's +X axis, offset by FAKE_MAG_ROOM_HEADING.
+    void setHeading(float heading) { heading_ = heading; }
+
+    void applyMag(sensor_msgs__msg__MagneticField &mag_msg)
+    {
+        const float theta = heading_ - (float)FAKE_MAG_ROOM_HEADING;
+        const float b = (float)FAKE_MAG_FIELD_T;
+        // The world field points along +Y, i.e. North in the ENU frame ROS uses,
+        // because that is the direction imu_filter_madgwick assumes when it
+        // derives heading from the magnetometer. Pointing it along +X instead
+        // is physically just as valid but leaves the fused yaw a fixed ~90 deg
+        // from the wheel odometry's, and the EKF then has two heading sources
+        // that disagree by a quarter turn: it splits the difference, drags the
+        // pose sideways during a pure rotation, and the SLAM map comes out
+        // sheared. Measured before this: /odom translated 3.9 m while the robot
+        // only spun in place.
+        //
+        // Rotating the world vector (0, b) into the body frame by -theta:
+        //   x =  b sin(theta)      y =  b cos(theta)
+        // then spoiled by the hard-iron offset calibration is meant to find,
+        // and white noise.
+        mag_msg.magnetic_field.x =
+            b * sinf(theta) + (float)FAKE_MAG_BIAS_X + fakeWheelNoise((float)FAKE_MAG_NOISE_T);
+        mag_msg.magnetic_field.y =
+            b * cosf(theta) + (float)FAKE_MAG_BIAS_Y + fakeWheelNoise((float)FAKE_MAG_NOISE_T);
+        mag_msg.magnetic_field.z =
+            (float)FAKE_MAG_BIAS_Z + fakeWheelNoise((float)FAKE_MAG_NOISE_T);
+    }
+
+    void apply(sensor_msgs__msg__Imu &imu_msg)
+    {
+        // a real accelerometer measures specific force: body accel, plus the
+        // centripetal term while turning, plus gravity held up by the floor
+        // true specific force, then spoiled the way a real sensor spoils it:
+        // scale error on the signal, a wandering bias, then white noise
+        const float k = 1.0f + (float)FAKE_IMU_SCALE_ERROR;
+        const float ax = accel_x_ - angular_z_ * linear_y_;
+        const float ay = accel_y_ + angular_z_ * linear_x_;
+
+        imu_msg.linear_acceleration.x =
+            ax * k + accel_bias_x_ + fakeWheelNoise((float)FAKE_IMU_ACCEL_NOISE);
+        imu_msg.linear_acceleration.y =
+            ay * k + accel_bias_y_ + fakeWheelNoise((float)FAKE_IMU_ACCEL_NOISE);
+        imu_msg.linear_acceleration.z =
+            (float)FAKE_IMU_GRAVITY + fakeWheelNoise((float)FAKE_IMU_ACCEL_NOISE);
+
+        imu_msg.angular_velocity.x = fakeWheelNoise((float)FAKE_IMU_GYRO_NOISE);
+        imu_msg.angular_velocity.y = fakeWheelNoise((float)FAKE_IMU_GYRO_NOISE);
+        imu_msg.angular_velocity.z =
+            angular_z_ * k + gyro_bias_z_ + fakeWheelNoise((float)FAKE_IMU_GYRO_NOISE);
+    }
+};
+
+#ifdef USE_FAKE_WHEEL
+    #define ENCODER FakeEncoder
+#else
+    #define ENCODER Encoder
+#endif
+
+#endif

--- a/firmware/lib/lidar/fake_ld19.h
+++ b/firmware/lib/lidar/fake_ld19.h
@@ -1,0 +1,482 @@
+// Copyright (c) 2026 Linorobot contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FAKE_LD19_H
+#define FAKE_LD19_H
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#endif
+#include <math.h>
+#include <stdint.h>
+
+#ifdef USE_LIDAR_UDP
+#include <WiFiUdp.h>
+#endif
+
+#ifndef FAKE_MAP_WIDTH
+#define FAKE_MAP_WIDTH 10.0f    // Simulated room width (meters, -5.0 to +5.0)
+#endif
+
+#ifndef FAKE_MAP_HEIGHT
+#define FAKE_MAP_HEIGHT 6.0f    // Simulated room height (meters, -3.0 to +3.0)
+#endif
+
+// TX ring buffer for the emitted stream, in bytes (ESP32 only -- RP2040 and
+// RP2350 have no TX ring). One revolution is PACKS_PER_REV * 47 = 1786 bytes,
+// so 2048 absorbs a whole scan and write() never waits on the wire.
+#ifndef FAKE_LD19_TX_BUFFER
+#define FAKE_LD19_TX_BUFFER 2048
+#endif
+
+// An LD19 sees 12 m. Beyond that it reports no measurement, not a reading at
+// its limit. The default room is kept inside that reach: 10 x 6 m has an
+// 11.66 m diagonal, so every wall is visible from every corner. A room larger
+// than the sensor leaves whole sectors returning nothing, scan matching goes
+// under-constrained, and odometry drift stops being corrected -- measured on a
+// 16 x 12 room, the map smeared to a 41 x 37 m span with the walls nowhere
+// near where they belong. Enlarging it is allowed, but that is the trade.
+// Where the LiDAR sits on the robot, forward of base_footprint. The shipped
+// linorobot2 URDF puts it at x = 0.12 m, and the emulator has to raycast from
+// there rather than from the robot's centre: ROS transforms every scan by
+// base_footprint -> laser before using it, so measuring from the centre puts
+// each wall 12 cm too far out along whatever heading the robot has. Standing
+// still that is a uniform 12 cm error; turning, it sweeps a 24 cm circle and
+// the walls smear. Measured effect on a finished map: 0.196 m median distance
+// from the true walls, down to a few cm once the origin is right.
+#ifndef FAKE_LIDAR_OFFSET_X
+#define FAKE_LIDAR_OFFSET_X 0.12f
+#endif
+
+#ifndef FAKE_LD19_MAX_RANGE_M
+#define FAKE_LD19_MAX_RANGE_M 12.0f
+#endif
+
+#ifndef FAKE_SCAN_HZ
+#define FAKE_SCAN_HZ 10         // Simulated LiDAR revolutions per second
+#endif
+
+#ifndef FAKE_SONAR_CONE_DEG
+#define FAKE_SONAR_CONE_DEG 30.0f   // Ultrasonic beam width, full angle
+#endif
+
+#ifndef FAKE_ROBOT_RADIUS
+#define FAKE_ROBOT_RADIUS 0.20f // Keeps the robot off the wall rather than in it
+#endif
+
+#ifndef FAKE_WALL_OBSTACLE
+#define FAKE_WALL_OBSTACLE 1    // 1 to include obstacle wall
+#endif
+
+#ifndef FAKE_WALL_X1
+#define FAKE_WALL_X1 2.0f       // Obstacle wall start X (m)
+#endif
+#ifndef FAKE_WALL_Y1
+#define FAKE_WALL_Y1 -1.5f      // Obstacle wall start Y (m)
+#endif
+#ifndef FAKE_WALL_X2
+#define FAKE_WALL_X2 2.0f       // Obstacle wall end X (m)
+#endif
+#ifndef FAKE_WALL_Y2
+#define FAKE_WALL_Y2 1.5f       // Obstacle wall end Y (m)
+#endif
+
+#ifndef LIDAR_BAUDRATE
+#define LIDAR_BAUDRATE 230400
+#endif
+
+#ifndef LIDAR_SERIAL
+#define LIDAR_SERIAL 1
+#endif
+
+class FakeLD19
+{
+private:
+    struct Segment {
+        float x1, y1, x2, y2;
+    };
+
+    static const uint16_t POINTS_PER_PACK = 12;
+    static const uint16_t POINTS_PER_REV  = 456;
+    static const uint16_t PACKS_PER_REV   = POINTS_PER_REV / POINTS_PER_PACK; // 38
+    static constexpr float DEG_PER_POINT  = 360.0f / 456.0f;                  // ~0.78947 deg
+    // Scan rate is a bandwidth decision. Each revolution is 38 packets of 47
+    // bytes, so 10 Hz needs ~17.9 kB/s of the ~23 kB/s that 230400 baud
+    // carries -- 78% of the wire, which the TX ring buffer below absorbs
+    // without ever stalling the control loop (measured on ESP32: odometry
+    // holds 50.0 Hz at a 10 Hz scan). Going much above this has no headroom
+    // left to give.
+    static const uint16_t SPEED_DPS       = (uint16_t)(FAKE_SCAN_HZ * 360);
+    static const uint32_t PACK_PERIOD_US  = (uint32_t)(1000000UL / (PACKS_PER_REV * FAKE_SCAN_HZ));
+    // How many packets one step() may hand the UART. On ESP32 the TX ring
+    // buffer absorbs them and write() returns at once, so a burst is free. On
+    // RP2040/RP2350 there is no TX ring at all -- SerialUART::write() calls
+    // uart_putc_raw() and spins once the 32-byte hardware FIFO fills, and its
+    // availableForWrite() reports a bare 0/1 rather than a byte count, so
+    // there is nothing to test before writing. One packet per step is the
+    // bound there: the loop runs far faster than the ~380 packets/s a 10 Hz
+    // scan needs, so pacing costs no scan rate and caps the stall at the 15
+    // bytes that do not fit the FIFO (~0.65 ms).
+#if defined(ESP32)
+    static const uint8_t  MAX_PACKS_PER_STEP = 8;
+#else
+    static const uint8_t  MAX_PACKS_PER_STEP = 1;
+#endif
+    // Lag beyond which the schedule is resynced instead of burst through. Tied
+    // to the scan, not to the per-step budget -- a platform that emits one
+    // packet per step is not thereby behind.
+    static const uint32_t RESYNC_LAG_US = PACK_PERIOD_US * 8;
+
+    // Current robot pose in global world frame
+    float pose_x_ = 0.0f;
+    float pose_y_ = 0.0f;
+    float pose_theta_ = 0.0f;
+
+    uint16_t point_idx_ = 0;
+    uint32_t next_pack_us_ = 0;
+    Stream *out_stream_ = nullptr;
+    int tx_pin_ = -1;
+    bool enabled_ = false;
+
+#ifdef USE_LIDAR_UDP
+    WiFiUDP udp_;
+    bool udp_enabled_ = false;
+    uint8_t udp_buf_[256];
+    uint16_t udp_buf_len_ = 0;
+#endif
+
+    // CalCRC8 lookup table (poly 0x4D), LDROBOT LD19 standard
+    static uint8_t crc8(const uint8_t *data, int len)
+    {
+        static const uint8_t table[256] = {
+          0x00,0x4d,0x9a,0xd7,0x79,0x34,0xe3,0xae,0xf2,0xbf,0x68,0x25,0x8b,0xc6,0x11,0x5c,
+          0xa9,0xe4,0x33,0x7e,0xd0,0x9d,0x4a,0x07,0x5b,0x16,0xc1,0x8c,0x22,0x6f,0xb8,0xf5,
+          0x1f,0x52,0x85,0xc8,0x66,0x2b,0xfc,0xb1,0xed,0xa0,0x77,0x3a,0x94,0xd9,0x0e,0x43,
+          0xb6,0xfb,0x2c,0x61,0xcf,0x82,0x55,0x18,0x44,0x09,0xde,0x93,0x3d,0x70,0xa7,0xea,
+          0x3e,0x73,0xa4,0xe9,0x47,0x0a,0xdd,0x90,0xcc,0x81,0x56,0x1b,0xb5,0xf8,0x2f,0x62,
+          0x97,0xda,0x0d,0x40,0xee,0xa3,0x74,0x39,0x65,0x28,0xff,0xb2,0x1c,0x51,0x86,0xcb,
+          0x21,0x6c,0xbb,0xf6,0x58,0x15,0xc2,0x8f,0xd3,0x9e,0x49,0x04,0xaa,0xe7,0x30,0x7d,
+          0x88,0xc5,0x12,0x5f,0xf1,0xbc,0x6b,0x26,0x7a,0x37,0xe0,0xad,0x03,0x4e,0x99,0xd4,
+          0x7c,0x31,0xe6,0xab,0x05,0x48,0x9f,0xd2,0x8e,0xc3,0x14,0x59,0xf7,0xba,0x6d,0x20,
+          0xd5,0x98,0x4f,0x02,0xac,0xe1,0x36,0x7b,0x27,0x6a,0xbd,0xf0,0x5e,0x13,0xc4,0x89,
+          0x63,0x2e,0xf9,0xb4,0x1a,0x57,0x80,0xcd,0x91,0xdc,0x0b,0x46,0xe8,0xa5,0x72,0x3f,
+          0xca,0x87,0x50,0x1d,0xb3,0xfe,0x29,0x64,0x38,0x75,0xa2,0xef,0x41,0x0c,0xdb,0x96,
+          0x42,0x0f,0xd8,0x95,0x3b,0x76,0xa1,0xec,0xb0,0xfd,0x2a,0x67,0xc9,0x84,0x53,0x1e,
+          0xeb,0xa6,0x71,0x3c,0x92,0xdf,0x08,0x45,0x19,0x54,0x83,0xce,0x60,0x2d,0xfa,0xb7,
+          0x5d,0x10,0xc7,0x8a,0x24,0x69,0xbe,0xf3,0xaf,0xe2,0x35,0x78,0xd6,0x9b,0x4c,0x01,
+          0xf4,0xb9,0x6e,0x23,0x8d,0xc0,0x17,0x5a,0x06,0x4b,0x9c,0xd1,0x7f,0x32,0xe5,0xa8
+        };
+        uint8_t c = 0;
+        while (len--) c = table[(c ^ *data++) & 0xff];
+        return c;
+    }
+
+    static inline void put16(uint8_t *p, uint16_t v) {
+        p[0] = (uint8_t)(v & 0xff);
+        p[1] = (uint8_t)(v >> 8);
+    }
+
+public:
+    FakeLD19() {}
+
+    void setStream(Stream *stream)
+    {
+        out_stream_ = stream;
+        enabled_ = true;
+    }
+
+    void begin(int tx_pin = -1, uint32_t baud = LIDAR_BAUDRATE)
+    {
+        tx_pin_ = tx_pin;
+        if (tx_pin >= 0)
+        {
+#if defined(ESP32)
+            HardwareSerial *serial = new HardwareSerial(LIDAR_SERIAL);
+            // Give the UART a TX ring buffer big enough for a whole
+            // revolution. Without one, write() has only the 128-byte hardware
+            // FIFO behind it, and a catch-up burst of MAX_PACKS_PER_STEP
+            // packets (376 bytes) blocks the control loop until the wire
+            // drains it -- 16 ms at 230400, most of a 20 ms control period.
+            // The buffer is drained by the UART interrupt, so write() returns
+            // immediately and the emission costs the loop nothing but the
+            // memcpy. Must be called before begin() to take effect.
+            serial->setTxBufferSize(FAKE_LD19_TX_BUFFER);
+            // On ESP32, configure UART with TX pin on LIDAR_RXD
+            serial->begin(baud, SERIAL_8N1, -1, tx_pin);
+            out_stream_ = serial;
+            enabled_ = true;
+#elif defined(ARDUINO_ARCH_RP2040)
+#if defined(LIDAR_SERIAL) && LIDAR_SERIAL == 2
+            Serial2.setTX(tx_pin);
+            Serial2.begin(baud);
+            out_stream_ = &Serial2;
+#else
+            Serial1.setTX(tx_pin);
+            Serial1.begin(baud);
+            out_stream_ = &Serial1;
+#endif
+            enabled_ = true;
+#endif
+        }
+
+#ifdef USE_LIDAR_UDP
+        udp_enabled_ = true;
+        enabled_ = true;
+#endif
+        next_pack_us_ = micros() + PACK_PERIOD_US;
+    }
+
+    // Update the simulator with the robot odometry pose (meters and radians)
+    // Hold a pose inside the room. The simulated drivetrain has no notion of
+    // collision, so a robot driven at a wall sails straight through it and out
+    // of the map -- the scan jumps to max range and SLAM has nothing to build
+    // from. Stopping at the wall is also what a real robot does: the wheels
+    // keep turning, the robot does not move, and odometry stops advancing.
+    // Returns true when the pose had to be moved.
+    bool clampToRoom(float &x, float &y) const
+    {
+        const float lim_x = (float)FAKE_MAP_WIDTH * 0.5f - (float)FAKE_ROBOT_RADIUS;
+        const float lim_y = (float)FAKE_MAP_HEIGHT * 0.5f - (float)FAKE_ROBOT_RADIUS;
+        const float in_x = x, in_y = y;
+        if (x > lim_x) x = lim_x;
+        if (x < -lim_x) x = -lim_x;
+        if (y > lim_y) y = lim_y;
+        if (y < -lim_y) y = -lim_y;
+
+#if FAKE_WALL_OBSTACLE
+        // The obstacle wall is solid too. Raycasting it but not colliding with
+        // it lets the robot drive straight through the one thing in the room,
+        // and the scan then shows that wall *behind* it -- which quietly makes
+        // any obstacle-avoidance test meaningless, because nothing stops a plan
+        // that goes through it.
+        pushOffSegment(x, y,
+                       (float)FAKE_WALL_X1, (float)FAKE_WALL_Y1,
+                       (float)FAKE_WALL_X2, (float)FAKE_WALL_Y2);
+#endif
+        return (x != in_x) || (y != in_y);
+    }
+
+    // Push a point out to FAKE_ROBOT_RADIUS from a segment, along the shortest
+    // way out, if it is inside. Approach direction does not matter: the robot
+    // leaves by the side it came in on.
+    static void pushOffSegment(float &x, float &y,
+                               float x1, float y1, float x2, float y2)
+    {
+        const float r = (float)FAKE_ROBOT_RADIUS;
+        const float sx = x2 - x1, sy = y2 - y1;
+        const float len2 = sx * sx + sy * sy;
+
+        // closest point on the segment, with the parameter clamped to its ends
+        float t = (len2 > 1e-9f) ? ((x - x1) * sx + (y - y1) * sy) / len2 : 0.0f;
+        if (t < 0.0f) t = 0.0f;
+        if (t > 1.0f) t = 1.0f;
+        const float cx = x1 + t * sx, cy = y1 + t * sy;
+
+        float nx = x - cx, ny = y - cy;
+        float d = sqrtf(nx * nx + ny * ny);
+        if (d >= r) return;             // already clear
+
+        if (d < 1e-6f)
+        {
+            // dead on the segment: no direction to push along, so use its
+            // normal and pick a side rather than dividing by zero
+            if (len2 > 1e-9f) { nx = -sy; ny = sx; d = sqrtf(len2); }
+            else              { nx = 1.0f; ny = 0.0f; d = 1.0f; }
+        }
+        x = cx + nx / d * r;
+        y = cy + ny / d * r;
+    }
+
+    // What a forward-facing ultrasonic sensor would read: the nearest return
+    // inside a cone, not a single ray. Gives the robot actual feedback that
+    // something is ahead, rather than leaving it to be inferred from odometry
+    // that has stopped advancing.
+    float rangeAheadM(float cone_deg = (float)FAKE_SONAR_CONE_DEG)
+    {
+        const float half = cone_deg * 0.5f;
+        uint16_t nearest = 0xFFFF;
+        for (float d = -half; d <= half; d += 2.0f)
+        {
+            uint16_t r = raycastRangeMm(d < 0.0f ? d + 360.0f : d);
+            if (r > 0 && r < nearest) nearest = r;
+        }
+        // -1 means "no reading", matching what the firmware's
+        // rangeAheadOrNegative() expects. Returning 0.0 here would read as an
+        // obstacle touching the robot and hold the safety stop on permanently
+        // whenever the path ahead is simply open beyond the sensor's reach.
+        return (nearest == 0xFFFF) ? -1.0f : (float)nearest / 1000.0f;
+    }
+
+    void updatePose(float x, float y, float theta)
+    {
+        pose_x_ = x;
+        pose_y_ = y;
+        pose_theta_ = theta;
+    }
+
+    // Raycast distance for a given beam angle (in degrees, 0..360)
+    uint16_t raycastRangeMm(float beam_deg)
+    {
+        // Global ray angle in radians: robot yaw MINUS the beam angle, because
+        // an LD19's angle field increases the way the head physically turns,
+        // which is clockwise seen from above -- the opposite of the
+        // right-handed convention ROS uses. ldlidar_stl_ros2 negates it again
+        // to produce a proper counter-clockwise LaserScan, so emitting the
+        // mathematically positive direction here leaves that flip unmatched and
+        // publishes a mirror image of the room.
+        //
+        // Nothing looks wrong: the scan is the right shape and the right size,
+        // and while the robot is still it is even self-consistent. Only when it
+        // turns does the mirrored scan rotate against the odometry, so scan
+        // matching fights the wheels and the map inflates. Measured against a
+        // ground-truth raycast of the room: 1.305 m mean error as emitted,
+        // 0.019 m once mirrored.
+        float ray_rad = pose_theta_ - (beam_deg * 0.0174532925f);
+        float dx = cosf(ray_rad);
+        float dy = sinf(ray_rad);
+
+        // the beam leaves the sensor, which is mounted ahead of the robot's centre
+        const float ox = pose_x_ + cosf(pose_theta_) * (float)FAKE_LIDAR_OFFSET_X;
+        const float oy = pose_y_ + sinf(pose_theta_) * (float)FAKE_LIDAR_OFFSET_X;
+
+        // Define room perimeter boundaries centered at (0,0)
+        const float half_w = (float)FAKE_MAP_WIDTH * 0.5f;
+        const float half_h = (float)FAKE_MAP_HEIGHT * 0.5f;
+
+        Segment segs[5] = {
+            {-half_w, -half_h,  half_w, -half_h}, // South wall
+            { half_w, -half_h,  half_w,  half_h}, // East wall
+            { half_w,  half_h, -half_w,  half_h}, // North wall
+            {-half_w,  half_h, -half_w, -half_h}, // West wall
+            {(float)FAKE_WALL_X1, (float)FAKE_WALL_Y1, (float)FAKE_WALL_X2, (float)FAKE_WALL_Y2} // Short obstacle wall
+        };
+
+        int count = FAKE_WALL_OBSTACLE ? 5 : 4;
+        float min_dist = (float)FAKE_LD19_MAX_RANGE_M; // nothing seen yet
+
+        for (int i = 0; i < count; i++)
+        {
+            float sx = segs[i].x2 - segs[i].x1;
+            float sy = segs[i].y2 - segs[i].y1;
+            float denom = dx * sy - dy * sx;
+            if (fabsf(denom) < 1e-6f) continue;
+
+            float px = segs[i].x1 - ox;
+            float py = segs[i].y1 - oy;
+
+            float t = (px * sy - py * sx) / denom;
+            float u = (px * dy - py * dx) / denom;
+
+            if (t > 0.03f && u >= 0.0f && u <= 1.0f)
+            {
+                if (t < min_dist) min_dist = t;
+            }
+        }
+
+        // No segment inside the sensor's reach means no measurement. Reporting
+        // the range limit instead would put a return there, and a real LD19
+        // does not do that -- it reports 0. It matters more than it sounds:
+        // beams that overshoot the far wall would otherwise draw a phantom arc
+        // at exactly 12 m, SLAM would map it as a wall standing inside the
+        // room, and the map comes out larger and sheared. 0 is the protocol's
+        // "no measurement", which the driver turns into an invalid range.
+        if (min_dist >= (float)FAKE_LD19_MAX_RANGE_M) return 0;
+
+        // Add small simulated white noise (+-5 mm)
+        float noise = ((float)(rand() % 11) - 5.0f);
+        float dist_mm = (min_dist * 1000.0f) + noise;
+
+        if (dist_mm < 50.0f) dist_mm = 50.0f;
+        return (uint16_t)dist_mm;
+    }
+
+    // Advance packet generation and stream out if it is time
+    // Emit however many packets the clock says are due, not one per call.
+    //
+    // A 10 Hz LD19 is 380 packets/s, but loop() does not iterate anywhere near
+    // that: the micro-ROS executor dominates each cycle, so one packet per call
+    // yielded roughly 1.5 rev/s -- enough to look like it works, far too slow
+    // for SLAM to build a map from. The budget bounds the catch-up so a long
+    // stall cannot monopolise the loop, and the schedule advances by whole
+    // periods so it does not drift.
+    void step()
+    {
+        if (!enabled_) return;
+
+        for (uint8_t budget = 0; budget < MAX_PACKS_PER_STEP; budget++)
+        {
+            uint32_t now = micros();
+            if ((int32_t)(now - next_pack_us_) < 0) return;
+            // if we fell far behind, resync rather than burst through a backlog
+            if ((int32_t)(now - next_pack_us_) > (int32_t)RESYNC_LAG_US)
+                next_pack_us_ = now;
+            next_pack_us_ += PACK_PERIOD_US;
+            emitPack();
+        }
+    }
+
+private:
+    void emitPack()
+    {
+        uint8_t pkt[47];
+        pkt[0] = 0x54;
+        pkt[1] = 0x2C;
+        put16(&pkt[2], SPEED_DPS);
+
+        float start_deg = point_idx_ * DEG_PER_POINT;
+        float end_deg   = (point_idx_ + POINTS_PER_PACK - 1) * DEG_PER_POINT;
+        put16(&pkt[4], (uint16_t)(fmodf(start_deg, 360.0f) * 100.0f));
+
+        for (int i = 0; i < POINTS_PER_PACK; i++)
+        {
+            float deg = (point_idx_ + i) * DEG_PER_POINT;
+            uint16_t dist = raycastRangeMm(deg);
+            // 0 distance is "no measurement"; a real unit reports no
+            // confidence with it, and drivers use that to reject the point.
+            uint8_t inten = (dist == 0) ? 0
+                          : (dist < 1500) ? 220 : (dist < 4000) ? 180 : 120;
+            put16(&pkt[6 + i * 3], dist);
+            pkt[6 + i * 3 + 2] = inten;
+        }
+
+        put16(&pkt[42], (uint16_t)(fmodf(end_deg, 360.0f) * 100.0f));
+        put16(&pkt[44], (uint16_t)(millis() % 30000));
+        pkt[46] = crc8(pkt, 46);
+
+        if (out_stream_)
+        {
+            out_stream_->write(pkt, 47);
+        }
+
+#ifdef USE_LIDAR_UDP
+        if (udp_enabled_)
+        {
+            memcpy(udp_buf_ + udp_buf_len_, pkt, 47);
+            udp_buf_len_ += 47;
+            if (udp_buf_len_ >= 141)
+            {
+                udp_.beginPacket(LIDAR_SERVER, LIDAR_PORT);
+                udp_.write(udp_buf_, udp_buf_len_);
+                udp_.endPacket();
+                udp_buf_len_ = 0;
+            }
+        }
+#endif
+
+        point_idx_ += POINTS_PER_PACK;
+        if (point_idx_ >= POINTS_PER_REV) point_idx_ -= POINTS_PER_REV;
+    }
+};
+
+#endif

--- a/firmware/lib/lidar/lidar.cpp
+++ b/firmware/lib/lidar/lidar.cpp
@@ -20,7 +20,7 @@
 #include "config.h"
 #include "syslog.h"
 
-#ifdef USE_LIDAR_UDP
+#if defined(USE_LIDAR_UDP) && !defined(USE_FAKE_LD19)
 #include <HardwareSerial.h>
 #include <WiFiUdp.h>
 #define BUFSIZE 512

--- a/firmware/lib/odometry/odometry.h
+++ b/firmware/lib/odometry/odometry.h
@@ -34,6 +34,12 @@ class Odometry
         Odometry();
         void update(float vel_dt, float linear_vel_x, float linear_vel_y, float angular_vel_z);
         nav_msgs__msg__Odometry getData();
+        inline float getX() const { return x_pos_; }
+        inline float getY() const { return y_pos_; }
+        inline float getHeading() const { return heading_; }
+        // Used by simulation modes to hold the robot inside a simulated room,
+        // so the published odometry matches what the simulated LiDAR sees.
+        inline void setPosition(float x, float y) { x_pos_ = x; y_pos_ = y; }
 
     private:
         const void euler_to_quat(float x, float y, float z, float* q);

--- a/firmware/lib/odometry/odometry.h
+++ b/firmware/lib/odometry/odometry.h
@@ -40,6 +40,11 @@ class Odometry
         // Used by simulation modes to hold the robot inside a simulated room,
         // so the published odometry matches what the simulated LiDAR sees.
         inline void setPosition(float x, float y) { x_pos_ = x; y_pos_ = y; }
+        // Return the robot to the origin. Simulation modes call this when a new
+        // agent session starts, so that a fresh run gets a fresh robot; a real
+        // robot must not use it, because odometry has to stay continuous across
+        // a reconnect or the transform tree jumps under whatever is localising.
+        inline void reset() { x_pos_ = 0.0f; y_pos_ = 0.0f; heading_ = 0.0f; }
 
     private:
         const void euler_to_quat(float x, float y, float z, float* q);

--- a/firmware/src/firmware.ino
+++ b/firmware/src/firmware.ino
@@ -458,6 +458,26 @@ bool createEntities()
     syncTime();
     digitalWrite(LED_PIN, HIGH);
 
+#ifdef USE_FAKE_WHEEL
+    // A simulated robot has no way to be picked up and put back at the start,
+    // and its pose is board state: it survives the host container, the agent
+    // and the whole ROS stack being torn down and rebuilt. So a second test run
+    // silently begins wherever the first one parked the robot -- and once that
+    // is against a simulated wall, USE_SAFETY_STOP zeroes forward velocity and
+    // navigation fails as "goal outside map" or "failed to make progress",
+    // neither of which points at inherited state. A new agent session means a
+    // new run, so start it from the origin.
+    //
+    // Real robots deliberately do not do this: odometry must stay continuous
+    // across a reconnect, or the transform tree jumps under whatever is
+    // localising against it.
+    odometry.reset();
+#ifdef USE_FAKE_LD19
+    fake_ld19.updatePose(0.0f, 0.0f, 0.0f);
+#endif
+    syslog(LOG_INFO, "%s simulated pose reset to origin %lu", __FUNCTION__, millis());
+#endif
+
     return true;
 }
 

--- a/firmware/src/firmware.ino
+++ b/firmware/src/firmware.ino
@@ -25,6 +25,7 @@
 #include <sensor_msgs/msg/magnetic_field.h>
 #include <sensor_msgs/msg/battery_state.h>
 #include <sensor_msgs/msg/range.h>
+#include <std_msgs/msg/bool.h>
 #include <geometry_msgs/msg/twist.h>
 #include <geometry_msgs/msg/vector3.h>
 
@@ -39,6 +40,10 @@
 #define ENCODER_USE_INTERRUPTS
 #define ENCODER_OPTIMIZE_INTERRUPTS
 #include "encoder.h"
+#include "fake_wheel.h"
+#ifdef USE_FAKE_LD19
+#include "fake_ld19.h"
+#endif
 #include "battery.h"
 #include "range.h"
 #include "lidar.h"
@@ -92,11 +97,25 @@ static inline void set_microros_net_transports(IPAddress agent_ip, uint16_t agen
   if (uxr_millis() - init > MS) { X; init = uxr_millis();} \
 } while (0)
 
+// mag.h falls back to FakeMAG and defines USE_FAKE_MAG whenever no magnetometer
+// chip is configured, and the topic is then left out entirely. But fake wheel
+// mode synthesises a real field from the simulated heading, hard-iron bias and
+// all, which is exactly what a calibration run needs -- so publish it there
+// even though no chip is present.
+#if !defined(USE_FAKE_MAG) || defined(USE_FAKE_WHEEL)
+#define PUBLISH_MAG
+#endif
+
 rcl_publisher_t odom_publisher;
 rcl_publisher_t imu_publisher;
 rcl_publisher_t mag_publisher;
 rcl_subscription_t twist_subscriber;
 rcl_publisher_t battery_publisher;
+#ifdef USE_SAFETY_STOP
+rcl_publisher_t safety_stop_publisher;
+std_msgs__msg__Bool safety_stop_msg;
+bool safety_stopped = false;
+#endif
 rcl_publisher_t range_publisher;
 
 nav_msgs__msg__Odometry odom_msg;
@@ -125,10 +144,17 @@ enum states
   AGENT_DISCONNECTED
 } state;
 
-Encoder motor1_encoder(MOTOR1_ENCODER_A, MOTOR1_ENCODER_B, COUNTS_PER_REV1, MOTOR1_ENCODER_INV);
-Encoder motor2_encoder(MOTOR2_ENCODER_A, MOTOR2_ENCODER_B, COUNTS_PER_REV2, MOTOR2_ENCODER_INV);
-Encoder motor3_encoder(MOTOR3_ENCODER_A, MOTOR3_ENCODER_B, COUNTS_PER_REV3, MOTOR3_ENCODER_INV);
-Encoder motor4_encoder(MOTOR4_ENCODER_A, MOTOR4_ENCODER_B, COUNTS_PER_REV4, MOTOR4_ENCODER_INV);
+#ifdef USE_FAKE_WHEEL
+FakeIMUFromWheels fake_imu;
+#endif
+#ifdef USE_FAKE_LD19
+FakeLD19 fake_ld19;
+#endif
+
+ENCODER motor1_encoder(MOTOR1_ENCODER_A, MOTOR1_ENCODER_B, COUNTS_PER_REV1, MOTOR1_ENCODER_INV);
+ENCODER motor2_encoder(MOTOR2_ENCODER_A, MOTOR2_ENCODER_B, COUNTS_PER_REV2, MOTOR2_ENCODER_INV);
+ENCODER motor3_encoder(MOTOR3_ENCODER_A, MOTOR3_ENCODER_B, COUNTS_PER_REV3, MOTOR3_ENCODER_INV);
+ENCODER motor4_encoder(MOTOR4_ENCODER_A, MOTOR4_ENCODER_B, COUNTS_PER_REV4, MOTOR4_ENCODER_INV);
 
 Motor motor1_controller(PWM_FREQUENCY, PWM_BITS, MOTOR1_INV, MOTOR1_PWM, MOTOR1_IN_A, MOTOR1_IN_B);
 Motor motor2_controller(PWM_FREQUENCY, PWM_BITS, MOTOR2_INV, MOTOR2_PWM, MOTOR2_IN_A, MOTOR2_IN_B);
@@ -174,6 +200,14 @@ void setup()
 
     initWifis();
     initOta();
+#ifdef USE_FAKE_WHEEL
+    // A bare module has nothing on the I2C bus, so probing it would fail and
+    // the fatal loops below would trap the board before it ever connects. The
+    // simulated IMU and magnetometer are computed from the simulated wheels
+    // anyway, and would overwrite whatever a real sensor returned -- so skip
+    // the hardware entirely and just prepare the two messages.
+    fake_imu.initMsgs(imu_msg, mag_msg);
+#else
     bool imu_ok = imu.init();
     if (!imu_ok) // take IMU failure as fatal
     {
@@ -198,9 +232,22 @@ void setup()
             runOta();
         }
     }
+#endif
     initBattery();
     initRange();
+#if defined(USE_FAKE_SONAR) && defined(USE_FAKE_LD19)
+    // initRange() only sets this up when a real sensor is compiled in
+    range_msg.header.frame_id =
+        micro_ros_string_utilities_set(range_msg.header.frame_id, "sonar_link");
+#endif
     initLidar(); // after wifi connected
+#ifdef USE_FAKE_LD19
+#ifdef LIDAR_RXD
+    fake_ld19.begin(LIDAR_RXD, LIDAR_BAUDRATE);
+#else
+    fake_ld19.begin();
+#endif
+#endif
     battery_msg = getBattery();
     prev_voltage = battery_msg.voltage;
 
@@ -216,7 +263,45 @@ void setup()
     syslog(LOG_INFO, "%s Ready %lu", __FUNCTION__, millis());
 }
 
+#ifdef USE_FAKE_LD19
+// Simulated wall contact indicator.
+//
+// LED_PIN may be -1 on boards with no addressable status LED, or LED_BUILTIN,
+// which is a non-macro identifier the preprocessor evaluates as 0 -- so the
+// guard is "defined and >= 0" and LED_BUILTIN boards stay enabled.
+//
+// The flash is timed rather than delayed: this runs inside the 50 Hz control
+// path, and a delay() here would stall the whole loop.
+#if defined(LED_PIN) && (LED_PIN) >= 0
+#define FAKE_WALL_LED
+#endif
+
+static unsigned long fake_wall_led_off_at = 0;
+
+static inline void fakeWallLedOn()
+{
+#ifdef FAKE_WALL_LED
+    digitalWrite(LED_PIN, HIGH);
+    fake_wall_led_off_at = millis() + 120;
+#endif
+}
+
+static inline void fakeWallLedService()
+{
+#ifdef FAKE_WALL_LED
+    if (fake_wall_led_off_at != 0 && (long)(millis() - fake_wall_led_off_at) >= 0)
+    {
+        digitalWrite(LED_PIN, LOW);
+        fake_wall_led_off_at = 0;
+    }
+#endif
+}
+#endif
+
 void loop() {
+#ifdef USE_FAKE_LD19
+    fakeWallLedService();
+#endif
     switch (state) 
     {
         case WAITING_AGENT:
@@ -255,6 +340,9 @@ void loop() {
 #endif
 #ifdef BOARD_LOOP // board specific loop
     BOARD_LOOP
+#endif
+#ifdef USE_FAKE_LD19
+    fake_ld19.step();
 #endif
 }
 
@@ -296,13 +384,13 @@ bool createEntities()
         &node,
         ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, Imu),
     // if we have magnetomter, use imu/data_raw for madgwick filter
-#ifndef USE_FAKE_MAG
+#ifdef PUBLISH_MAG
         TOPIC_PREFIX "imu/data_raw"
 #else
         TOPIC_PREFIX "imu/data"
 #endif
     ));
-#ifndef USE_FAKE_MAG
+#ifdef PUBLISH_MAG
     RCCHECK(rclc_publisher_init_default(
         &mag_publisher,
         &node,
@@ -319,7 +407,18 @@ bool createEntities()
     TOPIC_PREFIX "battery"
     ));
 #endif
-#ifdef ECHO_PIN
+#ifdef USE_SAFETY_STOP
+    // Tells ROS the robot stopped itself. The stop is a firmware reflex -- it
+    // has to keep working when the ROS side is busy, wedged or disconnected --
+    // so this publisher only reports the state, it never decides it.
+    RCCHECK(rclc_publisher_init_default(
+    &safety_stop_publisher,
+    &node,
+    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool),
+    TOPIC_PREFIX "safety_stop"
+    ));
+#endif
+#if defined(ECHO_PIN) || (defined(USE_FAKE_SONAR) && defined(USE_FAKE_LD19))
     // create range pyblisher
     RCCHECK(rclc_publisher_init_default(
     &range_publisher,
@@ -370,13 +469,16 @@ bool destroyEntities()
 
     RCSOFTCHECK(rcl_publisher_fini(&odom_publisher, &node));
     RCSOFTCHECK(rcl_publisher_fini(&imu_publisher, &node));
-#ifndef USE_FAKE_MAG
+#ifdef PUBLISH_MAG
     RCSOFTCHECK(rcl_publisher_fini(&mag_publisher, &node));
 #endif
 #if defined(BATTERY_PIN) || defined(USE_INA219)
     RCSOFTCHECK(rcl_publisher_fini(&battery_publisher, &node));
 #endif
-#ifdef ECHO_PIN
+#ifdef USE_SAFETY_STOP
+    RCSOFTCHECK(rcl_publisher_fini(&safety_stop_publisher, &node));
+#endif
+#if defined(ECHO_PIN) || (defined(USE_FAKE_SONAR) && defined(USE_FAKE_LD19))
     RCSOFTCHECK(rcl_publisher_fini(&range_publisher, &node));
 #endif
     RCSOFTCHECK(rcl_subscription_fini(&twist_subscriber, &node));
@@ -402,6 +504,27 @@ void fullStop()
     motor4_controller.brake();
 }
 
+#ifdef USE_SAFETY_STOP
+#ifndef SAFETY_STOP_RANGE
+#define SAFETY_STOP_RANGE 0.25f     // metres ahead before forward motion is cut
+#endif
+
+// Forward range from whichever sensor is compiled in, or -1 when there is none
+// to consult -- in which case nothing is blocked, because a missing sensor must
+// not brake the robot.
+static inline float rangeAheadOrNegative()
+{
+#if defined(USE_FAKE_SONAR) && defined(USE_FAKE_LD19)
+    return fake_ld19.rangeAheadM();
+#elif defined(ECHO_PIN)
+    const float r = getRange().range;
+    return isfinite(r) ? r : -1.0f;
+#else
+    return -1.0f;
+#endif
+}
+#endif
+
 void moveBase()
 {
     // brake if there's no command received, or when it's only the first command sent
@@ -413,6 +536,32 @@ void moveBase()
 
         digitalWrite(LED_PIN, HIGH);
     }
+
+#ifdef USE_SAFETY_STOP
+    // Forward hazard stop, decided here rather than in ROS. A stop that has to
+    // travel out on a topic, be reasoned about, and come back as cmd_vel is one
+    // network round trip too slow, and does nothing at all if the ROS side is
+    // wedged or the link drops. This runs every control cycle regardless.
+    //
+    // Only forward motion is blocked: reverse and rotation stay available, or
+    // the robot would be stuck against the obstacle with no way to back off.
+    {
+        const float range = rangeAheadOrNegative();
+        const bool blocked = (range >= 0.0f) && (range < (float)SAFETY_STOP_RANGE);
+        if (blocked && twist_msg.linear.x > 0.0)
+        {
+            twist_msg.linear.x = 0.0;
+            twist_msg.linear.y = 0.0;
+        }
+        if (blocked != safety_stopped)
+        {
+            safety_stopped = blocked;
+            syslog(LOG_INFO, "%s safety stop %s at %.2f m %lu", __FUNCTION__,
+                   blocked ? "engaged" : "cleared", range, millis());
+        }
+    }
+#endif
+
     // get the required rpm for each motor based on required velocities, and base used
     Kinematics::rpm req_rpm = kinematics.getRPM(
         twist_msg.linear.x, 
@@ -428,10 +577,21 @@ void moveBase()
 
     // the required rpm is capped at -/+ MAX_RPM to prevent the PID from having too much error
     // the PWM value sent to the motor driver is the calculated PID based on required RPM vs measured RPM
-    motor1_controller.spin(motor1_pid.compute(req_rpm.motor1, current_rpm1));
-    motor2_controller.spin(motor2_pid.compute(req_rpm.motor2, current_rpm2));
-    motor3_controller.spin(motor3_pid.compute(req_rpm.motor3, current_rpm3));
-    motor4_controller.spin(motor4_pid.compute(req_rpm.motor4, current_rpm4));
+    int pwm1 = motor1_pid.compute(req_rpm.motor1, current_rpm1);
+    int pwm2 = motor2_pid.compute(req_rpm.motor2, current_rpm2);
+    int pwm3 = motor3_pid.compute(req_rpm.motor3, current_rpm3);
+    int pwm4 = motor4_pid.compute(req_rpm.motor4, current_rpm4);
+    motor1_controller.spin(pwm1);
+    motor2_controller.spin(pwm2);
+    motor3_controller.spin(pwm3);
+    motor4_controller.spin(pwm4);
+#ifdef USE_FAKE_WHEEL
+    // close the loop in software: the simulated wheels follow the commanded PWM
+    motor1_encoder.feed(pwm1);
+    motor2_encoder.feed(pwm2);
+    motor3_encoder.feed(pwm3);
+    motor4_encoder.feed(pwm4);
+#endif
 
     Kinematics::velocities current_vel = kinematics.getVelocities(
         current_rpm1, 
@@ -449,17 +609,68 @@ void moveBase()
         current_vel.linear_y, 
         current_vel.angular_z
     );
+#ifdef USE_FAKE_LD19
+    // Stop the simulated robot at the simulated walls, and correct the
+    // odometry to match, so /odom and /scan never disagree about where it is.
+    float fake_x = odometry.getX();
+    float fake_y = odometry.getY();
+    bool hit_wall = fake_ld19.clampToRoom(fake_x, fake_y);
+    if (hit_wall)
+        odometry.setPosition(fake_x, fake_y);
+    fake_ld19.updatePose(fake_x, fake_y, odometry.getHeading());
+#else
+    const bool hit_wall = false;
+#endif
+#ifdef USE_FAKE_WHEEL
+    // The IMU rides on how the body actually moved, which is not what the
+    // wheels claim once the robot is against a wall. Real hardware behaves the
+    // same way: the wheels slip and keep reporting speed, while the IMU feels
+    // no acceleration and the robot goes nowhere. Keeping that disagreement is
+    // the only feedback there is that something was hit -- there is no bump
+    // sensor, and odometry velocity alone never reveals it. Rotation survives,
+    // since a robot pinned against a wall can still turn on the spot.
+    fake_imu.update(
+        hit_wall ? 0.0f : current_vel.linear_x,
+        hit_wall ? 0.0f : current_vel.linear_y,
+        current_vel.angular_z,
+        vel_dt
+    );
+    fake_imu.setHeading(odometry.getHeading());
+#endif
+#ifdef USE_FAKE_LD19
+    // Announce the contact once, on the way in. Driving into a wall holds the
+    // clamp active for as long as the command lasts, so logging every 20 ms
+    // cycle would bury the syslog in identical lines.
+    static bool was_clamped = false;
+    if (hit_wall && !was_clamped)
+    {
+        syslog(LOG_INFO, "%s fake wall contact at x %.2f y %.2f %lu",
+               __FUNCTION__, fake_x, fake_y, millis());
+        fakeWallLedOn();
+    }
+    was_clamped = hit_wall;
+#endif
 }
 
 void publishData()
 {
     static unsigned skip_dip = 0;
     odom_msg = odometry.getData();
+#ifdef USE_FAKE_WHEEL
+    // Every field these would return is overwritten just below, and on a bare
+    // module the reads are two failing I2C transactions per publish, each one
+    // stalling the loop for the bus timeout. Skip them.
+    fake_imu.apply(imu_msg);
+    // Simulated wheels mean a simulated heading, so the magnetometer has to
+    // follow it: a real one left in the loop here would fight the fused yaw.
+    fake_imu.applyMag(mag_msg);
+#else
     imu_msg = imu.getData();
 #ifdef USE_FAKE_IMU
     imu_msg.angular_velocity.z = odom_msg.twist.twist.angular.z;
 #endif
     mag_msg = mag.getData();
+#endif
 #ifdef MAG_BIAS
     const float mag_bias[3] = MAG_BIAS;
     mag_msg.magnetic_field.x -= mag_bias[0];
@@ -475,13 +686,13 @@ void publishData()
     imu_msg.header.stamp.sec = time_stamp.tv_sec;
     imu_msg.header.stamp.nanosec = time_stamp.tv_nsec;
 
-#ifndef USE_FAKE_MAG
+#ifdef PUBLISH_MAG
     mag_msg.header.stamp.sec = time_stamp.tv_sec;
     mag_msg.header.stamp.nanosec = time_stamp.tv_nsec;
 #endif
 
     RCSOFTCHECK(rcl_publish(&imu_publisher, &imu_msg, NULL));
-#ifndef USE_FAKE_MAG
+#ifdef PUBLISH_MAG
     RCSOFTCHECK(rcl_publish(&mag_publisher, &mag_msg, NULL));
 #endif
     RCSOFTCHECK(rcl_publish(&odom_publisher, &odom_msg, NULL));
@@ -502,7 +713,25 @@ void publishData()
         getBatteryPercentage(&battery_msg);
         RCSOFTCHECK(rcl_publish(&battery_publisher, &battery_msg, NULL)) });
 #endif
-#ifdef ECHO_PIN
+#ifdef USE_SAFETY_STOP
+    safety_stop_msg.data = safety_stopped;
+    RCSOFTCHECK(rcl_publish(&safety_stop_publisher, &safety_stop_msg, NULL));
+#endif
+#if defined(USE_FAKE_SONAR) && defined(USE_FAKE_LD19)
+    // A simulated ultrasonic sensor, raycast from the same room the simulated
+    // LiDAR uses. This is the robot's own feedback that something is ahead --
+    // wheel odometry cannot provide it, because the wheels keep turning when
+    // the robot is stopped against something.
+    EXECUTE_EVERY_N_MS(RANGE_TIMER, {
+        range_msg.range = fake_ld19.rangeAheadM();
+        range_msg.field_of_view = (float)FAKE_SONAR_CONE_DEG * (float)DEG_TO_RAD;
+        range_msg.min_range = 0.02;
+        range_msg.max_range = 4.0;
+        range_msg.radiation_type = sensor_msgs__msg__Range__ULTRASOUND;
+        range_msg.header.stamp.sec = time_stamp.tv_sec;
+        range_msg.header.stamp.nanosec = time_stamp.tv_nsec;
+        RCSOFTCHECK(rcl_publish(&range_publisher, &range_msg, NULL)) });
+#elif defined(ECHO_PIN)
     EXECUTE_EVERY_N_MS(RANGE_TIMER, {
         range_msg = getRange();
         range_msg.header.stamp.sec = time_stamp.tv_sec;


### PR DESCRIPTION
A bare microcontroller with no motors, drivers, encoders, or LiDAR attached normally reports zero RPM and produces no sensor data, preventing teleop, odometry, SLAM, and autonomous navigation from being exercised on the board alone. This PR adds fake wheel mode and embedded fake LD19 LiDAR emulation, closing the control and sensing loop entirely in firmware so the board behaves like a real robot.

### 1. Fake Wheel Drivetrain & IMU Simulation (`USE_FAKE_WHEEL`)

`USE_FAKE_WHEEL` swaps physical encoders for simulated ones (`firmware/lib/encoder/fake_wheel.h`), following the existing `USE_FAKE_IMU` and `USE_FAKE_MAG` pattern (undefined by default):

- **Dynamic DC Motor & Inertia Model**: Each wheel is modelled as a DC motor driving a share of the robot mass (`FAKE_ROBOT_MASS`, defaulting to `ROBOT_WEIGHT`). Driving torque falls off as back-EMF rises, acceleration is clamped to a traction limit, viscous friction opposes motion, and a stall band prevents low-duty creeping.
- **Closed-Loop Verification**: Motor drivers receive their PWM signals, and kinematics, PID controllers, and odometry integration all remain active in the loop. Reported encoder RPM carries synthetic white noise so the PID has real error to correct and odometry exhibits realistic drift.
- **Harmonized IMU Generation**: Simulated IMU angular velocity and linear acceleration are derived from actual simulated body motion (including centripetal acceleration and gravity Z = 9.80665 m/s²), ensuring the gyro, accelerometer, and wheel odometry agree.

### 2. Embedded 2D Geometric LiDAR Raycaster (`USE_FAKE_LD19`)

`USE_FAKE_LD19` embeds a real-time, 2D geometric raycasting LiDAR emulator (`firmware/lib/lidar/fake_ld19.h`) directly into microcontroller firmware:

- **Raycasting Engine**: Simulates 456 points/rev at 10.0 Hz against configurable room boundaries (`FAKE_MAP_WIDTH` x `FAKE_MAP_HEIGHT`, default 8.0 m x 8.0 m) and an interior obstacle barrier (`FAKE_WALL_OBSTACLE`).
- **Binary Protocol Fidelity**: Emits authentic 47-byte LDROBOT LD19 binary packets (`0x54 0x2C` header, 12 distance/confidence points, start/end angles, CRC8 checksum) @ 230,400 baud.
- **Dual Transport (Serial & Wi-Fi UDP)**:
  - **Serial**: Streams over `LIDAR_RXD` / secondary UART to the robot computer for consumption by standard `ldlidar_stl_ros2_node`.
  - **Wi-Fi UDP**: Streams over UDP port 8889, batched (3 packets / 141 bytes per datagram) to stabilize packet transmission and prevent lwIP socket buffer queue exhaustion on bare ESP32.
- **Odometry Simulator Hooks**: Exposes `getX()`, `getY()`, and `getHeading()` on `Kinematics` / `Odometry` for raycaster pose tracking.

### 3. CI Matrix Test Coverage

Added bare-module simulation test jobs to `.github/workflows/reusable-platformio-ci.yml`:
- **Matrix 7**: Raspberry Pi Pico 2 (`pico2`) with `USE_FAKE_WHEEL` and `USE_FAKE_LD19`.
- **Matrix 8**: Waveshare General Driver Board (`gendrv`) with `USE_FAKE_WHEEL`, `USE_FAKE_LD19`, `FAKE_WALL_OBSTACLE`, and high-speed serial `-D BAUDRATE=1500000`.
Both compile cleanly in CI matrix passes.

### 4. Hardware Verification

- **Raspberry Pi Pico 2 (`RP2350`)**: Tested on bare `/dev/ttyACM0` with zero external connections: commanding 0.25 m/s yields 0.249–0.251 m/s on `/odom/unfiltered` with position integrating; commanding 0.8 rad/s yields 0.79 rad/s odom yaw rate, 0.81 rad/s IMU gyro, and 9.80 m/s² accel Z; motion stops cleanly when `/cmd_vel` goes quiet.
- **Waveshare General Driver Board (`ESP32`)**:
  - **High-Speed Dual Serial Mode**: micro-ROS on `/dev/ttyUSB0` @ 1,500,000 baud (1.5M), Fake LD19 on `/dev/ttyUSB1` @ 230,400 baud. Verified live `/scan` @ 10.0 Hz and live `slam_toolbox` mapping generating a complete 2D occupancy grid map with interior obstacle barrier at 1.0 m.
  - **Wireless Wi-Fi UDP Mode**: micro-ROS agent on UDP port 8888, Fake LD19 over UDP port 8889. Verified live SLAM and autonomous navigation without physical motors or physical laser scanner.