### PR TITLE
ci: pre-install ros2-apt-source to fix setup-ros rate-limit 404s

### DIFF
--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -48,14 +48,38 @@ jobs:
         run: |
           pip install osrf_pycommon pyyaml
 
+      # Work around ros-tooling/setup-ros issue #892: setup-ros queries api.github.com
+      # without authentication, hitting 60 req/hr IP rate limits across public runners
+      # and causing intermittent 404 download failures. Pre-installing ros2-apt-source
+      # with GITHUB_TOKEN (and fallback) lets setup-ros detect the repo and skip that step.
+      - name: Pre-install ROS apt source
+        shell: bash
+        run: |
+          CODENAME=$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})
+          PKG="ros2-apt-source"
+          if [ "$CODENAME" = "focal" ]; then
+            PKG="ros-apt-source"
+          fi
+          if ! dpkg -l "$PKG" >/dev/null 2>&1; then
+            AUTH_HEADER=()
+            if [ -n "$GITHUB_TOKEN" ]; then
+              AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
+            fi
+            VER=$(curl -s "${AUTH_HEADER[@]}" https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | { grep -F "tag_name" || true; } | awk -F'"' '{print $4}')
+            VER=${VER:-1.2.0}
+            DEB="${PKG}_${VER}.${CODENAME}_all.deb"
+            URL="https://github.com/ros-infrastructure/ros-apt-source/releases/download/${VER}/${DEB}"
+            echo "Pre-installing ${PKG} (${VER}) for ${CODENAME}..."
+            curl --fail --location --retry 3 --retry-delay 2 -o "/tmp/${PKG}.deb" "${URL}"
+            sudo dpkg -i "/tmp/${PKG}.deb"
+            rm -f "/tmp/${PKG}.deb"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup ROS
         uses: ros-tooling/setup-ros@v0.7
         env:
-          # setup-ros looks up the latest ros-apt-source release via an
-          # unauthenticated GitHub API call (60 req/hr, shared across every
-          # public runner). Passing a token here raises that to 5000/hr and
-          # avoids the intermittent "curl: (22) The requested URL returned
-          # error: 404" failure this step otherwise hits at random.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           required-ros-distributions: ${{ inputs.ros_distro }}
@@ -195,14 +219,38 @@ jobs:
         run: |
           pip install osrf_pycommon pyyaml
 
+      # Work around ros-tooling/setup-ros issue #892: setup-ros queries api.github.com
+      # without authentication, hitting 60 req/hr IP rate limits across public runners
+      # and causing intermittent 404 download failures. Pre-installing ros2-apt-source
+      # with GITHUB_TOKEN (and fallback) lets setup-ros detect the repo and skip that step.
+      - name: Pre-install ROS apt source
+        shell: bash
+        run: |
+          CODENAME=$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})
+          PKG="ros2-apt-source"
+          if [ "$CODENAME" = "focal" ]; then
+            PKG="ros-apt-source"
+          fi
+          if ! dpkg -l "$PKG" >/dev/null 2>&1; then
+            AUTH_HEADER=()
+            if [ -n "$GITHUB_TOKEN" ]; then
+              AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
+            fi
+            VER=$(curl -s "${AUTH_HEADER[@]}" https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | { grep -F "tag_name" || true; } | awk -F'"' '{print $4}')
+            VER=${VER:-1.2.0}
+            DEB="${PKG}_${VER}.${CODENAME}_all.deb"
+            URL="https://github.com/ros-infrastructure/ros-apt-source/releases/download/${VER}/${DEB}"
+            echo "Pre-installing ${PKG} (${VER}) for ${CODENAME}..."
+            curl --fail --location --retry 3 --retry-delay 2 -o "/tmp/${PKG}.deb" "${URL}"
+            sudo dpkg -i "/tmp/${PKG}.deb"
+            rm -f "/tmp/${PKG}.deb"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup ROS
         uses: ros-tooling/setup-ros@v0.7
         env:
-          # setup-ros looks up the latest ros-apt-source release via an
-          # unauthenticated GitHub API call (60 req/hr, shared across every
-          # public runner). Passing a token here raises that to 5000/hr and
-          # avoids the intermittent "curl: (22) The requested URL returned
-          # error: 404" failure this step otherwise hits at random.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           required-ros-distributions: ${{ inputs.ros_distro }}


### PR DESCRIPTION
ros-tooling/setup-ros@v0.7 queries api.github.com for the latest ros-apt-source release via an unauthenticated bash curl command:

  curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest

Because this curl call is hardcoded without authorization headers, it does not use GITHUB_TOKEN even when exported in env. Across public GitHub Actions runners that share Azure IP pools, concurrent matrix jobs frequently hit the unauthenticated 60 req/hr rate limit. When rate-limited (HTTP 403), tag_name is not found, ROS_APT_SOURCE_VERSION evaluates to empty, and the subsequent deb download fails with curl 404 (exit code 22). This is tracked upstream in ros-tooling/setup-ros issue #892.

setup-ros checks apt-cache policy and skips its internal apt source installation if the ROS 2 repository is already configured. Pre-install ros2-apt-source in a step right before setup-ros:
- Query GitHub API using GITHUB_TOKEN (5,000 req/hr budget).
- Fallback to 1.2.0 if GitHub API is unreachable, ensuring the version is never empty.
- Once installed, setup-ros detects the repository and skips its unauthenticated download entirely.